### PR TITLE
feat: agent browser with live view and interactive takeover

### DIFF
--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -182,7 +182,18 @@ async def browser_start(sid: str, s: AsyncSession = Depends(db)) -> dict[str, ob
             "docker", "exec", container, "rc-browserd", "start",
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         )
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc)[:200]}
+    try:
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+    except TimeoutError:
+        # wait_for cancels communicate() but leaves docker exec running; kill and reap it.
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        await proc.wait()
+        return {"ok": False, "detail": "browser start timed out"}
     except Exception as exc:
         return {"ok": False, "detail": str(exc)[:200]}
     ok = proc.returncode == 0
@@ -195,7 +206,9 @@ async def browser_start(sid: str, s: AsyncSession = Depends(db)) -> dict[str, ob
 @router.post("/sessions/{sid}/browser/control")
 async def browser_control(sid: str, body: BrowserControlInput, s: AsyncSession = Depends(db)) -> dict[str, str]:
     await _get_session(s, sid)
-    await steer.set_browser_owner(sid, body.owner)  # durable, so a take before the worker subscribes is not lost
+    if not await steer.set_browser_owner(sid, body.owner):
+        raise HTTPException(503, "could not persist browser control; retry")
+    # Publish only after the durable write succeeds (live update; the worker reads the durable value authoritatively).
     await bus.publish_json(browser_channel(sid), {"owner": body.owner})
     return {"owner": body.owner}
 

--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -168,6 +168,30 @@ async def stop_run(rid: str, s: AsyncSession = Depends(db)) -> Run:
     return schema
 
 
+@router.post("/sessions/{sid}/browser/start")
+async def browser_start(sid: str, s: AsyncSession = Depends(db)) -> dict[str, object]:
+    """Boot the browser stack in the session's container so the operator can view
+    it even before the agent browses. Needs an active run (the container exists
+    only while a run executes); local sessions only for now."""
+    session = await _get_session(s, sid)
+    if session.server_id:
+        return {"ok": False, "detail": "live browser view is local-only for now"}
+    container = f"redcell-exec-{sid[:12]}"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "exec", container, "rc-browserd", "start",
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+        )
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc)[:200]}
+    ok = proc.returncode == 0
+    detail = out.decode(errors="replace")[-200:] if out else ""
+    if not ok and "No such container" in detail:
+        detail = "no running container for this session; start a run first"
+    return {"ok": ok, "detail": detail}
+
+
 @router.post("/sessions/{sid}/browser/control")
 async def browser_control(sid: str, body: BrowserControlInput, s: AsyncSession = Depends(db)) -> dict[str, str]:
     await _get_session(s, sid)

--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -195,9 +195,9 @@ async def browser_start(sid: str, s: AsyncSession = Depends(db)) -> dict[str, ob
 @router.post("/sessions/{sid}/browser/control")
 async def browser_control(sid: str, body: BrowserControlInput, s: AsyncSession = Depends(db)) -> dict[str, str]:
     await _get_session(s, sid)
-    owner = "operator" if body.owner == "operator" else "agent"
-    await bus.publish_json(browser_channel(sid), {"owner": owner})
-    return {"owner": owner}
+    await steer.set_browser_owner(sid, body.owner)  # durable, so a take before the worker subscribes is not lost
+    await bus.publish_json(browser_channel(sid), {"owner": body.owner})
+    return {"owner": body.owner}
 
 
 # ---- agents ----

--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -6,7 +6,14 @@ import asyncio
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from redcell_core import queue, steer
-from redcell_core.bus import bus, chat_channel, control_channel, shell_channel, shell_input_channel
+from redcell_core.bus import (
+    browser_channel,
+    bus,
+    chat_channel,
+    control_channel,
+    shell_channel,
+    shell_input_channel,
+)
 from redcell_core.db import session_scope
 from redcell_core.repositories import agents as agents_repo
 from redcell_core.repositories import chat as chat_repo
@@ -23,6 +30,7 @@ from redcell_core.schemas import (
     Agent,
     AgentEdge,
     AgentGraph,
+    BrowserControlInput,
     ChatMessage,
     ChatSendInput,
     CreateRunInput,
@@ -158,6 +166,14 @@ async def stop_run(rid: str, s: AsyncSession = Depends(db)) -> Run:
     await s.commit()
     await bus.publish_json(control_channel(rid), {"action": "stop"})
     return schema
+
+
+@router.post("/sessions/{sid}/browser/control")
+async def browser_control(sid: str, body: BrowserControlInput, s: AsyncSession = Depends(db)) -> dict[str, str]:
+    await _get_session(s, sid)
+    owner = "operator" if body.owner == "operator" else "agent"
+    await bus.publish_json(browser_channel(sid), {"owner": owner})
+    return {"owner": owner}
 
 
 # ---- agents ----

--- a/apps/api/app/routers/ws.py
+++ b/apps/api/app/routers/ws.py
@@ -8,6 +8,8 @@ import jwt
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from redcell_core.bus import bus, chat_channel, events_channel, shell_channel
 from redcell_core.config import settings
+from redcell_core.db import session_scope
+from redcell_core.repositories import sessions as sessions_repo
 from redcell_core.security import COOKIE_NAME
 
 router = APIRouter()
@@ -75,3 +77,70 @@ async def ws_shell(ws: WebSocket, shell_id: str) -> None:
         return
     await ws.accept()
     await _pump(ws, shell_channel(shell_id))
+
+
+async def _bridge(ws: WebSocket, proc: asyncio.subprocess.Process) -> None:
+    """Pump raw bytes both ways between the noVNC client and the container's VNC
+    server (RFB over the WebSocket)."""
+    async def to_ws() -> None:
+        assert proc.stdout is not None
+        while True:
+            chunk = await proc.stdout.read(65536)
+            if not chunk:
+                break
+            await ws.send_bytes(chunk)
+
+    async def to_proc() -> None:
+        assert proc.stdin is not None
+        try:
+            while True:
+                data = await ws.receive_bytes()
+                proc.stdin.write(data)
+                await proc.stdin.drain()
+        except (WebSocketDisconnect, Exception):
+            return
+
+    t1 = asyncio.create_task(to_ws())
+    t2 = asyncio.create_task(to_proc())
+    _, pending = await asyncio.wait({t1, t2}, return_when=asyncio.FIRST_COMPLETED)
+    for t in pending:
+        t.cancel()
+    try:
+        proc.kill()
+    except Exception:
+        pass
+    for t in pending:
+        try:
+            await t
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@router.websocket("/ws/browser/{session_id}")
+async def ws_browser(ws: WebSocket, session_id: str) -> None:
+    """Bridge a noVNC client to the session container's x11vnc via `docker exec`.
+    Local sessions only for now; remote-server sessions are a follow-up."""
+    if not _authed(ws):
+        await ws.close(code=4401)
+        return
+    async with session_scope() as s:
+        session = await sessions_repo.get(s, session_id)
+    if session is None:
+        await ws.close(code=4404)
+        return
+    if session.server_id:
+        await ws.close(code=4403)  # live view for remote servers not supported yet
+        return
+    container = f"redcell-exec-{session_id[:12]}"
+    await ws.accept()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "exec", "-i", container, "socat", "-", "TCP:127.0.0.1:5900",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except Exception:
+        await ws.close(code=1011)
+        return
+    await _bridge(ws, proc)

--- a/apps/api/app/routers/ws.py
+++ b/apps/api/app/routers/ws.py
@@ -100,19 +100,21 @@ async def _bridge(ws: WebSocket, proc: asyncio.subprocess.Process) -> None:
         except (WebSocketDisconnect, Exception):
             return
 
-    t1 = asyncio.create_task(to_ws())
-    t2 = asyncio.create_task(to_proc())
-    _, pending = await asyncio.wait({t1, t2}, return_when=asyncio.FIRST_COMPLETED)
-    for t in pending:
-        t.cancel()
+    tasks = {asyncio.create_task(to_ws()), asyncio.create_task(to_proc())}
     try:
-        proc.kill()
-    except Exception:
-        pass
-    for t in pending:
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        # Runs even if the bridge itself is cancelled, so the docker exec never leaks.
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
         try:
-            await t
-        except (asyncio.CancelledError, Exception):
+            proc.kill()
+        except Exception:
+            pass
+        try:
+            await proc.wait()
+        except Exception:
             pass
 
 

--- a/apps/api/tests/test_api_smoke.py
+++ b/apps/api/tests/test_api_smoke.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 # Ensure admin + providers exist, then release the bootstrap loop's connections.
 from redcell_core import seed  # noqa: E402
 from redcell_core.db import engine  # noqa: E402
+from starlette.websockets import WebSocketDisconnect
 
 
 async def _boot():
@@ -136,7 +137,7 @@ def test_api_smoke():
             try:
                 with fresh.websocket_connect(f"/api/v1/ws/browser/{sid}"):
                     check("ws-browser-auth-guard", False)
-            except Exception:
-                check("ws-browser-auth-guard", True)
+            except WebSocketDisconnect as e:
+                check("ws-browser-auth-guard", e.code == 4401)
 
     assert not failures, f"failed checks: {failures}"

--- a/apps/api/tests/test_api_smoke.py
+++ b/apps/api/tests/test_api_smoke.py
@@ -114,6 +114,10 @@ def test_api_smoke():
         check("run-resume", c.post(f"/api/v1/runs/{rid}/resume").status_code == 200)
         check("run-stop", c.post(f"/api/v1/runs/{rid}/stop").status_code == 200)
 
+        # browser control handoff (publishes the owner to the browser channel)
+        rbc = c.post(f"/api/v1/sessions/{sid}/browser/control", json={"owner": "operator"})
+        check("browser-control", rbc.status_code == 200 and rbc.json()["owner"] == "operator")
+
         # WebSocket chat round-trip (REST publish -> WS receive)
         with c.websocket_connect(f"/api/v1/ws/chat/{rid}") as ws:
             time.sleep(0.3)
@@ -129,5 +133,10 @@ def test_api_smoke():
                     check("ws-auth-guard", False)
             except Exception:
                 check("ws-auth-guard", True)
+            try:
+                with fresh.websocket_connect(f"/api/v1/ws/browser/{sid}"):
+                    check("ws-browser-auth-guard", False)
+            except Exception:
+                check("ws-browser-auth-guard", True)
 
     assert not failures, f"failed checks: {failures}"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@novnc/novnc": "1.7.0",
     "@redcell/api-client": "workspace:*",
     "@tanstack/react-query": "^5.59.0",
     "@xterm/addon-fit": "^0.10.0",

--- a/apps/web/src/app/panels/BrowserPanel.test.tsx
+++ b/apps/web/src/app/panels/BrowserPanel.test.tsx
@@ -15,11 +15,17 @@ vi.mock('@novnc/novnc', () => ({
   },
 }));
 
-const start = vi.fn(async () => ({ ok: true }));
-const control = vi.fn(async () => ({ owner: 'operator' }));
-// Stable object, mirrors the real singleton client, so the effect doesn't re-run every render.
-const apiObj = { browser: { start, control, vncUrl: (id: string) => `ws://x/api/v1/ws/browser/${id}` } };
-vi.mock('@/lib/api', () => ({ useApi: () => apiObj }));
+// vi.hoisted so the spies exist before vi.mock's factory runs (it is hoisted above imports).
+const h = vi.hoisted(() => {
+  const start = vi.fn(async () => ({ ok: true }));
+  const control = vi.fn(async () => ({ owner: 'operator' }));
+  return {
+    start,
+    control,
+    apiObj: { browser: { start, control, vncUrl: (id: string) => `ws://x/api/v1/ws/browser/${id}` } },
+  };
+});
+vi.mock('@/lib/api', () => ({ useApi: () => h.apiObj }));
 vi.mock('@/store/ui', () => ({
   useUI: (sel: (s: { activeSessionId: string }) => unknown) => sel({ activeSessionId: 'ses-1' }),
 }));
@@ -31,9 +37,9 @@ describe('BrowserPanel', () => {
     render(<BrowserPanel />);
     // Auto-connect on mount calls start, then noVNC connects -> Take control shows.
     const takeBtn = await screen.findByRole('button', { name: /take control/i });
-    expect(start).toHaveBeenCalledWith('ses-1');
+    expect(h.start).toHaveBeenCalledWith('ses-1');
     fireEvent.click(takeBtn);
     expect(await screen.findByRole('button', { name: /release control/i })).toBeInTheDocument();
-    expect(control).toHaveBeenCalledWith('ses-1', 'operator');
+    expect(h.control).toHaveBeenCalledWith('ses-1', 'operator');
   });
 });

--- a/apps/web/src/app/panels/BrowserPanel.test.tsx
+++ b/apps/web/src/app/panels/BrowserPanel.test.tsx
@@ -1,23 +1,25 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
-// noVNC opens a real WebSocket; stub it so the panel mounts without a socket.
+// Stub noVNC: fire 'connect' as soon as the panel registers for it, so the panel
+// reaches the connected state without a real socket.
 vi.mock('@novnc/novnc', () => ({
   default: class {
     viewOnly = true;
     scaleViewport = true;
-    addEventListener() {}
+    addEventListener(type: string, cb: () => void) {
+      if (type === 'connect') cb();
+    }
     removeEventListener() {}
     disconnect() {}
   },
 }));
 
+const start = vi.fn(async () => ({ ok: true }));
 const control = vi.fn(async () => ({ owner: 'operator' }));
-vi.mock('@/lib/api', () => ({
-  useApi: () => ({
-    browser: { control, vncUrl: (id: string) => `ws://x/api/v1/ws/browser/${id}` },
-  }),
-}));
+// Stable object, mirrors the real singleton client, so the effect doesn't re-run every render.
+const apiObj = { browser: { start, control, vncUrl: (id: string) => `ws://x/api/v1/ws/browser/${id}` } };
+vi.mock('@/lib/api', () => ({ useApi: () => apiObj }));
 vi.mock('@/store/ui', () => ({
   useUI: (sel: (s: { activeSessionId: string }) => unknown) => sel({ activeSessionId: 'ses-1' }),
 }));
@@ -25,10 +27,12 @@ vi.mock('@/store/ui', () => ({
 import { BrowserPanel } from './BrowserPanel';
 
 describe('BrowserPanel', () => {
-  it('renders and toggles operator control', async () => {
+  it('starts the browser on mount and toggles operator control once connected', async () => {
     render(<BrowserPanel />);
-    fireEvent.click(screen.getByRole('button', { name: /take control/i }));
-    // Label flips only after control() resolves and the state update renders.
+    // Auto-connect on mount calls start, then noVNC connects -> Take control shows.
+    const takeBtn = await screen.findByRole('button', { name: /take control/i });
+    expect(start).toHaveBeenCalledWith('ses-1');
+    fireEvent.click(takeBtn);
     expect(await screen.findByRole('button', { name: /release control/i })).toBeInTheDocument();
     expect(control).toHaveBeenCalledWith('ses-1', 'operator');
   });

--- a/apps/web/src/app/panels/BrowserPanel.test.tsx
+++ b/apps/web/src/app/panels/BrowserPanel.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// noVNC opens a real WebSocket; stub it so the panel mounts without a socket.
+vi.mock('@novnc/novnc', () => ({
+  default: class {
+    viewOnly = true;
+    scaleViewport = true;
+    addEventListener() {}
+    removeEventListener() {}
+    disconnect() {}
+  },
+}));
+
+const control = vi.fn(async () => ({ owner: 'operator' }));
+vi.mock('@/lib/api', () => ({
+  useApi: () => ({
+    browser: { control, vncUrl: (id: string) => `ws://x/api/v1/ws/browser/${id}` },
+  }),
+}));
+vi.mock('@/store/ui', () => ({
+  useUI: (sel: (s: { activeSessionId: string }) => unknown) => sel({ activeSessionId: 'ses-1' }),
+}));
+
+import { BrowserPanel } from './BrowserPanel';
+
+describe('BrowserPanel', () => {
+  it('renders and toggles operator control', async () => {
+    render(<BrowserPanel />);
+    fireEvent.click(screen.getByRole('button', { name: /take control/i }));
+    // Label flips only after control() resolves and the state update renders.
+    expect(await screen.findByRole('button', { name: /release control/i })).toBeInTheDocument();
+    expect(control).toHaveBeenCalledWith('ses-1', 'operator');
+  });
+});

--- a/apps/web/src/app/panels/BrowserPanel.tsx
+++ b/apps/web/src/app/panels/BrowserPanel.tsx
@@ -12,9 +12,15 @@ export function BrowserPanel() {
   const screenRef = useRef<HTMLDivElement>(null);
   const rfbRef = useRef<RFB | null>(null);
   const operatorRef = useRef(false);
+  const busyRef = useRef(false);
+  const sessionIdRef = useRef(sessionId);
   const [status, setStatus] = useState<Status>('idle');
   const [detail, setDetail] = useState('');
   const [operator, setOperator] = useState(false);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
 
   const teardown = useCallback(() => {
     try {
@@ -28,11 +34,16 @@ export function BrowserPanel() {
   const connect = useCallback(async () => {
     if (!sessionId || !screenRef.current) return;
     teardown();
+    // Ownership is per session: never carry the previous session's control state over.
+    operatorRef.current = false;
+    setOperator(false);
     setDetail('');
     setStatus('starting');
     const started = await api.browser
       .start(sessionId)
       .catch(() => ({ ok: false, detail: 'could not reach the API' }));
+    // Bail if the session changed while we were starting.
+    if (sessionId !== sessionIdRef.current) return;
     if (!started.ok) {
       setStatus('error');
       setDetail(started.detail || 'could not start the browser (is a run active?)');
@@ -41,7 +52,7 @@ export function BrowserPanel() {
     setStatus('connecting');
     try {
       const rfb = new RFB(screenRef.current, api.browser.vncUrl(sessionId), { shared: true });
-      rfb.viewOnly = !operatorRef.current;
+      rfb.viewOnly = true; // view-only until the operator explicitly takes control of THIS session
       rfb.scaleViewport = true;
       rfb.addEventListener('connect', () => setStatus('connected'));
       rfb.addEventListener('disconnect', () => setStatus('disconnected'));
@@ -58,12 +69,21 @@ export function BrowserPanel() {
   }, [connect, teardown]);
 
   const toggleControl = async () => {
-    if (!sessionId) return;
+    if (!sessionId || busyRef.current) return;
+    const target = sessionId;
+    const rfb = rfbRef.current;
     const next = !operator;
-    await api.browser.control(sessionId, next ? 'operator' : 'agent');
-    operatorRef.current = next;
-    if (rfbRef.current) rfbRef.current.viewOnly = !next;
-    setOperator(next);
+    busyRef.current = true;
+    try {
+      await api.browser.control(target, next ? 'operator' : 'agent');
+      // Only apply if the same session and the same RFB instance are still live.
+      if (sessionIdRef.current !== target || rfbRef.current !== rfb || !rfb) return;
+      operatorRef.current = next;
+      rfb.viewOnly = !next;
+      setOperator(next);
+    } finally {
+      busyRef.current = false;
+    }
   };
 
   if (!sessionId) return <Empty>No active session.</Empty>;

--- a/apps/web/src/app/panels/BrowserPanel.tsx
+++ b/apps/web/src/app/panels/BrowserPanel.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import RFB from '@novnc/novnc';
+import { useUI } from '@/store/ui';
+import { useApi } from '@/lib/api';
+import { Button, Empty } from '@/components/ui/primitives';
+
+type Status = 'connecting' | 'connected' | 'disconnected';
+
+export function BrowserPanel() {
+  const sessionId = useUI((s) => s.activeSessionId);
+  const api = useApi();
+  const screenRef = useRef<HTMLDivElement>(null);
+  const rfbRef = useRef<RFB | null>(null);
+  const operatorRef = useRef(false);
+  const [status, setStatus] = useState<Status>('connecting');
+  const [operator, setOperator] = useState(false);
+
+  useEffect(() => {
+    if (!sessionId || !screenRef.current) return;
+    setStatus('connecting');
+    let rfb: RFB | null = null;
+    try {
+      rfb = new RFB(screenRef.current, api.browser.vncUrl(sessionId), { shared: true });
+      rfb.viewOnly = !operatorRef.current;
+      rfb.scaleViewport = true;
+      rfb.addEventListener('connect', () => setStatus('connected'));
+      rfb.addEventListener('disconnect', () => setStatus('disconnected'));
+      rfbRef.current = rfb;
+    } catch {
+      setStatus('disconnected');
+    }
+    return () => {
+      try {
+        rfb?.disconnect();
+      } catch {
+        /* already gone */
+      }
+      rfbRef.current = null;
+    };
+  }, [sessionId, api]);
+
+  const toggleControl = async () => {
+    if (!sessionId) return;
+    const next = !operator;
+    await api.browser.control(sessionId, next ? 'operator' : 'agent');
+    operatorRef.current = next;
+    if (rfbRef.current) rfbRef.current.viewOnly = !next;
+    setOperator(next);
+  };
+
+  if (!sessionId) return <Empty>No active session.</Empty>;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-none items-center gap-2 border-b border-border bg-bg2 px-3 py-2">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-faint">Browser</span>
+        <span className="font-mono text-[10px] text-muted">
+          {status}
+          {operator ? ' · you have control' : ''}
+        </span>
+        <Button variant="subtle" className="ml-auto h-6 px-2 text-[11px]" onClick={toggleControl}>
+          {operator ? 'Release control' : 'Take control'}
+        </Button>
+      </div>
+      <div ref={screenRef} className="min-h-0 flex-1 bg-black" />
+    </div>
+  );
+}

--- a/apps/web/src/app/panels/BrowserPanel.tsx
+++ b/apps/web/src/app/panels/BrowserPanel.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import RFB from '@novnc/novnc';
 import { useUI } from '@/store/ui';
 import { useApi } from '@/lib/api';
 import { Button, Empty } from '@/components/ui/primitives';
 
-type Status = 'connecting' | 'connected' | 'disconnected';
+type Status = 'idle' | 'starting' | 'connecting' | 'connected' | 'disconnected' | 'error';
 
 export function BrowserPanel() {
   const sessionId = useUI((s) => s.activeSessionId);
@@ -12,32 +12,50 @@ export function BrowserPanel() {
   const screenRef = useRef<HTMLDivElement>(null);
   const rfbRef = useRef<RFB | null>(null);
   const operatorRef = useRef(false);
-  const [status, setStatus] = useState<Status>('connecting');
+  const [status, setStatus] = useState<Status>('idle');
+  const [detail, setDetail] = useState('');
   const [operator, setOperator] = useState(false);
 
-  useEffect(() => {
-    if (!sessionId || !screenRef.current) return;
-    setStatus('connecting');
-    let rfb: RFB | null = null;
+  const teardown = useCallback(() => {
     try {
-      rfb = new RFB(screenRef.current, api.browser.vncUrl(sessionId), { shared: true });
+      rfbRef.current?.disconnect();
+    } catch {
+      /* already gone */
+    }
+    rfbRef.current = null;
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!sessionId || !screenRef.current) return;
+    teardown();
+    setDetail('');
+    setStatus('starting');
+    const started = await api.browser
+      .start(sessionId)
+      .catch(() => ({ ok: false, detail: 'could not reach the API' }));
+    if (!started.ok) {
+      setStatus('error');
+      setDetail(started.detail || 'could not start the browser (is a run active?)');
+      return;
+    }
+    setStatus('connecting');
+    try {
+      const rfb = new RFB(screenRef.current, api.browser.vncUrl(sessionId), { shared: true });
       rfb.viewOnly = !operatorRef.current;
       rfb.scaleViewport = true;
       rfb.addEventListener('connect', () => setStatus('connected'));
       rfb.addEventListener('disconnect', () => setStatus('disconnected'));
       rfbRef.current = rfb;
     } catch {
-      setStatus('disconnected');
+      setStatus('error');
+      setDetail('VNC connection failed');
     }
-    return () => {
-      try {
-        rfb?.disconnect();
-      } catch {
-        /* already gone */
-      }
-      rfbRef.current = null;
-    };
-  }, [sessionId, api]);
+  }, [sessionId, api, teardown]);
+
+  useEffect(() => {
+    void connect();
+    return teardown;
+  }, [connect, teardown]);
 
   const toggleControl = async () => {
     if (!sessionId) return;
@@ -54,13 +72,25 @@ export function BrowserPanel() {
     <div className="flex h-full flex-col">
       <div className="flex flex-none items-center gap-2 border-b border-border bg-bg2 px-3 py-2">
         <span className="font-mono text-[10px] uppercase tracking-wider text-faint">Browser</span>
-        <span className="font-mono text-[10px] text-muted">
+        <span className="min-w-0 truncate font-mono text-[10px] text-muted">
           {status}
           {operator ? ' · you have control' : ''}
+          {detail ? ` · ${detail}` : ''}
         </span>
-        <Button variant="subtle" className="ml-auto h-6 px-2 text-[11px]" onClick={toggleControl}>
-          {operator ? 'Release control' : 'Take control'}
-        </Button>
+        {status === 'connected' ? (
+          <Button variant="subtle" className="ml-auto h-6 flex-none px-2 text-[11px]" onClick={toggleControl}>
+            {operator ? 'Release control' : 'Take control'}
+          </Button>
+        ) : (
+          <Button
+            variant="subtle"
+            className="ml-auto h-6 flex-none px-2 text-[11px]"
+            disabled={status === 'starting' || status === 'connecting'}
+            onClick={() => void connect()}
+          >
+            Connect
+          </Button>
+        )}
       </div>
       <div ref={screenRef} className="min-h-0 flex-1 bg-black" />
     </div>

--- a/apps/web/src/app/panels/PanelView.tsx
+++ b/apps/web/src/app/panels/PanelView.tsx
@@ -10,6 +10,7 @@ import { ChatPanel } from './ChatPanel';
 import { AttackSurfacePanel } from './AttackSurfacePanel';
 import { LootPanel } from './LootPanel';
 import { ReportsPanel } from './ReportsPanel';
+import { BrowserPanel } from './BrowserPanel';
 
 export function PanelView({ id }: { id: PanelId }) {
   switch (id) {
@@ -35,6 +36,8 @@ export function PanelView({ id }: { id: PanelId }) {
       return <LootPanel />;
     case 'reports':
       return <ReportsPanel />;
+    case 'browser':
+      return <BrowserPanel />;
     default:
       return null;
   }

--- a/apps/web/src/novnc.d.ts
+++ b/apps/web/src/novnc.d.ts
@@ -1,0 +1,15 @@
+// @novnc/novnc ships no type declarations; declare the slice of RFB we use.
+declare module '@novnc/novnc' {
+  export interface RFBOptions {
+    shared?: boolean;
+    credentials?: { password?: string };
+  }
+  export default class RFB {
+    constructor(target: Element, url: string, options?: RFBOptions);
+    viewOnly: boolean;
+    scaleViewport: boolean;
+    addEventListener(type: string, listener: (e: Event) => void): void;
+    removeEventListener(type: string, listener: (e: Event) => void): void;
+    disconnect(): void;
+  }
+}

--- a/apps/web/src/store/workspace.test.ts
+++ b/apps/web/src/store/workspace.test.ts
@@ -36,4 +36,20 @@ describe('useWorkspace', () => {
     useWorkspace.getState().showPanel('reports');
     expect(getLeaves(useWorkspace.getState().layout)).toContain('reports');
   });
+
+  it('setLayout prunes duplicate leaves so mosaic never gets a bad tree', () => {
+    useWorkspace.getState().setLayout({
+      direction: 'row',
+      splitPercentage: 50,
+      first: 'findings',
+      second: 'findings',
+    });
+    expect(getLeaves(useWorkspace.getState().layout)).toEqual(['findings']);
+  });
+
+  it('addPanel is a no-op when the panel is already visible', () => {
+    const before = useWorkspace.getState().layout;
+    useWorkspace.getState().addPanel('findings');
+    expect(useWorkspace.getState().layout).toBe(before);
+  });
 });

--- a/apps/web/src/store/workspace.ts
+++ b/apps/web/src/store/workspace.ts
@@ -14,7 +14,8 @@ export type PanelId =
   | 'chat'
   | 'surface'
   | 'loot'
-  | 'reports';
+  | 'reports'
+  | 'browser';
 
 export const PANEL_LABELS: Record<PanelId, string> = {
   agents: 'Agent graph',
@@ -28,6 +29,7 @@ export const PANEL_LABELS: Record<PanelId, string> = {
   surface: 'Attack surface',
   loot: 'Loot & creds',
   reports: 'Reports',
+  browser: 'Browser',
 };
 
 export const SWAPPABLE: PanelId[] = [
@@ -42,6 +44,7 @@ export const SWAPPABLE: PanelId[] = [
   'listeners',
   'proxy',
   'reports',
+  'browser',
 ];
 
 type Node = MosaicNode<PanelId>;

--- a/apps/web/src/store/workspace.ts
+++ b/apps/web/src/store/workspace.ts
@@ -56,6 +56,28 @@ const DEFAULT_LAYOUT: Node = {
   second: { direction: 'column', splitPercentage: 52, first: 'findings', second: 'context' },
 };
 
+// react-mosaic crashes if a leaf id appears twice. A bad drag or adding an
+// already-visible panel can produce that, and it persists, so every later render
+// (including a brand-new session) white-screens. These keep the tree valid.
+function hasDuplicateLeaves(node: Node | null): boolean {
+  if (node == null) return false;
+  const leaves = getLeaves(node);
+  return new Set(leaves).size !== leaves.length;
+}
+
+function dedupeLeaves(node: Node | null, seen: Set<PanelId> = new Set()): Node | null {
+  if (node == null) return null;
+  if (typeof node === 'string') {
+    if (seen.has(node)) return null;
+    seen.add(node);
+    return node;
+  }
+  const first = dedupeLeaves(node.first, seen);
+  const second = dedupeLeaves(node.second, seen);
+  if (first && second) return { ...node, first, second };
+  return first ?? second ?? null;
+}
+
 interface WorkspaceState {
   layout: Node | null;
   setLayout: (n: Node | null) => void;
@@ -68,14 +90,19 @@ export const useWorkspace = create<WorkspaceState>()(
   persist(
     (set) => ({
       layout: DEFAULT_LAYOUT,
-      setLayout: (layout) => set({ layout }),
+      setLayout: (layout) =>
+        set({ layout: hasDuplicateLeaves(layout) ? dedupeLeaves(layout) : layout }),
       reset: () => set({ layout: DEFAULT_LAYOUT }),
       addPanel: (id) =>
-        set((s) => ({
-          layout: s.layout
-            ? { direction: 'row', first: s.layout, second: id, splitPercentage: 76 }
-            : id,
-        })),
+        set((s) => {
+          const leaves = s.layout ? getLeaves(s.layout) : [];
+          if (leaves.includes(id)) return {};
+          return {
+            layout: s.layout
+              ? { direction: 'row', first: s.layout, second: id, splitPercentage: 76 }
+              : id,
+          };
+        }),
       showPanel: (id) =>
         set((s) => {
           const leaves = s.layout ? getLeaves(s.layout) : [];
@@ -87,6 +114,19 @@ export const useWorkspace = create<WorkspaceState>()(
           };
         }),
     }),
-    { name: 'redcell.workspace.v3' },
+    {
+      name: 'redcell.workspace.v3',
+      // Heal an already-corrupted persisted layout (duplicate leaves) on load,
+      // so a stuck browser recovers on the next reload instead of crashing.
+      merge: (persisted, current) => {
+        const p = (persisted ?? {}) as Partial<WorkspaceState>;
+        const layout = p.layout !== undefined ? p.layout : current.layout;
+        return {
+          ...current,
+          ...p,
+          layout: hasDuplicateLeaves(layout ?? null) ? dedupeLeaves(layout ?? null) : layout,
+        };
+      },
+    },
   ),
 );

--- a/apps/web/src/test/mockClient.test.ts
+++ b/apps/web/src/test/mockClient.test.ts
@@ -108,3 +108,11 @@ describe('settings', () => {
     expect(models.some((m) => m.provider === 'ollama')).toBe(true);
   });
 });
+
+describe('browser', () => {
+  it('control echoes the owner and vncUrl points at the browser ws', async () => {
+    const res = await client.browser.control('ses-1', 'operator');
+    expect(res.owner).toBe('operator');
+    expect(client.browser.vncUrl('ses-1')).toContain('/ws/browser/');
+  });
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
     // allow importing files from the monorepo root (the api-client package)
     fs: { allow: ['../..'] },
   },
+  // es2022 so @novnc/novnc's top-level await survives the build (all target browsers support it).
+  build: { target: 'es2022' },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,8 +19,10 @@ export default defineConfig({
     // allow importing files from the monorepo root (the api-client package)
     fs: { allow: ['../..'] },
   },
-  // es2022 so @novnc/novnc's top-level await survives the build (all target browsers support it).
+  // es2022 so @novnc/novnc's top-level await survives both the production build
+  // and the dev-server dependency pre-bundling (all target browsers support it).
   build: { target: 'es2022' },
+  optimizeDeps: { esbuildOptions: { target: 'es2022' } },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
       "name": "@redcell/web",
       "version": "0.0.0",
       "dependencies": {
+        "@novnc/novnc": "1.7.0",
         "@redcell/api-client": "workspace:*",
         "@tanstack/react-query": "^5.59.0",
         "@xterm/addon-fit": "^0.10.0",
@@ -211,6 +212,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@novnc/novnc": ["@novnc/novnc@1.7.0", "", {}, "sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA=="],
 
     "@react-dnd/asap": ["@react-dnd/asap@5.0.2", "", {}, "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A=="],
 

--- a/docker/kali/Dockerfile
+++ b/docker/kali/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       sqlmap nikto wpscan \
       gobuster ffuf feroxbuster dirb dirbuster \
       nuclei httpx-toolkit \
+      # browser automation (agent-driven + live VNC view)
+      chromium xvfb x11vnc \
       # exploitation / creds
       hydra john hashcat \
       # wordlists
@@ -31,6 +33,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # rockyou ships gzipped; unpack it so tools can use it directly.
 RUN [ -f /usr/share/wordlists/rockyou.txt.gz ] && gunzip -f /usr/share/wordlists/rockyou.txt.gz || true
+
+# Playwright as a CDP client only (drives the apt chromium above), so no browser
+# download is needed. Kali's Python is externally managed, hence --break-system-packages.
+RUN pip3 install --no-cache-dir --break-system-packages playwright
+
+# Agent-driven browser helper + supervisor.
+COPY rc-browserd rc-browser /usr/local/bin/
+RUN chmod +x /usr/local/bin/rc-browserd /usr/local/bin/rc-browser
 
 WORKDIR /root
 CMD ["sleep", "infinity"]

--- a/docker/kali/rc-browser
+++ b/docker/kali/rc-browser
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""REDCELL in-container browser action helper. Connects to the headed Chromium
+started by rc-browserd over CDP, performs one action, and prints a single JSON
+line. Driven by the engine BrowserManager through backend.run, so the browser is
+operated exactly like every other tool in the container."""
+
+import base64
+import json
+import sys
+
+CDP = "http://localhost:9222"
+
+
+def _out(obj):
+    print(json.dumps(obj))
+
+
+def _page(pw):
+    browser = pw.chromium.connect_over_cdp(CDP)
+    ctx = browser.contexts[0] if browser.contexts else browser.new_context()
+    page = ctx.pages[0] if ctx.pages else ctx.new_page()
+    return browser, page
+
+
+def _run(action, argv):
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as pw:
+        browser, page = _page(pw)
+        try:
+            if action == "open":
+                page.goto(argv[0], wait_until="domcontentloaded", timeout=30000)
+                _out({"ok": True, "url": page.url, "title": page.title()})
+            elif action == "click":
+                page.click(argv[0], timeout=15000)
+                _out({"ok": True, "url": page.url})
+            elif action == "type":
+                submit = "--submit" in argv[2:]
+                page.fill(argv[0], argv[1], timeout=15000)
+                if submit:
+                    page.keyboard.press("Enter")
+                _out({"ok": True, "url": page.url})
+            elif action == "read":
+                text = page.inner_text("body")[:6000]
+                links = [
+                    {"text": (a.inner_text() or "").strip()[:80], "href": a.get_attribute("href")}
+                    for a in page.query_selector_all("a[href]")[:40]
+                ]
+                inputs = [
+                    {"name": i.get_attribute("name"), "type": i.get_attribute("type"),
+                     "id": i.get_attribute("id")}
+                    for i in page.query_selector_all("input, textarea, select")[:40]
+                ]
+                _out({"ok": True, "url": page.url, "title": page.title(), "text": text,
+                      "links": links, "inputs": inputs})
+            elif action == "screenshot":
+                _out({"ok": True, "b64": base64.b64encode(page.screenshot()).decode()})
+            else:
+                _out({"ok": False, "error": f"unknown action {action}"})
+        finally:
+            # connect_over_cdp: close() disconnects the client but leaves Chromium
+            # running, so page state persists for the next action.
+            browser.close()
+
+
+def main(argv):
+    if not argv:
+        _out({"ok": False, "error": "no action"})
+        return
+    try:
+        _run(argv[0], argv[1:])
+    except Exception as exc:
+        _out({"ok": False, "error": (str(exc) or type(exc).__name__)[:300]})
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/docker/kali/rc-browserd
+++ b/docker/kali/rc-browserd
@@ -1,0 +1,57 @@
+#!/bin/sh
+# REDCELL in-container browser supervisor. Boots a headed Chromium on a virtual
+# X display with a VNC server, so the agent (over CDP) and the operator (over
+# VNC) drive the same browser. Idempotent start; used by the engine
+# BrowserManager and torn down when a run ends.
+PIDFILE=/tmp/rc-browser.pids
+DISPLAY_NUM=:99
+CDP_PORT=9222
+VNC_PORT=5900
+
+is_up() {
+  curl -s "http://localhost:${CDP_PORT}/json/version" >/dev/null 2>&1
+}
+
+start() {
+  if is_up; then echo "already running"; return 0; fi
+  : > "$PIDFILE"
+  Xvfb "$DISPLAY_NUM" -screen 0 1280x800x24 >/tmp/xvfb.log 2>&1 &
+  echo $! >> "$PIDFILE"
+  sleep 1
+  DISPLAY="$DISPLAY_NUM" chromium \
+    --remote-debugging-port="${CDP_PORT}" \
+    --remote-debugging-address=127.0.0.1 \
+    --no-sandbox --no-first-run --disable-gpu \
+    --disable-dev-shm-usage --window-size=1280,800 about:blank \
+    >/tmp/chromium.log 2>&1 &
+  echo $! >> "$PIDFILE"
+  # x11vnc backgrounds itself; bind to loopback only, no password, no exposed port.
+  x11vnc -display "$DISPLAY_NUM" -localhost -nopw -forever -shared \
+    -rfbport "${VNC_PORT}" -bg -o /tmp/x11vnc.log >/dev/null 2>&1
+  i=0
+  while [ $i -lt 30 ]; do
+    if is_up; then echo "ready"; return 0; fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+  echo "browser failed to start" >&2
+  return 1
+}
+
+stop() {
+  if [ -f "$PIDFILE" ]; then
+    while read -r pid; do
+      [ -n "$pid" ] && kill "$pid" 2>/dev/null
+    done < "$PIDFILE"
+    rm -f "$PIDFILE"
+  fi
+  pkill -f "x11vnc.*${VNC_PORT}" 2>/dev/null
+  return 0
+}
+
+case "$1" in
+  start) start ;;
+  stop) stop ;;
+  status) is_up ;;
+  *) echo "usage: rc-browserd {start|stop|status}" >&2; exit 2 ;;
+esac

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -180,4 +180,8 @@ export interface ApiClient {
   shellIO: {
     subscribe(shellId: string, cb: (chunk: string) => void): Unsubscribe;
   };
+  browser: {
+    control(sessionId: string, owner: 'operator' | 'agent'): Promise<{ owner: string }>;
+    vncUrl(sessionId: string): string;
+  };
 }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -181,6 +181,7 @@ export interface ApiClient {
     subscribe(shellId: string, cb: (chunk: string) => void): Unsubscribe;
   };
   browser: {
+    start(sessionId: string): Promise<{ ok: boolean; detail?: string }>;
     control(sessionId: string, owner: 'operator' | 'agent'): Promise<{ owner: string }>;
     vncUrl(sessionId: string): string;
   };

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -135,6 +135,7 @@ export function createHttpClient(baseUrl: string, wsUrl: string): ApiClient {
         subscribe('shell', shellId, (m) => cb(typeof m === 'string' ? m : String(m))),
     },
     browser: {
+      start: (sessionId) => req(`/sessions/${sessionId}/browser/start`, { method: 'POST' }),
       control: (sessionId, owner) => req(`/sessions/${sessionId}/browser/control`, json({ owner })),
       vncUrl: (sessionId) => `${wsUrl}/browser/${encodeURIComponent(sessionId)}`,
     },

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -134,5 +134,9 @@ export function createHttpClient(baseUrl: string, wsUrl: string): ApiClient {
       subscribe: (shellId, cb) =>
         subscribe('shell', shellId, (m) => cb(typeof m === 'string' ? m : String(m))),
     },
+    browser: {
+      control: (sessionId, owner) => req(`/sessions/${sessionId}/browser/control`, json({ owner })),
+      vncUrl: (sessionId) => `${wsUrl}/browser/${encodeURIComponent(sessionId)}`,
+    },
   };
 }

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -582,6 +582,9 @@ export function createMockClient(): ApiClient {
       },
     },
     browser: {
+      async start() {
+        return { ok: true };
+      },
       async control(_sessionId, owner) {
         return { owner };
       },

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -581,6 +581,14 @@ export function createMockClient(): ApiClient {
         return () => clearInterval(timer);
       },
     },
+    browser: {
+      async control(_sessionId, owner) {
+        return { owner };
+      },
+      vncUrl(sessionId) {
+        return `ws://mock/api/v1/ws/browser/${sessionId}`;
+      },
+    },
   };
 }
 

--- a/packages/core/redcell_core/bus.py
+++ b/packages/core/redcell_core/bus.py
@@ -36,6 +36,11 @@ def control_channel(run_id: str) -> str:
     return f"control:{run_id}"
 
 
+def browser_channel(session_id: str) -> str:
+    """Browser control-owner handoff (operator take/release) from the API to the worker."""
+    return f"browser:{session_id}"
+
+
 class _MemoryBackend:
     def __init__(self) -> None:
         self._subs: dict[str, set[asyncio.Queue[str]]] = defaultdict(set)

--- a/packages/core/redcell_core/engine/browser.py
+++ b/packages/core/redcell_core/engine/browser.py
@@ -1,0 +1,76 @@
+"""Session-scoped browser control. Boots the in-container browser stack lazily
+(rc-browserd) and drives it through the rc-browser helper via backend.run, the
+same path every other tool uses. While the operator holds control through the VNC
+bridge, agent actions no-op so the two never fight for the cursor."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from typing import Any
+
+
+class BrowserManager:
+    def __init__(self, backend: Any, session_id: str, bus: Any = None) -> None:
+        self.backend = backend
+        self.session_id = session_id
+        self.bus = bus
+        self.owner = "agent"
+        self._started = False
+
+    def set_owner(self, owner: str) -> None:
+        self.owner = "operator" if owner == "operator" else "agent"
+
+    async def ensure_started(self) -> None:
+        if self._started:
+            return
+        await self.backend.run("rc-browserd start")
+        self._started = True
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        try:
+            await self.backend.run("rc-browserd stop")
+        finally:
+            self._started = False
+
+    async def _action(self, *parts: str) -> dict[str, Any]:
+        if self.owner == "operator":
+            return {"status": "operator_has_control"}
+        await self.ensure_started()
+        cmd = "rc-browser " + " ".join(shlex.quote(p) for p in parts)
+        res = await self.backend.run(cmd)
+        return _parse_json(getattr(res, "output", res))
+
+    async def open(self, url: str) -> dict[str, Any]:
+        return await self._action("open", url)
+
+    async def click(self, selector: str) -> dict[str, Any]:
+        return await self._action("click", selector)
+
+    async def type(self, selector: str, text: str, submit: bool = False) -> dict[str, Any]:
+        parts = ["type", selector, text]
+        if submit:
+            parts.append("--submit")
+        return await self._action(*parts)
+
+    async def read(self) -> dict[str, Any]:
+        return await self._action("read")
+
+    async def screenshot(self) -> dict[str, Any]:
+        return await self._action("screenshot")
+
+
+def _parse_json(output: Any) -> dict[str, Any]:
+    """rc-browser prints one JSON line. Scan from the last non-empty line so any
+    startup log noise ahead of it is ignored."""
+    text = output if isinstance(output, str) else str(output)
+    for line in reversed([ln for ln in text.splitlines() if ln.strip()]):
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return {"ok": False, "error": "no JSON from rc-browser", "raw": text[:300]}

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -349,6 +349,9 @@ class LiveRunner:
     async def _dispatch_browser(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
         if self._browser is None:
             return {"error": "browser not available for this session"}
+        # Authoritative ownership: read the durable value before every action, so a
+        # take/release is honored even if the live subscription missed it.
+        self._browser.set_owner(await steer.get_browser_owner(self.session_id))
         if name == "browser_open":
             return await self._browser.open(args.get("url", ""))
         if name == "browser_click":

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -26,6 +26,7 @@ from ..repositories import sessions as sessions_repo
 from ..repositories import settings as settings_repo
 from ..repositories import shells as shells_repo
 from ..schemas import ExecutionSettings, LlmSettings
+from .browser import BrowserManager
 from .execution import build_backend
 from .llm import LlmClient
 from .tools import (
@@ -130,6 +131,7 @@ class LiveRunner:
         self.source: str | None = None
         self.server = None  # the chosen remote Server row, or None for local
         self._listener_tasks: list[asyncio.Task] = []
+        self._browser: BrowserManager | None = None
 
     async def run(self) -> None:
         await self._load()
@@ -158,6 +160,11 @@ class LiveRunner:
         finally:
             for t in self._listener_tasks:
                 t.cancel()
+            if self._browser is not None:
+                try:
+                    await self._browser.stop()
+                except Exception:
+                    pass
             if self.backend is not None:
                 await self.backend.close()
 
@@ -213,6 +220,8 @@ class LiveRunner:
             self.backend = build_backend(exec_cfg, server=server, server_secret=server_secret,
                                          proxy_url=proxy_url, name=f"redcell-exec-{self.session_id[:12]}",
                                          mounts=mounts)
+        if self._browser is None and self.kind != "code":
+            self._browser = BrowserManager(self.backend, self.session_id, self.bus)
 
     async def _ensure_orchestrator(self, s) -> str:
         nodes, _ = await agents_repo.graph(s, self.run_id)
@@ -330,6 +339,28 @@ class LiveRunner:
             return {"ok": True}
         return {"error": f"unknown tool {name}"}
 
+    async def _dispatch_browser(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        if self._browser is None:
+            return {"error": "browser not available for this session"}
+        if name == "browser_open":
+            return await self._browser.open(args.get("url", ""))
+        if name == "browser_click":
+            return await self._browser.click(args.get("selector", ""))
+        if name == "browser_type":
+            return await self._browser.type(args.get("selector", ""), args.get("text", ""),
+                                            bool(args.get("submit")))
+        if name == "browser_read":
+            return await self._browser.read()
+        if name == "browser_screenshot":
+            res = await self._browser.screenshot()
+            if res.get("ok") and res.get("b64"):
+                # Record the capture as loot evidence; keep the blob out of the agent's context.
+                await self._record_loot({"kind": "file", "label": "browser screenshot",
+                                         "value": "screenshot of the current page", "source": "browser"})
+                return {"ok": True, "captured": True, "url": res.get("url")}
+            return res
+        return {"error": f"unknown browser tool {name}"}
+
     # ---- executor sub-agent ----
     async def _delegate(self, agent_name: str, objective: str) -> dict[str, Any]:
         async with session_scope() as s:
@@ -387,6 +418,15 @@ class LiveRunner:
                         if fnd.get("title"):
                             findings_here.append(fnd["title"])
                     stop = True
+                elif cname.startswith("browser_"):
+                    calls += 1
+                    label = (cargs.get("url") or cargs.get("selector") or "").strip()
+                    async with session_scope() as s:
+                        await agents_repo.update(s, agent_id, action=f"{cname} {label}".strip()[:80], calls=calls)
+                    await self._event(agent_name, "tool", f"[browser] {cname} {label}".strip())
+                    res = await self._dispatch_browser(cname, cargs)
+                    messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
+                                     "content": json.dumps(res)[:2000]})
             if stop:
                 break
 

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -9,7 +9,7 @@ import json
 from typing import Any, TypedDict
 
 from .. import steer
-from ..bus import Bus, chat_channel, shell_channel, shell_input_channel
+from ..bus import Bus, browser_channel, chat_channel, shell_channel, shell_input_channel
 from ..config import settings
 from ..db import session_scope
 from ..repositories import agents as agents_repo
@@ -135,6 +135,8 @@ class LiveRunner:
 
     async def run(self) -> None:
         await self._load()
+        if self._browser is not None:
+            self._listener_tasks.append(asyncio.create_task(self._watch_browser_control()))
         if self.kind != "code":
             await self._seed_targets()
         try:
@@ -360,6 +362,21 @@ class LiveRunner:
                 return {"ok": True, "captured": True, "url": res.get("url")}
             return res
         return {"error": f"unknown browser tool {name}"}
+
+    async def _watch_browser_control(self) -> None:
+        """Flip the browser's control owner when the operator takes or releases it."""
+        try:
+            async for payload in self.bus.subscribe(browser_channel(self.session_id)):
+                try:
+                    data = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if self._browser is not None and "owner" in data:
+                    self._browser.set_owner(data["owner"])
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            pass
 
     # ---- executor sub-agent ----
     async def _delegate(self, agent_name: str, objective: str) -> dict[str, Any]:

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -5,6 +5,7 @@ Imported only in live mode; litellm and langgraph are imported lazily."""
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 from typing import Any, TypedDict
 
@@ -16,6 +17,7 @@ from ..repositories import agents as agents_repo
 from ..repositories import chat as chat_repo
 from ..repositories import findings as findings_repo
 from ..repositories import hosts as hosts_repo
+from ..repositories import ids
 from ..repositories import listeners as listeners_repo
 from ..repositories import loot as loot_repo
 from ..repositories import provider_credentials as creds_repo
@@ -26,6 +28,7 @@ from ..repositories import sessions as sessions_repo
 from ..repositories import settings as settings_repo
 from ..repositories import shells as shells_repo
 from ..schemas import ExecutionSettings, LlmSettings
+from ..storage import storage
 from .browser import BrowserManager
 from .execution import build_backend
 from .llm import LlmClient
@@ -148,6 +151,8 @@ class LiveRunner:
                 await self._event("orchestrator", "steer",
                                   f"execution backend unavailable ({exc}); using simulated execution")
                 self.backend = SimBackend()
+                if self._browser is not None:
+                    self._browser.backend = self.backend
             if self.kind == "code":
                 await self._prepare_source()
             await self._orchestrate()
@@ -356,15 +361,25 @@ class LiveRunner:
         if name == "browser_screenshot":
             res = await self._browser.screenshot()
             if res.get("ok") and res.get("b64"):
-                # Record the capture as loot evidence; keep the blob out of the agent's context.
-                await self._record_loot({"kind": "file", "label": "browser screenshot",
-                                         "value": "screenshot of the current page", "source": "browser"})
-                return {"ok": True, "captured": True, "url": res.get("url")}
+                # Persist the PNG to the loot bucket and record it as evidence; keep the
+                # blob out of the agent's context and hand back a stable artifact key.
+                key = f"browser/{self.run_id}/{ids.new_id('shot')}.png"
+                try:
+                    await storage.put(settings.bucket_loot, key, base64.b64decode(res["b64"]), "image/png")
+                    await self._record_loot({"kind": "file", "label": "browser screenshot",
+                                             "value": key, "source": "browser"})
+                except Exception as exc:
+                    return {"ok": False, "error": f"screenshot capture ok but store failed: {exc}"[:200]}
+                return {"ok": True, "captured": True, "artifact": key, "url": res.get("url")}
             return res
         return {"error": f"unknown browser tool {name}"}
 
     async def _watch_browser_control(self) -> None:
-        """Flip the browser's control owner when the operator takes or releases it."""
+        """Flip the browser's control owner when the operator takes or releases it.
+        Loads the persisted owner first so a take-control that landed before this
+        subscription is not lost, then follows live updates on the channel."""
+        if self._browser is not None:
+            self._browser.set_owner(await steer.get_browser_owner(self.session_id))
         try:
             async for payload in self.bus.subscribe(browser_channel(self.session_id)):
                 try:
@@ -375,8 +390,8 @@ class LiveRunner:
                     self._browser.set_owner(data["owner"])
         except asyncio.CancelledError:
             raise
-        except Exception:
-            pass
+        except Exception as exc:
+            await self._event("orchestrator", "steer", f"browser control watch ended: {exc}")
 
     # ---- executor sub-agent ----
     async def _delegate(self, agent_name: str, objective: str) -> dict[str, Any]:

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -160,6 +160,62 @@ EXECUTOR_TOOLS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "browser_open",
+            "description": "Open a URL in a real browser. Use the browser (not curl) for JS-rendered apps and SPAs, login and multi-step flows, and client-side bugs where raw HTTP cannot see the page.",
+            "parameters": {
+                "type": "object",
+                "properties": {"url": {"type": "string"}},
+                "required": ["url"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "browser_click",
+            "description": "Click the first element matching a CSS selector in the open browser page.",
+            "parameters": {
+                "type": "object",
+                "properties": {"selector": {"type": "string", "description": "CSS selector."}},
+                "required": ["selector"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "browser_type",
+            "description": "Type text into the element matching a CSS selector. Set submit to press Enter after (useful for search boxes and logins).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "selector": {"type": "string", "description": "CSS selector."},
+                    "text": {"type": "string"},
+                    "submit": {"type": "boolean"},
+                },
+                "required": ["selector", "text"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "browser_read",
+            "description": "Read the current page: visible text plus notable links and input fields. Use it to see what rendered after navigation or a click.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "browser_screenshot",
+            "description": "Capture a screenshot of the current page as evidence.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
 ]
 
 

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -4,6 +4,8 @@ validate straight from SQLAlchemy ORM rows."""
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
@@ -221,7 +223,7 @@ class ChatSendInput(Camel):
 
 
 class BrowserControlInput(Camel):
-    owner: str  # "operator" to take control, "agent" to release
+    owner: Literal["operator", "agent"]  # "operator" to take control, "agent" to release
 
 
 # ---- settings / providers ----

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -220,6 +220,10 @@ class ChatSendInput(Camel):
     text: str
 
 
+class BrowserControlInput(Camel):
+    owner: str  # "operator" to take control, "agent" to release
+
+
 # ---- settings / providers ----
 class LlmSettings(Camel):
     provider: str = "moonshot"

--- a/packages/core/redcell_core/steer.py
+++ b/packages/core/redcell_core/steer.py
@@ -62,13 +62,14 @@ def _browser_owner_key(session_id: str) -> str:
     return f"browser_owner:{session_id}"
 
 
-async def set_browser_owner(session_id: str, owner: str) -> None:
-    """Persist who holds the browser (operator/agent) so a take/release survives
-    the pub/sub timing: the worker loads it when its watcher starts."""
+async def set_browser_owner(session_id: str, owner: str) -> bool:
+    """Persist who holds the browser (operator/agent). Returns False on failure so
+    the caller does not report a successful take/release that was never stored."""
     try:
         await _r.set(_browser_owner_key(session_id), owner, ex=86400)
+        return True
     except Exception:
-        pass
+        return False
 
 
 async def get_browser_owner(session_id: str) -> str:

--- a/packages/core/redcell_core/steer.py
+++ b/packages/core/redcell_core/steer.py
@@ -56,3 +56,23 @@ async def is_awaiting(run_id: str) -> bool:
         return bool(await _r.get(_awaiting_key(run_id)))
     except Exception:
         return False
+
+
+def _browser_owner_key(session_id: str) -> str:
+    return f"browser_owner:{session_id}"
+
+
+async def set_browser_owner(session_id: str, owner: str) -> None:
+    """Persist who holds the browser (operator/agent) so a take/release survives
+    the pub/sub timing: the worker loads it when its watcher starts."""
+    try:
+        await _r.set(_browser_owner_key(session_id), owner, ex=86400)
+    except Exception:
+        pass
+
+
+async def get_browser_owner(session_id: str) -> str:
+    try:
+        return (await _r.get(_browser_owner_key(session_id))) or "agent"
+    except Exception:
+        return "agent"

--- a/packages/core/tests/test_browser.py
+++ b/packages/core/tests/test_browser.py
@@ -125,18 +125,25 @@ async def test_dispatch_browser_type_passes_submit():
     assert r._browser.calls[-1] == ("type", "#q", "hi", True)
 
 
-async def test_dispatch_browser_screenshot_records_loot_and_strips_blob(monkeypatch):
+async def test_dispatch_browser_screenshot_persists_and_strips_blob(monkeypatch):
     r = _runner_with_browser()
     recorded: list[dict] = []
+    puts: list[tuple] = []
 
     async def fake_loot(args):
         recorded.append(args)
 
+    async def fake_put(bucket, key, data, content_type):
+        puts.append((bucket, key, content_type))
+
     monkeypatch.setattr(r, "_record_loot", fake_loot)
+    monkeypatch.setattr("redcell_core.engine.runner.storage.put", fake_put)
     out = await r._dispatch_browser("browser_screenshot", {})
-    assert out == {"ok": True, "captured": True, "url": None}
+    assert out["ok"] is True and out["captured"] is True
     assert "b64" not in out
-    assert recorded and recorded[0]["kind"] == "file"
+    assert out["artifact"]  # a stable reference the operator can fetch
+    assert puts and puts[0][0].endswith("loot") and puts[0][2] == "image/png"
+    assert recorded and recorded[0]["value"] == out["artifact"]
 
 
 async def test_dispatch_browser_unavailable_returns_error():

--- a/packages/core/tests/test_browser.py
+++ b/packages/core/tests/test_browser.py
@@ -84,6 +84,10 @@ from redcell_core.engine.runner import LiveRunner  # noqa: E402
 class FakeBrowser:
     def __init__(self) -> None:
         self.calls: list[tuple] = []
+        self.owner = "agent"
+
+    def set_owner(self, owner):
+        self.owner = owner
 
     async def open(self, url):
         self.calls.append(("open", url))

--- a/packages/core/tests/test_browser.py
+++ b/packages/core/tests/test_browser.py
@@ -1,0 +1,76 @@
+"""Unit tests for BrowserManager: command construction, lazy start, operator
+control gating, and tolerant JSON parsing. No real browser or container."""
+
+from redcell_core.engine.browser import BrowserManager
+
+
+class _Res:
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+
+class FakeBackend:
+    def __init__(self, output: str = '{"ok": true}') -> None:
+        self.commands: list[str] = []
+        self.output = output
+
+    async def run(self, cmd: str, **kw):
+        self.commands.append(cmd)
+        return _Res(self.output)
+
+
+def _mgr(output='{"ok": true}'):
+    be = FakeBackend(output)
+    return BrowserManager(be, "ses-1"), be
+
+
+async def test_ensure_started_runs_once():
+    m, be = _mgr()
+    await m.ensure_started()
+    await m.ensure_started()
+    assert be.commands.count("rc-browserd start") == 1
+
+
+async def test_open_runs_rc_browser_and_parses_json():
+    m, be = _mgr('{"ok": true, "url": "https://x", "title": "X"}')
+    out = await m.open("https://x")
+    assert out["url"] == "https://x"
+    assert any(c.startswith("rc-browser open ") for c in be.commands)
+
+
+async def test_operator_control_blocks_agent_actions():
+    m, be = _mgr()
+    m.set_owner("operator")
+    out = await m.open("https://x")
+    assert out == {"status": "operator_has_control"}
+    assert not any(c.startswith("rc-browser") for c in be.commands)
+
+
+async def test_releasing_control_lets_agent_act_again():
+    m, be = _mgr()
+    m.set_owner("operator")
+    await m.open("https://x")
+    m.set_owner("agent")
+    await m.open("https://y")
+    assert any("rc-browser open" in c for c in be.commands)
+
+
+async def test_type_with_submit_includes_flag_and_quotes_spaces():
+    m, be = _mgr()
+    await m.type("#q", "a b", submit=True)
+    cmd = next(c for c in be.commands if c.startswith("rc-browser type"))
+    assert "--submit" in cmd
+    assert "'a b'" in cmd
+
+
+async def test_stop_runs_rc_browserd_stop():
+    m, be = _mgr()
+    await m.ensure_started()
+    await m.stop()
+    assert "rc-browserd stop" in be.commands
+
+
+async def test_parse_tolerates_log_noise_before_json():
+    m, be = _mgr('boot log line\nanother\n{"ok": true, "url": "u"}')
+    out = await m.read()
+    assert out["url"] == "u"

--- a/packages/core/tests/test_browser.py
+++ b/packages/core/tests/test_browser.py
@@ -143,3 +143,8 @@ async def test_dispatch_browser_unavailable_returns_error():
     r = LiveRunner(bus=None, run_id="run-1")
     out = await r._dispatch_browser("browser_open", {"url": "x"})
     assert "error" in out
+
+
+def test_browser_channel_name():
+    from redcell_core.bus import browser_channel
+    assert browser_channel("ses-1") == "browser:ses-1"

--- a/packages/core/tests/test_browser.py
+++ b/packages/core/tests/test_browser.py
@@ -74,3 +74,72 @@ async def test_parse_tolerates_log_noise_before_json():
     m, be = _mgr('boot log line\nanother\n{"ok": true, "url": "u"}')
     out = await m.read()
     assert out["url"] == "u"
+
+
+# ---- runner dispatch routing ----
+
+from redcell_core.engine.runner import LiveRunner  # noqa: E402
+
+
+class FakeBrowser:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def open(self, url):
+        self.calls.append(("open", url))
+        return {"ok": True, "url": url}
+
+    async def click(self, selector):
+        self.calls.append(("click", selector))
+        return {"ok": True}
+
+    async def type(self, selector, text, submit=False):
+        self.calls.append(("type", selector, text, submit))
+        return {"ok": True}
+
+    async def read(self):
+        self.calls.append(("read",))
+        return {"ok": True, "text": "hi"}
+
+    async def screenshot(self):
+        self.calls.append(("screenshot",))
+        return {"ok": True, "b64": "AAAA"}
+
+
+def _runner_with_browser():
+    r = LiveRunner(bus=None, run_id="run-1")
+    r._browser = FakeBrowser()
+    return r
+
+
+async def test_dispatch_browser_open_routes():
+    r = _runner_with_browser()
+    out = await r._dispatch_browser("browser_open", {"url": "https://x"})
+    assert out["url"] == "https://x"
+    assert r._browser.calls == [("open", "https://x")]
+
+
+async def test_dispatch_browser_type_passes_submit():
+    r = _runner_with_browser()
+    await r._dispatch_browser("browser_type", {"selector": "#q", "text": "hi", "submit": True})
+    assert r._browser.calls[-1] == ("type", "#q", "hi", True)
+
+
+async def test_dispatch_browser_screenshot_records_loot_and_strips_blob(monkeypatch):
+    r = _runner_with_browser()
+    recorded: list[dict] = []
+
+    async def fake_loot(args):
+        recorded.append(args)
+
+    monkeypatch.setattr(r, "_record_loot", fake_loot)
+    out = await r._dispatch_browser("browser_screenshot", {})
+    assert out == {"ok": True, "captured": True, "url": None}
+    assert "b64" not in out
+    assert recorded and recorded[0]["kind"] == "file"
+
+
+async def test_dispatch_browser_unavailable_returns_error():
+    r = LiveRunner(bus=None, run_id="run-1")
+    out = await r._dispatch_browser("browser_open", {"url": "x"})
+    assert "error" in out


### PR DESCRIPTION
## Summary

Gives agents a real browser they can drive during a run, plus an operator Browser panel that shows it live and supports interactive takeover over noVNC. Closes #3.

The design was brainstormed and specced first. Decisions: interactive takeover (not view-only); the browser is baked into the per-session Kali container; lazy-start (zero cost until used); agent-navigation scope enforcement is deferred to #2.

## What is included

- **Kali image** (`docker/kali/`): adds `chromium`, `xvfb`, `x11vnc`, and Playwright as a CDP client, plus `rc-browserd` (boots a headed Chromium on a virtual X display with a loopback-only VNC server) and `rc-browser` (one browser action, prints JSON).
- **Engine**: session-scoped `BrowserManager` that drives the container browser through `backend.run`; executor tools `browser_open` / `browser_click` / `browser_type` / `browser_read` / `browser_screenshot` dispatched in the runner; agent/operator control handoff over a `browser:{sessionId}` channel; teardown on run end.
- **API**: `GET /ws/browser/{sessionId}` bridges a noVNC client to the container's x11vnc via `docker exec ... socat` (authenticated by the existing JWT cookie); `POST /sessions/{sid}/browser/control` for take/release.
- **Frontend**: `BrowserPanel` embedding noVNC with a Take/Release control toggle, registered in the panel switch and workspace registry; `@novnc/novnc` dependency; api-client `browser.control` / `browser.vncUrl`.

## Verified (automated, all green)

- `uv run pytest` — 48 passed (includes new `test_browser.py` and the API smoke browser checks)
- `uvx ruff@0.15.8 check .` — clean
- `bun run typecheck`, `bun run lint`, `bun run test` (35 passed), `bun run build` — all green (build target raised to es2022 for noVNC's top-level await)

## Manual e2e (NOT run in CI, needs a maintainer)

CI cannot build or run the ~1 GB browser image, so the browser/VNC runtime is unverified here. Please validate before relying on it:

1. Rebuild and publish the image (required before live use, the new packages only exist in a rebuilt image):
   `docker build -t martian56/kali:latest docker/kali && docker push martian56/kali:latest`
2. In live mode, create a local network session against a practice target (Juice Shop from `docker-compose.targets.yml`).
3. Confirm the agent can `browser_open` and `browser_read` a JS-rendered page, that the Browser panel shows it live, and that Take control lets you drive it, then Release hands it back.

## Known limitations / follow-ups

- Live view is **local sessions only** for now; remote-server sessions close the VNC socket with code 4403. The remote bridge is a follow-up.
- `browser_eval` and agent-navigation scope enforcement are intentionally deferred (scope enforcement lands with #2).
- Screenshots record a loot evidence entry (metadata); persisting the PNG bytes to the loot bucket is a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive browser panel for live sessions, with viewing and operator control.
  * Added browser automation for navigation, clicking, typing, page reading, and screenshots.
  * Added session browser startup and secure real-time browser streaming.
  * Added Chromium-based browser support to the session environment.

* **Bug Fixes**
  * Prevented duplicate panels and repaired duplicate entries in saved layouts.

* **Tests**
  * Added coverage for browser controls, streaming authentication, automation, screenshots, and layout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->