### PR TITLE
test(core): cover reporting, key parsing, and probe output

### DIFF
--- a/packages/core/tests/test_keys.py
+++ b/packages/core/tests/test_keys.py
@@ -1,0 +1,45 @@
+"""Unit tests for SSH private-key normalization, which reflows single-line
+pasted keys back into valid PEM and leaves everything else untouched."""
+
+from redcell_core.keys import normalize_private_key
+
+
+def test_none_and_empty_pass_through():
+    assert normalize_private_key(None) is None
+    assert normalize_private_key("") == ""
+
+
+def test_non_key_text_is_left_alone():
+    assert normalize_private_key("hunter2") == "hunter2"
+    assert normalize_private_key("  a passphrase  ") == "  a passphrase  "
+
+
+def test_text_mentioning_private_key_without_markers_is_untouched():
+    # Has the phrase but no BEGIN/END block: hand it back so the parser reports
+    # the real error rather than us guessing.
+    weird = "this PRIVATE KEY looks broken"
+    assert normalize_private_key(weird) == weird
+
+
+def test_multiline_pem_is_preserved_with_trailing_newline():
+    pem = ("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+           "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB\n"
+           "AAAAMwAAAAtzc2gtZWQyNTUxOQAAACDrealkeymaterialheregoes\n"
+           "-----END OPENSSH PRIVATE KEY-----")
+    out = normalize_private_key(pem)
+    assert out.startswith("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+    assert out.endswith("-----END OPENSSH PRIVATE KEY-----\n")
+    assert "b3BlbnNzaC1rZXktdjEA" in out
+
+
+def test_singleline_pem_is_reflowed_to_64_columns():
+    body = "A" * 130  # a base64-ish blob with the line breaks stripped out
+    blob = f"-----BEGIN RSA PRIVATE KEY----- {body} -----END RSA PRIVATE KEY-----"
+    out = normalize_private_key(blob)
+    lines = out.splitlines()
+    assert lines[0] == "-----BEGIN RSA PRIVATE KEY-----"
+    assert lines[-1] == "-----END RSA PRIVATE KEY-----"
+    middle = lines[1:-1]
+    assert all(len(line) <= 64 for line in middle)
+    assert "".join(middle) == body  # reflow preserves the payload exactly
+    assert out.endswith("\n")

--- a/packages/core/tests/test_probe.py
+++ b/packages/core/tests/test_probe.py
@@ -1,0 +1,31 @@
+"""Unit tests for the server-probe output parser. probe_server/probe_proxy need
+a live host, but _parse (turning the prefixed probe lines into facts) is pure."""
+
+from redcell_core.probe import _parse
+
+
+def test_parses_all_facts():
+    out = _parse("H:web-01\nU:Linux 6.1.0\nC:4\nM:8192\nI:10.0.0.5 192.168.1.9")
+    assert out["hostname"] == "web-01"
+    assert out["os"] == "Linux 6.1.0"
+    assert out["cpu"] == 4
+    assert out["ram_gb"] == 8  # 8192 MB rounds to 8 GB
+    assert out["ip"] == "10.0.0.5"  # first address only
+
+
+def test_ignores_blank_and_non_numeric_values():
+    out = _parse("H:\nC:notanumber\nM:\nI:")
+    assert out.get("hostname") is None
+    assert "cpu" not in out  # non-numeric CPU is dropped
+    assert "ram_gb" not in out
+    assert out.get("ip") is None
+
+
+def test_ram_rounds_and_floors_at_one_gb():
+    assert _parse("M:1500")["ram_gb"] == 1   # round(1.46) -> 1
+    assert _parse("M:100")["ram_gb"] == 1    # max(1, round(0.1)) -> 1
+    assert _parse("M:2600")["ram_gb"] == 3   # round(2.54) -> 3
+
+
+def test_empty_output_yields_no_facts():
+    assert _parse("") == {}

--- a/packages/core/tests/test_reporting.py
+++ b/packages/core/tests/test_reporting.py
@@ -1,0 +1,143 @@
+"""Unit tests for the report generators: the prose humanizer, the SARIF
+exporter, and a smoke test of the PDF builder. All pure, no DB or infra."""
+
+from types import SimpleNamespace
+
+from redcell_core.engine.reporting.pdf import build_pdf
+from redcell_core.engine.reporting.sarif import build_sarif
+from redcell_core.engine.reporting.text import humanize
+
+# ---- humanize: the style safety net (no em-dashes, smart quotes, ellipses) ----
+
+def test_humanize_replaces_em_dash_with_comma():
+    assert humanize("foo — bar") == "foo, bar"
+
+
+def test_humanize_strips_every_typographic_tell():
+    out = humanize("He said “hi” and ‘bye’… then left–fast•now")
+    for ch in ("—", "–", "‘", "’", "“", "”", "…", "•"):
+        assert ch not in out
+    assert '"hi"' in out
+    assert "'bye'" in out
+    assert "..." in out
+
+
+def test_humanize_handles_none_and_empty():
+    assert humanize(None) == ""
+    assert humanize("") == ""
+
+
+def test_humanize_collapses_runs_of_spaces():
+    assert humanize("a    b") == "a b"
+
+
+# ---- SARIF export ----
+
+def _finding(**kw):
+    base = dict(id="finding-1", title="SQL Injection", severity="critical", cvss=9.8,
+                location="/api/search", cwe="CWE-89", status="verified")
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_sarif_top_level_shape():
+    doc = build_sarif([_finding()])
+    assert doc["version"] == "2.1.0"
+    assert doc["$schema"].endswith("sarif-2.1.0.json")
+    driver = doc["runs"][0]["tool"]["driver"]
+    assert driver["name"] == "REDCELL"
+    assert len(doc["runs"][0]["results"]) == 1
+
+
+def test_sarif_maps_severity_to_level():
+    findings = [
+        _finding(id="f-c", cwe=None, title="c", severity="critical"),
+        _finding(id="f-h", cwe=None, title="h", severity="high"),
+        _finding(id="f-m", cwe=None, title="m", severity="medium"),
+        _finding(id="f-l", cwe=None, title="l", severity="low"),
+        _finding(id="f-i", cwe=None, title="i", severity="info"),
+        _finding(id="f-x", cwe=None, title="x", severity="bogus"),
+    ]
+    levels = {r["properties"]["severity"]: r["level"] for r in build_sarif(findings)["runs"][0]["results"]}
+    assert levels["critical"] == "error"
+    assert levels["high"] == "error"
+    assert levels["medium"] == "warning"
+    assert levels["low"] == "note"
+    assert levels["info"] == "note"
+    assert levels["bogus"] == "warning"  # unknown severity falls back to warning
+
+
+def test_sarif_dedupes_rules_by_cwe():
+    findings = [_finding(id="a", cwe="CWE-89"), _finding(id="b", cwe="CWE-89"),
+                _finding(id="c", cwe="CWE-79")]
+    doc = build_sarif(findings)
+    assert len(doc["runs"][0]["tool"]["driver"]["rules"]) == 2  # CWE-89 collapses to one rule
+    assert len(doc["runs"][0]["results"]) == 3
+
+
+def test_sarif_falls_back_to_title_and_unspecified_location():
+    doc = build_sarif([_finding(cwe=None, title="Open Redirect", location="")])
+    result = doc["runs"][0]["results"][0]
+    assert result["ruleId"] == "Open Redirect"
+    uri = result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+    assert uri == "unspecified"
+    rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+    assert rule["properties"]["security-severity"] == "9.8"
+
+
+# ---- PDF builder (smoke) ----
+
+def _session():
+    return SimpleNamespace(client="Acme", name="Acme Q3 Pentest",
+                           targets=["https://acme.test"], scope=["*.acme.test"], roe="no DoS")
+
+
+def _narrative(with_findings=True):
+    n = {
+        "executive_summary": "One high-severity issue was found.",
+        "posture": "Overall posture is fair.",
+        "overview": "We tested the public application.",
+        "methodology": "OWASP-aligned black-box testing.",
+        "recommendations": ["Fix the SQL injection first."],
+    }
+    if with_findings:
+        n["findings"] = {"finding-1": {"impact": "Full database read.", "remediation": "Parameterize queries."}}
+    return n
+
+
+def _base_ctx(findings, narrative, **extra):
+    ctx = {
+        "title": "Acme Penetration Test",
+        "company": "REDCELL",
+        "classification": "CONFIDENTIAL",
+        "report_id": "RPT-001",
+        "generated_at": "2026-08-12T10:00:00Z",
+        "contact": "ops@redcell.local",
+        "session": _session(),
+        "findings": findings,
+        "narrative": narrative,
+    }
+    ctx.update(extra)
+    return ctx
+
+
+def test_build_pdf_produces_a_valid_pdf():
+    finding = SimpleNamespace(
+        id="finding-1", title="SQL Injection", severity="high", cvss=8.2,
+        location="/api/search?q=", cwe="CWE-89", status="verified",
+        evidence_request="GET /api/search?q=1", evidence_response="error: SQL syntax near '1'",
+        remediation="Use parameterized queries.")
+    ctx = _base_ctx(
+        [finding], _narrative(),
+        hosts=[SimpleNamespace(host="acme.test", ip="203.0.113.5", tech=["nginx"], source="target")],
+        loot=[SimpleNamespace(kind="credential", label="admin", value="s3cret", source="dump")])
+    data = build_pdf(ctx)
+    assert isinstance(data, bytes)
+    assert data[:5] == b"%PDF-"
+    assert len(data) > 1000
+
+
+def test_build_pdf_with_no_findings_still_renders():
+    data = build_pdf(_base_ctx([], _narrative(with_findings=False)))
+    assert data[:5] == b"%PDF-"
+    assert len(data) > 1000


### PR DESCRIPTION
## Summary

Adds targeted unit tests for backend modules that carried real logic but had no direct coverage. All are pure and need no database or infrastructure.

- **`reporting/text.py`** (the humanizer): asserts it strips em-dashes, smart quotes, ellipses, en-dashes, and bullets, since this is what enforces the project's writing-style rule. Also covers `None`/empty and space collapsing.
- **`reporting/sarif.py`**: severity-to-level mapping (including the unknown-severity fallback to `warning`), rule dedup by CWE, and the title/`unspecified`-location fallbacks.
- **`reporting/pdf.py`**: a smoke test that `build_pdf` returns a valid, non-empty PDF (`%PDF-` header), both with a full finding/host/loot set and with no findings.
- **`keys.py`**: multi-line PEM preserved (with trailing newline), single-line PEM reflowed to 64-column lines with the payload intact, and non-key input returned untouched.
- **`probe.py`**: the pure `_parse` helper that turns prefixed probe output into host facts (hostname, OS, CPU, RAM rounding/floor, first IP), plus blank/non-numeric handling.

19 tests, all passing.

## Related issue

Closes #10.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor or cleanup
- [ ] Docs
- [x] Other (test coverage)

## Checklist

- [x] `uv run pytest` passes (the new files pass; verified in isolation since this sandbox has no Postgres/Redis/MinIO, and they need none. Full suite runs in CI.)
- [x] `bun run typecheck` and `bun run build` pass (unaffected: backend-only change)
- [x] No em-dashes, smart quotes, or AI-sounding copy in code, UI, docs, or commit messages
- [x] The change is focused on a single thing
- [x] UI changes include a screenshot (no UI change: tests only)
- [x] Anything security-sensitive was handled per SECURITY.md, not in a public PR (n/a)

Note: the test-key material in `test_keys.py` is fabricated filler, not a real private key. `ruff check` is also clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013uNGK9iWsPMTGv8Zp9mdMH)_