### PR TITLE
feat: structured agent tool integrations (nmap, nuclei, web discovery, metasploit)

### DIFF
--- a/packages/core/redcell_core/engine/msf.py
+++ b/packages/core/redcell_core/engine/msf.py
@@ -1,0 +1,40 @@
+"""Build controlled Metasploit invocations (msfconsole batch mode) and parse the
+module search table. Same execution posture as run_command (the agent can already
+run msfconsole); this just gives it a structured search and run surface."""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+_MODULE_RE = re.compile(r"\b((?:exploit|auxiliary|post|payload|encoder|nop|evasion)/[\w/\-.]+)")
+_MODULE_OK = re.compile(r"^[\w/\-.]+$")
+
+
+def build_msf_search(query: str) -> str:
+    return f"msfconsole -q -x {shlex.quote(f'search {query}; exit')}"
+
+
+def build_msf_run(module: str, options: dict[str, str] | None = None) -> str:
+    """`use <module>; set K V; ...; run; exit`, shell-quoted as one script."""
+    lines = [f"use {module}"]
+    for k, v in (options or {}).items():
+        lines.append(f"set {k} {v}")
+    lines += ["run", "exit"]
+    return f"msfconsole -q -x {shlex.quote('; '.join(lines))}"
+
+
+def valid_module(module: str) -> bool:
+    return bool(module) and bool(_MODULE_OK.match(module)) and ".." not in module
+
+
+def parse_msf_search(output: str) -> list[str]:
+    """Pull module paths out of a `search` result table, order-preserving, deduped."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in output.splitlines():
+        m = _MODULE_RE.search(line)
+        if m and m.group(1) not in seen:
+            seen.add(m.group(1))
+            out.append(m.group(1))
+    return out

--- a/packages/core/redcell_core/engine/nmap.py
+++ b/packages/core/redcell_core/engine/nmap.py
@@ -1,0 +1,62 @@
+"""Build a safe nmap command and parse its XML output into structured hosts.
+Pure and unit-testable; the runner runs the command in the container and records
+the parsed hosts onto the attack surface."""
+
+from __future__ import annotations
+
+import shlex
+import xml.etree.ElementTree as ET
+from typing import Any
+
+
+def build_nmap_command(target: str, ports: str | None = None,
+                       service_detection: bool = False, scripts: bool = False) -> str:
+    """`nmap -oX -` (XML to stdout) with a curated, shell-quoted flag set. Every
+    argument is quoted so a garbled or hostile target cannot inject shell."""
+    parts = ["nmap", "-oX", "-", "-T4", "-Pn"]
+    if service_detection:
+        parts.append("-sV")
+    if scripts:
+        parts.append("-sC")
+    if ports:
+        parts += ["-p", ports]
+    parts.append(target)
+    return " ".join(shlex.quote(p) for p in parts)
+
+
+def parse_nmap_xml(xml: str) -> list[dict[str, Any]]:
+    """Return up hosts with their open ports/services from nmap -oX output."""
+    hosts: list[dict[str, Any]] = []
+    try:
+        root = ET.fromstring(xml)
+    except ET.ParseError:
+        return hosts
+    for host in root.findall("host"):
+        status = host.find("status")
+        if status is not None and status.get("state") == "down":
+            continue
+        addr = ""
+        for a in host.findall("address"):
+            if a.get("addrtype") in ("ipv4", "ipv6"):
+                addr = a.get("addr", "")
+                break
+        hostnames = [hn.get("name", "") for hn in host.findall("./hostnames/hostname") if hn.get("name")]
+        ports: list[dict[str, Any]] = []
+        for p in host.findall("./ports/port"):
+            st = p.find("state")
+            if st is None or st.get("state") not in ("open", "open|filtered"):
+                continue
+            svc = p.find("service")
+            service = svc.get("name", "") if svc is not None else ""
+            product = svc.get("product", "") if svc is not None else ""
+            version = svc.get("version", "") if svc is not None else ""
+            ver = " ".join(x for x in (product, version) if x)
+            ports.append({
+                "port": int(p.get("portid", 0) or 0),
+                "protocol": p.get("protocol", "tcp"),
+                "service": service,
+                "version": ver,
+            })
+        if addr or hostnames or ports:
+            hosts.append({"ip": addr, "hostnames": hostnames, "ports": ports})
+    return hosts

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -29,6 +29,7 @@ from ..repositories import settings as settings_repo
 from ..repositories import shells as shells_repo
 from ..schemas import ExecutionSettings, LlmSettings
 from ..storage import storage
+from . import msf, nmap, webscan
 from .browser import BrowserManager
 from .execution import build_backend
 from .llm import LlmClient
@@ -396,6 +397,80 @@ class LiveRunner:
         except Exception as exc:
             await self._event("orchestrator", "steer", f"browser control watch ended: {exc}")
 
+    # ---- structured tool integrations ----
+    async def _dispatch_toolset(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        if name == "nmap_scan":
+            return await self._run_nmap(args)
+        if name == "nuclei_scan":
+            return await self._run_nuclei(args)
+        if name == "web_discover":
+            return await self._run_web_discover(args)
+        if name == "msf_search":
+            return await self._run_msf_search(args)
+        if name == "msf_run":
+            return await self._run_msf_run(args)
+        return {"error": f"unknown tool {name}"}
+
+    async def _run_nmap(self, args: dict[str, Any]) -> dict[str, Any]:
+        target = str(args.get("target", "")).strip()
+        if not target:
+            return {"error": "target required"}
+        cmd = nmap.build_nmap_command(target, ports=args.get("ports"),
+                                      service_detection=bool(args.get("service_detection")),
+                                      scripts=bool(args.get("scripts")))
+        res = await self.backend.run(cmd)
+        hosts = nmap.parse_nmap_xml(getattr(res, "output", "") or "")
+        for h in hosts:
+            await self._record_host({
+                "host": (h["hostnames"][0] if h["hostnames"] else h["ip"]) or target,
+                "ip": h["ip"],
+                "ports": [{"port": p["port"], "service": p["service"], "version": p["version"]}
+                          for p in h["ports"]],
+                "source": "nmap",
+            })
+        open_ports = sum(len(h["ports"]) for h in hosts)
+        summary = [{"ip": h["ip"], "hostnames": h["hostnames"][:2], "ports": h["ports"][:20]}
+                   for h in hosts[:20]]
+        return {"ok": True, "hosts_up": len(hosts), "open_ports": open_ports, "hosts": summary}
+
+    async def _run_nuclei(self, args: dict[str, Any]) -> dict[str, Any]:
+        target = str(args.get("target", "")).strip()
+        if not target:
+            return {"error": "target required"}
+        cmd = webscan.build_nuclei_command(target, severity=args.get("severity"))
+        res = await self.backend.run(cmd)
+        findings = webscan.parse_nuclei_jsonl(getattr(res, "output", "") or "", target=target)
+        for f in findings:
+            await self._record_finding(f)
+        return {"ok": True, "findings": len(findings), "titles": [f["title"] for f in findings[:20]]}
+
+    async def _run_web_discover(self, args: dict[str, Any]) -> dict[str, Any]:
+        url = str(args.get("url", "")).strip()
+        if not url:
+            return {"error": "url required"}
+        cmd = webscan.build_ffuf_command(url, wordlist=args.get("wordlist"),
+                                         vhost=(args.get("mode") == "vhost"))
+        res = await self.backend.run(cmd)
+        results = webscan.parse_ffuf_json(getattr(res, "output", "") or "")
+        return {"ok": True, "found": len(results), "results": results[:50]}
+
+    async def _run_msf_search(self, args: dict[str, Any]) -> dict[str, Any]:
+        query = str(args.get("query", "")).strip()
+        if not query:
+            return {"error": "query required"}
+        res = await self.backend.run(msf.build_msf_search(query))
+        modules = msf.parse_msf_search(getattr(res, "output", "") or "")
+        return {"ok": True, "count": len(modules), "modules": modules[:40]}
+
+    async def _run_msf_run(self, args: dict[str, Any]) -> dict[str, Any]:
+        module = str(args.get("module", "")).strip()
+        if not msf.valid_module(module):
+            return {"error": "invalid module path"}
+        options = args.get("options") if isinstance(args.get("options"), dict) else {}
+        cmd = msf.build_msf_run(module, {str(k): str(v) for k, v in options.items()})
+        res = await self.backend.run(cmd)
+        return {"ok": True, "output": (getattr(res, "output", "") or "")[-3000:]}
+
     # ---- executor sub-agent ----
     async def _delegate(self, agent_name: str, objective: str) -> dict[str, Any]:
         async with session_scope() as s:
@@ -462,6 +537,16 @@ class LiveRunner:
                     res = await self._dispatch_browser(cname, cargs)
                     messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
                                      "content": json.dumps(res)[:2000]})
+                elif cname in ("nmap_scan", "nuclei_scan", "web_discover", "msf_search", "msf_run"):
+                    calls += 1
+                    label = str(cargs.get("target") or cargs.get("url") or cargs.get("query")
+                                or cargs.get("module") or "")[:60]
+                    async with session_scope() as s:
+                        await agents_repo.update(s, agent_id, action=f"{cname} {label}".strip()[:80], calls=calls)
+                    await self._event(agent_name, "tool", f"[{cname}] {label}".strip())
+                    res = await self._dispatch_toolset(cname, cargs)
+                    messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
+                                     "content": json.dumps(res)[:4000]})
             if stop:
                 break
 

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -216,6 +216,81 @@ EXECUTOR_TOOLS = [
             "parameters": {"type": "object", "properties": {}},
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "nmap_scan",
+            "description": "Port/service scan with nmap. Results are parsed and recorded onto the Attack Surface automatically; you get a concise summary, not raw text. Prefer this over running nmap via run_command.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "target": {"type": "string", "description": "Host, IP, hostname, or CIDR."},
+                    "ports": {"type": "string", "description": "Port spec, e.g. '80,443,8080' or '1-1000'. Optional."},
+                    "service_detection": {"type": "boolean", "description": "Detect service versions (-sV)."},
+                    "scripts": {"type": "boolean", "description": "Run default NSE scripts (-sC)."},
+                },
+                "required": ["target"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "nuclei_scan",
+            "description": "Run nuclei templates against a URL. Matches are recorded as findings (with CVSS where nuclei provides it). Returns a summary.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "target": {"type": "string", "description": "URL to scan, e.g. https://app.example.com."},
+                    "severity": {"type": "string", "description": "Optional filter, e.g. 'critical,high,medium'."},
+                },
+                "required": ["target"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "web_discover",
+            "description": "Directory or vhost discovery with ffuf. Returns the discovered paths (or vhosts) with status codes, structured. Record notable exposures with report/record_finding yourself.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string", "description": "Base URL, e.g. https://app.example.com."},
+                    "mode": {"type": "string", "enum": ["dir", "vhost"], "description": "Directory brute force or virtual-host discovery. Default dir."},
+                    "wordlist": {"type": "string", "description": "Optional wordlist path in the container."},
+                },
+                "required": ["url"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "msf_search",
+            "description": "Search Metasploit modules by keyword. Returns matching module paths.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "e.g. 'apache struts' or a CVE id."}},
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "msf_run",
+            "description": "Run a Metasploit module with options and return its output. Use msf_search first to find the exact module path. Set RHOSTS and other options via options.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "module": {"type": "string", "description": "Full module path, e.g. auxiliary/scanner/http/http_version."},
+                    "options": {"type": "object", "description": "Module options, e.g. {\"RHOSTS\": \"10.0.0.5\", \"RPORT\": \"8080\"}."},
+                },
+                "required": ["module"],
+            },
+        },
+    },
 ]
 
 
@@ -249,6 +324,10 @@ def executor_system(name: str, objective: str) -> str:
     return (
         f"You are the '{name}' executor on an authorized red-team engagement. Achieve this "
         f"objective using shell tools: {objective}\n"
+        "Prefer the structured tools when they fit: nmap_scan for port/service discovery (it records the "
+        "attack surface for you), nuclei_scan for template-based vulns (records findings with CVSS), "
+        "web_discover for directory/vhost brute forcing, and msf_search then msf_run for Metasploit "
+        "modules. Use run_command for anything else.\n"
         "Run one command at a time, read the output, and adapt. Do not run destructive or "
         "out-of-scope commands. When done, call report with a concise summary and any finding."
     )

--- a/packages/core/redcell_core/engine/webscan.py
+++ b/packages/core/redcell_core/engine/webscan.py
@@ -1,0 +1,99 @@
+"""Web-tool command builders and output parsers: nuclei (-> findings with CVSS)
+and ffuf/gobuster directory-vhost discovery (-> structured paths). Pure and
+unit-testable; the runner runs the commands and records or returns the results."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from typing import Any
+
+DEFAULT_WORDLIST = "/usr/share/wordlists/dirb/common.txt"
+_MATCH_CODES = "200,204,301,302,307,401,403,405"
+
+
+# ---- nuclei -> findings ----
+
+def build_nuclei_command(target: str, severity: str | None = None) -> str:
+    parts = ["nuclei", "-u", target, "-jsonl", "-silent", "-nc"]
+    if severity:
+        parts += ["-severity", severity]
+    return " ".join(shlex.quote(p) for p in parts)
+
+
+def parse_nuclei_jsonl(output: str, target: str = "") -> list[dict[str, Any]]:
+    """One JSON object per line. Map each to a finding dict for _record_finding."""
+    findings: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        info = obj.get("info") or {}
+        classification = info.get("classification") or {}
+        cwe_ids = classification.get("cwe-id") or []
+        finding = {
+            "title": info.get("name") or obj.get("template-id") or "nuclei finding",
+            "severity": (info.get("severity") or "info").lower(),
+            "location": obj.get("matched-at") or obj.get("host") or target,
+            "cwe": (cwe_ids[0].upper() if cwe_ids else "").replace("CWE-CWE-", "CWE-"),
+            "status": "candidate",
+        }
+        score = classification.get("cvss-score")
+        if isinstance(score, (int, float)) and score > 0:
+            finding["cvss"] = float(score)
+        findings.append(finding)
+    return findings
+
+
+# ---- ffuf / gobuster -> discovered paths ----
+
+def build_ffuf_command(url: str, wordlist: str | None = None, vhost: bool = False) -> str:
+    """ffuf writing a JSON report to a temp file, then cat it, so parsing gets clean
+    JSON without ffuf's progress noise on stdout."""
+    wl = wordlist or DEFAULT_WORDLIST
+    out = "/tmp/rc-ffuf.json"
+    if vhost:
+        base = url.rstrip("/")
+        host = re.sub(r"^https?://", "", base)
+        target = ["-u", base, "-H", f"Host: FUZZ.{host}"]
+    else:
+        target = ["-u", url.rstrip("/") + "/FUZZ"]
+    parts = ["ffuf", *target, "-w", wl, "-mc", _MATCH_CODES, "-of", "json", "-o", out, "-s"]
+    cmd = " ".join(shlex.quote(p) for p in parts)
+    return f"{cmd} >/dev/null 2>&1; cat {out}"
+
+
+def parse_ffuf_json(output: str) -> list[dict[str, Any]]:
+    """ffuf JSON report: {results: [{url, status, length, ...}]}."""
+    text = output.strip()
+    start = text.find("{")
+    if start < 0:
+        return []
+    try:
+        doc = json.loads(text[start:])
+    except json.JSONDecodeError:
+        return []
+    out: list[dict[str, Any]] = []
+    for r in doc.get("results") or []:
+        out.append({
+            "url": r.get("url", ""),
+            "status": r.get("status", 0),
+            "length": r.get("length", 0),
+        })
+    return out
+
+
+def parse_gobuster_text(output: str) -> list[dict[str, Any]]:
+    """gobuster dir text lines like `/admin (Status: 301) [Size: 178]`."""
+    out: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        m = re.match(r"\s*(\S+)\s+\(Status:\s*(\d+)\)(?:\s*\[Size:\s*(\d+)\])?", line)
+        if m:
+            out.append({"path": m.group(1), "status": int(m.group(2)),
+                        "length": int(m.group(3) or 0)})
+    return out

--- a/packages/core/tests/test_toolset.py
+++ b/packages/core/tests/test_toolset.py
@@ -1,0 +1,180 @@
+"""Unit tests for the structured tool integrations (issue #5): nmap/nuclei/ffuf/
+gobuster parsers, command builders, and the runner dispatch that records hosts
+and findings. No real tools or container."""
+
+from redcell_core.engine.msf import build_msf_run, parse_msf_search, valid_module
+from redcell_core.engine.nmap import build_nmap_command, parse_nmap_xml
+from redcell_core.engine.runner import LiveRunner
+from redcell_core.engine.webscan import (
+    parse_ffuf_json,
+    parse_gobuster_text,
+    parse_nuclei_jsonl,
+)
+
+NMAP_XML = """<?xml version="1.0"?>
+<nmaprun>
+  <host>
+    <status state="up"/>
+    <address addr="10.0.0.5" addrtype="ipv4"/>
+    <hostnames><hostname name="web.local"/></hostnames>
+    <ports>
+      <port protocol="tcp" portid="80"><state state="open"/><service name="http" product="nginx" version="1.18.0"/></port>
+      <port protocol="tcp" portid="443"><state state="open"/><service name="https" product="nginx"/></port>
+      <port protocol="tcp" portid="22"><state state="closed"/><service name="ssh"/></port>
+    </ports>
+  </host>
+  <host>
+    <status state="down"/>
+    <address addr="10.0.0.6" addrtype="ipv4"/>
+  </host>
+</nmaprun>"""
+
+NUCLEI_JSONL = (
+    '{"template-id":"tech-detect","info":{"name":"nginx","severity":"info"},"host":"https://x","matched-at":"https://x"}\n'
+    '{"template-id":"cve-x","info":{"name":"SQL Injection","severity":"high",'
+    '"classification":{"cwe-id":["CWE-89"],"cvss-score":8.2}},"matched-at":"https://x/search"}\n'
+)
+
+FFUF_JSON = '{"results":[{"url":"https://x/admin","status":301,"length":178},{"url":"https://x/login","status":200,"length":540}]}'
+
+GOBUSTER = "/admin (Status: 301) [Size: 178]\n/login (Status: 200) [Size: 540]\n"
+
+MSF_SEARCH = """Matching Modules
+================
+   #  Name                                              Rank
+   -  ----                                              ----
+   0  exploit/multi/http/struts2_content_type_ognl      excellent
+   1  auxiliary/scanner/http/apache_normalize_path_rce  normal
+"""
+
+
+class _Res:
+    def __init__(self, output: str) -> None:
+        self.output = output
+
+
+class FakeBackend:
+    def __init__(self, output: str = "") -> None:
+        self.commands: list[str] = []
+        self.output = output
+
+    async def run(self, cmd: str, **kw):
+        self.commands.append(cmd)
+        return _Res(self.output)
+
+
+# ---- parsers ----
+
+def test_parse_nmap_xml():
+    hosts = parse_nmap_xml(NMAP_XML)
+    assert len(hosts) == 1  # the down host is excluded
+    h = hosts[0]
+    assert h["ip"] == "10.0.0.5"
+    assert {p["port"] for p in h["ports"]} == {80, 443}  # closed port excluded
+    assert any(p["version"] == "nginx 1.18.0" for p in h["ports"])
+
+
+def test_parse_nmap_xml_tolerates_garbage():
+    assert parse_nmap_xml("not xml") == []
+
+
+def test_build_nmap_command_quotes_and_flags():
+    cmd = build_nmap_command("10.0.0.5; rm -rf /", ports="80,443", service_detection=True, scripts=True)
+    assert "-oX" in cmd and "-sV" in cmd and "-sC" in cmd and "-p" in cmd
+    assert "'10.0.0.5; rm -rf /'" in cmd  # target quoted, injection neutralized
+
+
+def test_parse_nuclei_jsonl():
+    fs = parse_nuclei_jsonl(NUCLEI_JSONL)
+    assert len(fs) == 2
+    hi = next(f for f in fs if f["severity"] == "high")
+    assert hi["cvss"] == 8.2 and hi["cwe"] == "CWE-89" and hi["location"] == "https://x/search"
+
+
+def test_parse_ffuf_json():
+    rs = parse_ffuf_json(FFUF_JSON)
+    assert len(rs) == 2 and rs[0]["status"] == 301 and rs[0]["url"].endswith("/admin")
+
+
+def test_parse_gobuster_text():
+    rs = parse_gobuster_text(GOBUSTER)
+    assert len(rs) == 2 and rs[0]["path"] == "/admin" and rs[0]["status"] == 301
+
+
+def test_parse_msf_search():
+    assert parse_msf_search(MSF_SEARCH) == [
+        "exploit/multi/http/struts2_content_type_ognl",
+        "auxiliary/scanner/http/apache_normalize_path_rce",
+    ]
+
+
+def test_valid_module():
+    assert valid_module("auxiliary/scanner/http/http_version")
+    assert not valid_module("../../etc/passwd")
+    assert not valid_module("; ls")
+
+
+def test_build_msf_run_quotes_script():
+    cmd = build_msf_run("auxiliary/scanner/http/http_version", {"RHOSTS": "10.0.0.5"})
+    assert "http_version" in cmd and "RHOSTS" in cmd and cmd.startswith("msfconsole -q -x ")
+
+
+# ---- runner dispatch ----
+
+def _runner(output=""):
+    r = LiveRunner(bus=None, run_id="run-1")
+    r.backend = FakeBackend(output)
+    return r
+
+
+async def test_run_nmap_records_hosts(monkeypatch):
+    r = _runner(NMAP_XML)
+    recorded: list[dict] = []
+
+    async def fake_host(a):
+        recorded.append(a)
+
+    monkeypatch.setattr(r, "_record_host", fake_host)
+    out = await r._run_nmap({"target": "10.0.0.5", "service_detection": True})
+    assert out["ok"] and out["hosts_up"] == 1 and out["open_ports"] == 2
+    assert recorded and recorded[0]["ip"] == "10.0.0.5" and recorded[0]["source"] == "nmap"
+    assert any("-sV" in c for c in r.backend.commands)
+
+
+async def test_run_nuclei_records_findings(monkeypatch):
+    r = _runner(NUCLEI_JSONL)
+    recorded: list[dict] = []
+
+    async def fake_finding(a):
+        recorded.append(a)
+
+    monkeypatch.setattr(r, "_record_finding", fake_finding)
+    out = await r._run_nuclei({"target": "https://x"})
+    assert out["findings"] == 2
+    assert any(f.get("cvss") == 8.2 for f in recorded)
+
+
+async def test_run_web_discover_returns_paths():
+    r = _runner(FFUF_JSON)
+    out = await r._run_web_discover({"url": "https://x"})
+    assert out["found"] == 2 and any(res["status"] == 301 for res in out["results"])
+
+
+async def test_run_msf_search_parses_modules():
+    r = _runner(MSF_SEARCH)
+    out = await r._run_msf_search({"query": "struts"})
+    assert out["count"] == 2
+    assert "exploit/multi/http/struts2_content_type_ognl" in out["modules"]
+
+
+async def test_run_msf_run_rejects_bad_module():
+    r = _runner("done")
+    assert "error" in await r._run_msf_run({"module": "; rm -rf /"})
+    ok = await r._run_msf_run({"module": "auxiliary/scanner/http/http_version",
+                               "options": {"RHOSTS": "10.0.0.5"}})
+    assert ok["ok"] and any("RHOSTS" in c for c in r.backend.commands)
+
+
+async def test_dispatch_toolset_unknown():
+    r = _runner()
+    assert "error" in await r._dispatch_toolset("nope", {})


### PR DESCRIPTION
## Summary

Implements the full toolset from #5: structured integrations that parse tool output in Python and record it onto the existing models, instead of leaving the model to read raw text. Closes #5.

Design note: the agent already runs any Kali tool through the generic `run_command`. The value here is turning a few high-value tools from "raw text the model must interpret" into "structured results the system records directly."

## Tools added (executor tools)

- **`nmap_scan(target, ports?, service_detection?, scripts?)`** — runs `nmap -oX -`, parses the XML, and records hosts/ports/services onto the Attack Surface. Returns a trimmed summary.
- **`nuclei_scan(target, severity?)`** — runs nuclei (`-jsonl`), maps each match to a finding (CVSS/CWE where nuclei provides them). Records findings.
- **`web_discover(url, mode=dir|vhost, wordlist?)`** — runs ffuf, returns the discovered paths/vhosts with status codes, structured.
- **`msf_search(query)`** — searches Metasploit modules, returns module paths.
- **`msf_run(module, options?)`** — runs a module via `msfconsole -q -x`, returns its output.

Parsers live in focused, pure modules: `engine/nmap.py`, `engine/webscan.py`, `engine/msf.py`.

## How it maps

- nmap → hosts (`_record_host` → Attack Surface panel)
- nuclei → findings (`_record_finding` → Findings panel; CVSS from nuclei or the severity floor)
- web_discover / msf → structured results returned to the agent (no new model needed)

## Safety

- Every command is assembled from a fixed template and shell-quoted, so a hostile or garbled `target`/`url`/`query` cannot inject shell.
- `msf_run` validates the module path (`^[\w/\-.]+$`, no `..`) and has the same execution posture as `run_command` (which can already run `msfconsole`). Agent-navigation/target scope enforcement is deferred to #2, consistent with the rest of the engine.

## Verified (automated, green)

- `uv run pytest` — 63 passed (15 new in `test_toolset.py`: parsers, command builders, runner dispatch against a fake backend)
- `uvx ruff@0.15.8 check .` — clean
- No frontend changes; results surface in the existing panels.

## Manual e2e (NOT in CI)

The tools actually executing (nmap/nuclei/ffuf/msfconsole) need the Kali container, which CI can't run. Validate on a live session against a practice target, e.g. `nmap_scan` populating the Attack Surface and `nuclei_scan` adding findings.
