### PR TITLE
feat(findings): operator triage — verify, dismiss, and dedupe (#6)

### DIFF
--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -40,10 +40,12 @@ from redcell_core.schemas import (
     Host,
     Listener,
     LootItem,
+    MergeFindingsInput,
     OpenShellInput,
     ProxyEntry,
     Run,
     Session,
+    SetFindingStatusInput,
     Shell,
     ShellWriteInput,
     StartListenerInput,
@@ -253,6 +255,27 @@ async def get_finding(fid: str, s: AsyncSession = Depends(db)) -> Finding:
 @router.post("/findings/{fid}/verify", response_model=Finding)
 async def verify_finding(fid: str, s: AsyncSession = Depends(db)) -> Finding:
     row = await findings_repo.verify(s, fid)
+    if row is None:
+        raise HTTPException(404, "finding not found")
+    return Finding.model_validate(row)
+
+
+@router.post("/findings/{fid}/status", response_model=Finding)
+async def set_finding_status(fid: str, body: SetFindingStatusInput,
+                             s: AsyncSession = Depends(db)) -> Finding:
+    try:
+        row = await findings_repo.set_status(s, fid, body.status)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    if row is None:
+        raise HTTPException(404, "finding not found")
+    return Finding.model_validate(row)
+
+
+@router.post("/findings/{fid}/merge", response_model=Finding)
+async def merge_findings(fid: str, body: MergeFindingsInput,
+                         s: AsyncSession = Depends(db)) -> Finding:
+    row = await findings_repo.merge(s, fid, body.duplicate_ids)
     if row is None:
         raise HTTPException(404, "finding not found")
     return Finding.model_validate(row)

--- a/apps/web/src/app/panels/FindingsPanel.tsx
+++ b/apps/web/src/app/panels/FindingsPanel.tsx
@@ -1,19 +1,74 @@
+import { useMemo } from 'react';
+import type { Finding, FindingStatus } from '@redcell/api-client';
 import { cn } from '@/lib/cn';
 import { useUI } from '@/store/ui';
-import { useFindings, useVerifyFinding } from '@/features/hooks';
+import { useFindings, useMergeFindings, useSetFindingStatus } from '@/features/hooks';
 import { Button, Empty, SeverityTag, Spinner } from '@/components/ui/primitives';
+
+// Group active findings that likely describe the same issue: same location and
+// either the same title or the same CWE. The first in each group (most recent)
+// is the canonical record; the rest are duplicates the operator can merge in.
+function duplicateGroups(findings: Finding[]) {
+  const active = findings.filter((f) => f.status !== 'dismissed');
+  const parent = new Map<string, string>(active.map((f) => [f.id, f.id]));
+  const find = (x: string): string => {
+    let r = x;
+    while (parent.get(r) !== r) r = parent.get(r)!;
+    while (parent.get(x) !== r) {
+      const next = parent.get(x)!;
+      parent.set(x, r);
+      x = next;
+    }
+    return r;
+  };
+  const union = (a: string, b: string) => parent.set(find(a), find(b));
+  for (let i = 0; i < active.length; i++) {
+    for (let j = i + 1; j < active.length; j++) {
+      const a = active[i]!;
+      const b = active[j]!;
+      const sameLoc = !!a.location && a.location.toLowerCase() === b.location.toLowerCase();
+      if (!sameLoc) continue;
+      const sameTitle = a.title.toLowerCase() === b.title.toLowerCase();
+      const sameCwe = !!a.cwe && a.cwe === b.cwe;
+      if (sameTitle || sameCwe) union(a.id, b.id);
+    }
+  }
+  const byRoot = new Map<string, Finding[]>();
+  for (const f of active) {
+    const r = find(f.id);
+    (byRoot.get(r) ?? byRoot.set(r, []).get(r)!).push(f);
+  }
+  const dupsOf = new Map<string, string[]>();
+  const isDup = new Set<string>();
+  for (const group of byRoot.values()) {
+    if (group.length < 2) continue;
+    const [canonical, ...rest] = group;
+    dupsOf.set(canonical!.id, rest.map((r) => r.id));
+    rest.forEach((r) => isDup.add(r.id));
+  }
+  return { dupsOf, isDup };
+}
 
 export function FindingsPanel() {
   const engId = useUI((s) => s.activeSessionId);
   const selection = useUI((s) => s.selection);
   const select = useUI((s) => s.select);
   const { data, isLoading } = useFindings(engId);
-  const verify = useVerifyFinding();
+  const setStatus = useSetFindingStatus();
+  const merge = useMergeFindings();
+  const busy = setStatus.isPending || merge.isPending;
+
+  const { dupsOf, isDup } = useMemo(() => duplicateGroups(data ?? []), [data]);
 
   if (isLoading) return <div className="grid h-full place-items-center"><Spinner /></div>;
   if (!data || data.length === 0) return <Empty>No findings yet.</Empty>;
 
   const th = 'sticky top-0 z-10 bg-bg2 px-3 py-2 text-left font-mono text-[9.5px] font-bold uppercase tracking-wider text-faint border-b border-border';
+
+  const move = (e: React.MouseEvent, id: string, status: FindingStatus) => {
+    e.stopPropagation();
+    setStatus.mutate({ id, status });
+  };
 
   return (
     <div className="h-full overflow-auto">
@@ -31,37 +86,70 @@ export function FindingsPanel() {
         <tbody>
           {data.map((f) => {
             const active = selection?.type === 'finding' && selection.id === f.id;
+            const dupIds = dupsOf.get(f.id);
+            const dismissed = f.status === 'dismissed';
             return (
               <tr
                 key={f.id}
                 onClick={() => select({ type: 'finding', id: f.id })}
-                className={cn('cursor-pointer border-b border-border hover:bg-panel2', active && 'bg-panel2')}
+                className={cn(
+                  'cursor-pointer border-b border-border hover:bg-panel2',
+                  active && 'bg-panel2',
+                  dismissed && 'opacity-50',
+                )}
               >
                 <td className="px-3 py-2 font-mono text-[11px] text-faint">{f.id}</td>
                 <td className="px-3 py-2"><SeverityTag sev={f.severity} cvss={f.cvss} /></td>
-                <td className="px-3 py-2 text-text">{f.title}</td>
+                <td className={cn('px-3 py-2 text-text', dismissed && 'line-through')}>{f.title}</td>
                 <td className="px-3 py-2 font-mono text-faint">{f.location}</td>
-                <td className="px-3 py-2">
+                <td className="px-3 py-2 whitespace-nowrap">
                   {f.status === 'verified' ? (
                     <span className="font-mono text-[11px] font-bold text-live">✓ verified</span>
+                  ) : dismissed ? (
+                    <span className="font-mono text-[11px] text-faint">dismissed</span>
                   ) : (
                     <span className="font-mono text-[11px] text-faint">{f.status}</span>
                   )}
-                </td>
-                <td className="px-3 py-2 text-right">
-                  {f.status !== 'verified' && (
-                    <Button
-                      variant="subtle"
-                      className="h-6 px-2 text-[11px]"
-                      disabled={verify.isPending}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        verify.mutate(f.id);
-                      }}
-                    >
-                      Verify
-                    </Button>
+                  {isDup.has(f.id) && (
+                    <span className="ml-2 rounded border border-border px-1 font-mono text-[9px] uppercase tracking-wider text-faint">
+                      dup
+                    </span>
                   )}
+                </td>
+                <td className="px-3 py-2 text-right whitespace-nowrap">
+                  <div className="flex justify-end gap-1">
+                    {dupIds && dupIds.length > 0 && (
+                      <Button
+                        variant="subtle"
+                        className="h-6 px-2 text-[11px]"
+                        disabled={busy}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          merge.mutate({ primaryId: f.id, duplicateIds: dupIds });
+                        }}
+                        title="Dismiss the likely duplicates of this finding"
+                      >
+                        Merge {dupIds.length}
+                      </Button>
+                    )}
+                    {f.status !== 'verified' && !dismissed && (
+                      <Button variant="subtle" className="h-6 px-2 text-[11px]" disabled={busy}
+                        onClick={(e) => move(e, f.id, 'verified')}>
+                        Verify
+                      </Button>
+                    )}
+                    {!dismissed ? (
+                      <Button variant="subtle" className="h-6 px-2 text-[11px]" disabled={busy}
+                        onClick={(e) => move(e, f.id, 'dismissed')}>
+                        Dismiss
+                      </Button>
+                    ) : (
+                      <Button variant="subtle" className="h-6 px-2 text-[11px]" disabled={busy}
+                        onClick={(e) => move(e, f.id, 'candidate')}>
+                        Reopen
+                      </Button>
+                    )}
+                  </div>
                 </td>
               </tr>
             );

--- a/apps/web/src/features/hooks.ts
+++ b/apps/web/src/features/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useApi } from '@/lib/api';
-import type { ChatMessage, Settings } from '@redcell/api-client';
+import type { ChatMessage, FindingStatus, Settings } from '@redcell/api-client';
 
 export function useSessions() {
   const api = useApi();
@@ -137,11 +137,22 @@ export function useLoot(sessionId: string | null) {
   });
 }
 
-export function useVerifyFinding() {
+export function useSetFindingStatus() {
   const api = useApi();
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (id: string) => api.findings.verify(id),
+    mutationFn: ({ id, status }: { id: string; status: FindingStatus }) =>
+      api.findings.setStatus(id, status),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['findings'] }),
+  });
+}
+
+export function useMergeFindings() {
+  const api = useApi();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ primaryId, duplicateIds }: { primaryId: string; duplicateIds: string[] }) =>
+      api.findings.merge(primaryId, duplicateIds),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['findings'] }),
   });
 }

--- a/apps/web/src/test/mockClient.test.ts
+++ b/apps/web/src/test/mockClient.test.ts
@@ -45,19 +45,36 @@ describe('runs', () => {
 });
 
 describe('findings', () => {
-  it('marks a finding verified', async () => {
+  async function findWithFindings() {
     const sessions = await client.sessions.list();
-    let target;
     for (const s of sessions) {
       const findings = await client.findings.list(s.id);
-      if (findings.length) {
-        target = findings[0];
-        break;
-      }
+      if (findings.length) return { sessionId: s.id, findings };
     }
-    expect(target, 'expected a fixture finding to verify').toBeTruthy();
-    const verified = await client.findings.verify(target!.id);
+    throw new Error('expected a fixture session with findings');
+  }
+
+  it('marks a finding verified', async () => {
+    const { findings } = await findWithFindings();
+    const verified = await client.findings.verify(findings[0]!.id);
     expect(verified.status).toBe('verified');
+  });
+
+  it('sets an arbitrary triage status', async () => {
+    const { findings } = await findWithFindings();
+    const dismissed = await client.findings.setStatus(findings[0]!.id, 'dismissed');
+    expect(dismissed.status).toBe('dismissed');
+  });
+
+  it('merges duplicates by dismissing them and keeping the primary', async () => {
+    const { sessionId, findings } = await findWithFindings();
+    if (findings.length < 2) return; // fixtures always have several, but stay safe
+    const [primary, dup] = findings;
+    const kept = await client.findings.merge(primary!.id, [dup!.id]);
+    expect(kept.id).toBe(primary!.id);
+    const after = await client.findings.list(sessionId);
+    expect(after.find((f) => f.id === dup!.id)!.status).toBe('dismissed');
+    expect(after.find((f) => f.id === primary!.id)!.status).not.toBe('dismissed');
   });
 });
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -10,6 +10,7 @@ import type {
   DraftChatOutput,
   EventMsg,
   Finding,
+  FindingStatus,
   Host,
   ID,
   Listener,
@@ -114,6 +115,9 @@ export interface ApiClient {
     list(sessionId: string, params?: ListQuery): Promise<Finding[]>;
     get(id: string): Promise<Finding>;
     verify(id: string): Promise<Finding>;
+    setStatus(id: string, status: FindingStatus): Promise<Finding>;
+    /** Fold duplicates into a primary finding: the duplicates are dismissed. */
+    merge(primaryId: string, duplicateIds: string[]): Promise<Finding>;
   };
   shells: {
     list(sessionId: string, params?: ListQuery): Promise<Shell[]>;

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -66,6 +66,8 @@ export function createHttpClient(baseUrl: string, wsUrl: string): ApiClient {
       list: (sessionId, params) => req(`/sessions/${sessionId}/findings${qs(params)}`),
       get: (id) => req(`/findings/${id}`),
       verify: (id) => req(`/findings/${id}/verify`, { method: 'POST' }),
+      setStatus: (id, status) => req(`/findings/${id}/status`, json({ status })),
+      merge: (primaryId, duplicateIds) => req(`/findings/${primaryId}/merge`, json({ duplicateIds })),
     },
     shells: {
       list: (sessionId, params) => req(`/sessions/${sessionId}/shells${qs(params)}`),

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -218,6 +218,24 @@ export function createMockClient(): ApiClient {
         finding.status = 'verified';
         return structuredClone(finding);
       },
+      async setStatus(id, status) {
+        await delay(200);
+        const finding = db.findings.find((f) => f.id === id);
+        if (!finding) throw new Error(`finding ${id} not found`);
+        finding.status = status;
+        return structuredClone(finding);
+      },
+      async merge(primaryId, duplicateIds) {
+        await delay(200);
+        const primary = db.findings.find((f) => f.id === primaryId);
+        if (!primary) throw new Error(`finding ${primaryId} not found`);
+        for (const dupId of duplicateIds) {
+          if (dupId === primaryId) continue;
+          const dup = db.findings.find((f) => f.id === dupId);
+          if (dup && dup.sessionId === primary.sessionId) dup.status = 'dismissed';
+        }
+        return structuredClone(primary);
+      },
     },
 
     shells: {

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -6,7 +6,7 @@ export type ISODate = string;
 export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type RunStatus = 'queued' | 'running' | 'paused' | 'completed' | 'failed' | 'stopped';
 export type AgentStatus = 'running' | 'waiting' | 'done' | 'idle' | 'failed';
-export type FindingStatus = 'candidate' | 'verified' | 'inconclusive';
+export type FindingStatus = 'candidate' | 'verified' | 'dismissed' | 'inconclusive';
 export type ShellKind = 'tool' | 'interactive' | 'reverse';
 export type ShellStatus = 'running' | 'idle' | 'closed';
 

--- a/packages/core/redcell_core/engine/reporting/generate.py
+++ b/packages/core/redcell_core/engine/reporting/generate.py
@@ -33,6 +33,12 @@ def _slug(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", (text or "report").lower()).strip("-")[:50] or "report"
 
 
+def select_report_findings(findings) -> list:
+    """Findings that belong in a client report: dismissed ones (false positives
+    and merged duplicates) are excluded; everything else is kept."""
+    return [f for f in findings if f.status != "dismissed"]
+
+
 def _findings_json(findings) -> list:
     return [{
         "id": f.id, "title": f.title, "severity": f.severity, "cvss": f.cvss, "cwe": f.cwe,
@@ -48,7 +54,7 @@ async def generate_report(report_id: str) -> None:
             if report is None:
                 return
             session = await sessions_repo.get(s, report.session_id)
-            findings = await findings_repo.list_for_session(s, report.session_id)
+            findings = select_report_findings(await findings_repo.list_for_session(s, report.session_id))
             hosts = await hosts_repo.list_for_session(s, report.session_id)
             loot = await loot_repo.list_for_session(s, report.session_id)
             cfg = await settings_repo.get(s)

--- a/packages/core/redcell_core/engine/reporting/pdf.py
+++ b/packages/core/redcell_core/engine/reporting/pdf.py
@@ -60,6 +60,8 @@ def _styles():
                                textColor=INK, spaceAfter=6),
         "small": ParagraphStyle("rc_small", fontName="Helvetica", fontSize=8.5, leading=12,
                                 textColor=MUTED),
+        "verified": ParagraphStyle("rc_verified", fontName="Helvetica-Bold", fontSize=8.5,
+                                   leading=12, textColor=colors.HexColor("#1a7f4b")),
         "meta": ParagraphStyle("rc_meta", fontName="Helvetica", fontSize=9, leading=13, textColor=INK),
         "mono": ParagraphStyle("rc_mono", fontName="Courier", fontSize=8, leading=11, textColor=INK),
         "label": ParagraphStyle("rc_label", fontName="Helvetica-Bold", fontSize=8, leading=11,
@@ -223,12 +225,13 @@ def _findings_index(st, findings) -> Table:
         ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
     ]
     for f in findings:
+        verified = f.status == "verified"
         rows.append([
             _p(f.id.replace("finding-", "")[:8], st["small"]),
             _p(f.title, st["meta"]),
             _Bar(f.severity, SEV.get(f.severity, MUTED), width=22 * mm),
             _p(f"{f.cvss:.1f}" if f.cvss else "-", st["meta"]),
-            _p(f.status, st["small"]),
+            _p("verified" if verified else f.status, st["verified"] if verified else st["small"]),
         ])
     t = Table(rows, colWidths=[16 * mm, None, 26 * mm, 14 * mm, 20 * mm], repeatRows=1)
     t.setStyle(TableStyle(style))

--- a/packages/core/redcell_core/repositories/findings.py
+++ b/packages/core/redcell_core/repositories/findings.py
@@ -6,6 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..models import Finding
 from . import ids
 
+# Triage states an operator can set. "candidate" is the default an agent records
+# under; "verified" is confirmed; "dismissed" is a false positive or duplicate
+# and is excluded from generated reports.
+VALID_STATUSES = ("candidate", "verified", "dismissed", "inconclusive")
+
 
 async def list_for_session(s: AsyncSession, sid: str, *, severity: str | None = None,
                            status: str | None = None, q: str | None = None,
@@ -40,9 +45,35 @@ async def exists(s: AsyncSession, session_id: str, title: str, location: str) ->
     return (await s.scalar(q)) is not None
 
 
-async def verify(s: AsyncSession, fid: str) -> Finding | None:
+async def set_status(s: AsyncSession, fid: str, status: str) -> Finding | None:
+    """Set a finding's triage status. Returns None if the finding is missing.
+    Raises ValueError on an unknown status."""
+    if status not in VALID_STATUSES:
+        raise ValueError(f"invalid status: {status}")
     row = await s.get(Finding, fid)
     if row:
-        row.status = "verified"
+        row.status = status
         await s.flush()
     return row
+
+
+async def verify(s: AsyncSession, fid: str) -> Finding | None:
+    return await set_status(s, fid, "verified")
+
+
+async def merge(s: AsyncSession, primary_id: str, duplicate_ids: list[str]) -> Finding | None:
+    """Fold duplicates into a primary finding by dismissing them. The primary is
+    kept as the canonical record. Only duplicates in the primary's session are
+    touched, and the primary itself is never dismissed. Returns the primary, or
+    None if it is missing."""
+    primary = await s.get(Finding, primary_id)
+    if primary is None:
+        return None
+    for dup_id in duplicate_ids:
+        if dup_id == primary_id:
+            continue
+        dup = await s.get(Finding, dup_id)
+        if dup is not None and dup.session_id == primary.session_id:
+            dup.status = "dismissed"
+    await s.flush()
+    return primary

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -127,6 +127,14 @@ class Finding(Camel):
     created_at: str
 
 
+class SetFindingStatusInput(Camel):
+    status: str
+
+
+class MergeFindingsInput(Camel):
+    duplicate_ids: list[str] = []
+
+
 # ---- shells ----
 class Shell(Camel):
     id: str

--- a/packages/core/tests/test_findings_triage.py
+++ b/packages/core/tests/test_findings_triage.py
@@ -1,0 +1,66 @@
+"""Findings triage: status transitions and duplicate merge (issue #6)."""
+
+import pytest
+from redcell_core.db import session_scope
+from redcell_core.repositories import findings as findings_repo
+from redcell_core.repositories import sessions as sessions_repo
+
+
+async def _session(s, name="T"):
+    return await sessions_repo.create(s, {"name": name, "client": "C", "scope": [], "targets": []})
+
+
+async def _finding(s, sid, **kw):
+    data = {"session_id": sid, "title": "T", "severity": "high", "location": "/a"}
+    data.update(kw)
+    return await findings_repo.create(s, data)
+
+
+@pytest.mark.asyncio
+async def test_set_status_transitions():
+    async with session_scope() as s:
+        sess = await _session(s)
+        f = await _finding(s, sess.id)
+        assert f.status == "candidate"
+        assert (await findings_repo.set_status(s, f.id, "verified")).status == "verified"
+        assert (await findings_repo.set_status(s, f.id, "dismissed")).status == "dismissed"
+        # verify() is a shortcut for set_status(..., "verified")
+        assert (await findings_repo.verify(s, f.id)).status == "verified"
+
+
+@pytest.mark.asyncio
+async def test_set_status_rejects_unknown_status():
+    async with session_scope() as s:
+        sess = await _session(s)
+        f = await _finding(s, sess.id)
+        with pytest.raises(ValueError):
+            await findings_repo.set_status(s, f.id, "bogus")
+
+
+@pytest.mark.asyncio
+async def test_set_status_missing_finding_returns_none():
+    async with session_scope() as s:
+        assert await findings_repo.set_status(s, "RC-nope", "verified") is None
+
+
+@pytest.mark.asyncio
+async def test_merge_dismisses_duplicates_but_keeps_primary_and_other_sessions():
+    async with session_scope() as s:
+        a = await _session(s, "A")
+        b = await _session(s, "B")
+        primary = await _finding(s, a.id, title="XSS", location="/x")
+        dup = await _finding(s, a.id, title="XSS reflected", location="/x")
+        foreign = await _finding(s, b.id, title="XSS", location="/x")
+        result = await findings_repo.merge(s, primary.id, [dup.id, foreign.id, primary.id])
+        assert result.id == primary.id
+        assert (await findings_repo.get(s, dup.id)).status == "dismissed"
+        # a finding in another session is never touched
+        assert (await findings_repo.get(s, foreign.id)).status == "candidate"
+        # the primary stays the canonical record
+        assert (await findings_repo.get(s, primary.id)).status == "candidate"
+
+
+@pytest.mark.asyncio
+async def test_merge_missing_primary_returns_none():
+    async with session_scope() as s:
+        assert await findings_repo.merge(s, "RC-nope", []) is None

--- a/packages/core/tests/test_reporting.py
+++ b/packages/core/tests/test_reporting.py
@@ -3,6 +3,7 @@ exporter, and a smoke test of the PDF builder. All pure, no DB or infra."""
 
 from types import SimpleNamespace
 
+from redcell_core.engine.reporting.generate import select_report_findings
 from redcell_core.engine.reporting.pdf import build_pdf
 from redcell_core.engine.reporting.sarif import build_sarif
 from redcell_core.engine.reporting.text import humanize
@@ -29,6 +30,17 @@ def test_humanize_handles_none_and_empty():
 
 def test_humanize_collapses_runs_of_spaces():
     assert humanize("a    b") == "a b"
+
+
+# ---- report triage filter ----
+
+def test_select_report_findings_excludes_dismissed():
+    findings = [
+        SimpleNamespace(id="a", status="verified"),
+        SimpleNamespace(id="b", status="dismissed"),
+        SimpleNamespace(id="c", status="candidate"),
+    ]
+    assert [f.id for f in select_report_findings(findings)] == ["a", "c"]
 
 
 # ---- SARIF export ----


### PR DESCRIPTION
Closes #6.

Gives the operator a curation workflow over findings before a report ships: mark a finding verified or dismissed, and fold likely duplicates into one canonical record. Reports respect the triage state.

## Backend
- `findings` repo: `set_status()` validates against a known status set; `verify()` now delegates to it; `merge(primary, dupIds)` dismisses duplicates while keeping the primary, and only touches findings in the primary's session.
- API: `POST /findings/{id}/status` and `POST /findings/{id}/merge` alongside the existing `/verify`.
- Reporting: dismissed findings (false positives and merged duplicates) are excluded from generated reports (`select_report_findings`), and verified findings are highlighted in the PDF findings index.
- No DB migration: the `status` column already existed (default `candidate`); this adds the `dismissed` value and the transitions around it.

## Frontend
- `FindingStatus` gains `dismissed`. The api-client interface, HTTP client, mock client, and hooks all learn `setStatus` + `merge`.
- `FindingsPanel`: Verify / Dismiss / Reopen controls, dimmed + struck styling for dismissed rows, and client-side duplicate detection (same location and same title or CWE) that surfaces a `Merge N` action on the canonical row and a `dup` tag on the others.

## Status vocabulary
`candidate` (the default an agent records under) → `verified` or `dismissed`, reversible via Reopen. `inconclusive` stays valid for compatibility.

## Tests
- Backend: repo status transitions + invalid-status rejection + merge scoping; report exclusion filter. 68 backend tests pass.
- Frontend: mock-client `setStatus` and `merge`; typecheck + lint + 39 web tests pass.
- UI verified in mock mode with Playwright: verify/dismiss/reopen transitions and dismissed-row styling all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added finding status controls for verifying, dismissing, reopening, and marking findings inconclusive.
  * Added duplicate detection and merging, preserving the primary finding while dismissing duplicates.
  * Added visual indicators for duplicate and dismissed findings.
* **Reporting**
  * Dismissed findings are excluded from generated reports.
  * Verified findings are highlighted in report indexes.
* **Bug Fixes**
  * Added validation for invalid status updates and clearer handling of missing findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->