### PR TITLE
dist(compose): zero-setup docker compose up (no required .env)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,31 @@
 name: redcell
 
+x-app-env: &app-env
+  REDCELL_RUN_MODE: ${REDCELL_RUN_MODE:-live}
+  REDCELL_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-redcell}:${POSTGRES_PASSWORD:-redcell}@postgres:5432/${POSTGRES_DB:-redcell}
+  REDCELL_REDIS_URL: redis://redis:6379/0
+  REDCELL_S3_ENDPOINT: http://minio:9000
+  REDCELL_S3_PRESIGN_ENDPOINT: ${REDCELL_S3_PRESIGN_ENDPOINT:-http://localhost:9000}
+  REDCELL_S3_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+  REDCELL_S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
+  REDCELL_S3_REGION: ${REDCELL_S3_REGION:-us-east-1}
+  REDCELL_SECRET_KEY: ${REDCELL_SECRET_KEY:-bRaPZZwSP-Bt9ziZ-iGjxLnQM5mlE-iOW2bMCoyUUp4=}
+  REDCELL_JWT_SECRET: ${REDCELL_JWT_SECRET:-dev-insecure-change-me-in-production-0123456789}
+  REDCELL_ADMIN_USERNAME: ${REDCELL_ADMIN_USERNAME:-admin}
+  REDCELL_ADMIN_PASSWORD: ${REDCELL_ADMIN_PASSWORD:-admin}
+  REDCELL_CORS_ORIGINS: ${REDCELL_CORS_ORIGINS:-http://localhost:5183}
+
 services:
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: redcell
-      POSTGRES_PASSWORD: redcell
-      POSTGRES_DB: redcell
+      POSTGRES_USER: ${POSTGRES_USER:-redcell}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-redcell}
+      POSTGRES_DB: ${POSTGRES_DB:-redcell}
     volumes:
       - redcell_pg:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U redcell']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-redcell}']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -27,8 +42,8 @@ services:
     image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     ports:
       - '9000:9000'
       - '9001:9001'
@@ -42,12 +57,7 @@ services:
 
   migrate:
     image: ghcr.io/martian56/redcell-api:latest
-    env_file:
-      - .env
-    environment:
-      REDCELL_DATABASE_URL: postgresql+asyncpg://redcell:redcell@postgres:5432/redcell
-      REDCELL_REDIS_URL: redis://redis:6379/0
-      REDCELL_S3_ENDPOINT: http://minio:9000
+    environment: *app-env
     command: ['sh', '-c', 'rc db upgrade && rc seed']
     restart: 'no'
     depends_on:
@@ -58,13 +68,7 @@ services:
 
   api:
     image: ghcr.io/martian56/redcell-api:latest
-    env_file:
-      - .env
-    environment:
-      REDCELL_DATABASE_URL: postgresql+asyncpg://redcell:redcell@postgres:5432/redcell
-      REDCELL_REDIS_URL: redis://redis:6379/0
-      REDCELL_S3_ENDPOINT: http://minio:9000
-      REDCELL_S3_PRESIGN_ENDPOINT: http://localhost:9000
+    environment: *app-env
     ports:
       - '8080:8080'
     volumes:
@@ -83,13 +87,7 @@ services:
 
   worker:
     image: ghcr.io/martian56/redcell-worker:latest
-    env_file:
-      - .env
-    environment:
-      REDCELL_DATABASE_URL: postgresql+asyncpg://redcell:redcell@postgres:5432/redcell
-      REDCELL_REDIS_URL: redis://redis:6379/0
-      REDCELL_S3_ENDPOINT: http://minio:9000
-      REDCELL_S3_PRESIGN_ENDPOINT: http://localhost:9000
+    environment: *app-env
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     extra_hosts:


### PR DESCRIPTION
`docker compose up` now works on a fresh clone with no setup step.

Before, the compose used `env_file: .env`, which made Compose **require** a `.env` file, so a fresh machine failed until you ran `cp .env.example .env`.

Now the config is inlined in `environment:` via a shared YAML anchor with `${VAR:-default}` interpolation, and `env_file` is dropped. Result:
- `docker compose up -d` runs immediately with sensible local defaults.
- Everything is still overridable by setting env vars or dropping an optional `.env` next to the compose (Compose auto-reads it for interpolation, not required).
- Postgres/MinIO creds and the derived `REDCELL_DATABASE_URL` interpolate from the same variables, so overriding one keeps them consistent.

Validated with `docker compose --env-file /dev/null config` (pure defaults, no .env): resolves cleanly. Defaults are the same local values already in `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application configuration consistency across development services.
  * Added environment-variable overrides for database, storage, authentication, admin, and CORS settings.
  * Enabled configurable PostgreSQL and MinIO credentials.
  * Standardized environment handling for migrations, API, and background worker services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->