### PR TITLE
fix(engine): read command output in chunks so long lines don't crash runs

### DIFF
--- a/packages/core/redcell_core/engine/execution.py
+++ b/packages/core/redcell_core/engine/execution.py
@@ -123,15 +123,25 @@ class LocalDockerBackend(ExecutionBackend):
             "docker", "exec", *env_args, self.name, "sh", "-c", command,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         )
-        chunks: list[str] = []
+        # Read in fixed chunks, not line-iteration: readline() caps a single line at
+        # 64 KB and raises on longer ones (nmap XML, a nuclei JSON line with a big body).
         assert proc.stdout is not None
-        async for raw in proc.stdout:
-            line = raw.decode(errors="replace")
-            chunks.append(line)
+        raw = bytearray()
+        pending = b""
+        while True:
+            data = await proc.stdout.read(65536)
+            if not data:
+                break
+            raw += data
             if on_output:
-                await on_output(line.rstrip("\n") + "\r\n")
+                pending += data
+                while b"\n" in pending:
+                    line, pending = pending.split(b"\n", 1)
+                    await on_output(line.decode(errors="replace").rstrip("\r") + "\r\n")
+        if on_output and pending:
+            await on_output(pending.decode(errors="replace") + "\r\n")
         await proc.wait()
-        return ExecResult(exit_code=proc.returncode or 0, output="".join(chunks))
+        return ExecResult(exit_code=proc.returncode or 0, output=raw.decode(errors="replace"))
 
     async def close(self) -> None:
         await self._docker("rm", "-f", self.name, check=False)


### PR DESCRIPTION
## What

`LocalDockerBackend.run` read a command's stdout by line iteration (`async for raw in proc.stdout`), which uses `StreamReader.readline()`. That caps a single line at 64 KB and raises `Separator is not found, and chunk exceed the limit` on anything longer. A tool that emits one long line, such as nmap's `-oX -` XML or a nuclei JSONL record with a large matched response body, crashed the entire run with `engine error: Separator is not found`.

## Fix

Read fixed 64 KB chunks with `proc.stdout.read(65536)` and split complete lines out of a rolling buffer for the `on_output` stream. No per-line cap, so large tool output flows through cleanly.

## How it came up

Surfaced during live testing of the new structured toolset (#5): the first `nmap_scan` run died on the XML output. With this fix the same run executes healthily and the tools are dispatched normally.

## Test

- `ruff check` clean
- Existing suite unaffected (backend I/O path, not covered by unit tests; CI runs the full suite)