### PR TITLE
fix: live-run chat answers, and persistent terminal scrollback

### DIFF
--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -397,20 +397,11 @@ async def chat_send(rid: str, body: ChatSendInput, s: AsyncSession = Depends(db)
     if await steer.is_awaiting(rid):
         # orchestrator asked a question; this message is the answer
         return schema
-    if run.status == "running":
-        # steer the live run; picked up at the next step
-        await steer.push_steer(rid, body.text)
-        ack = await chat_repo.create(s, rid, "assistant", "Got it. Steering the run now.")
-        await s.commit()
-        await bus.publish_json(chat_channel(rid), {"id": ack.id, "runId": rid, "role": "assistant",
-                                                   "text": ack.text, "options": None, "ts": ack.ts})
-        return schema
-    # run inactive; read-only assistant answers
-    asyncio.create_task(_answer_chat(rid, body.text))
+    asyncio.create_task(_answer_chat(rid, body.text, running=(run.status == "running")))
     return schema
 
 
-async def _answer_chat(rid: str, text: str) -> None:
+async def _answer_chat(rid: str, text: str, running: bool) -> None:
     from redcell_core.engine.assistant import answer_run
     try:
         result = await answer_run(rid, text)
@@ -420,11 +411,12 @@ async def _answer_chat(rid: str, text: str) -> None:
             payload = {"id": m.id, "runId": rid, "role": "assistant", "text": reply,
                        "options": None, "ts": m.ts}
         await bus.publish_json(chat_channel(rid), payload)
-        # operator asked for action; hand off to the orchestrator and reopen the run
+        # operator asked for action; hand the instruction to the orchestrator
         if result.get("kind") == "continue":
             await steer.push_steer(rid, result.get("instruction") or text)
-            async with session_scope() as s:
-                await runs_repo.set_status(s, rid, "running")
-            await queue.enqueue("run_engagement", rid)
+            if not running:
+                async with session_scope() as s:
+                    await runs_repo.set_status(s, rid, "running")
+                await queue.enqueue("run_engagement", rid)
     except Exception:
         pass

--- a/apps/api/tests/test_chat_intent.py
+++ b/apps/api/tests/test_chat_intent.py
@@ -1,0 +1,38 @@
+"""Regression: a question sent while a run is live must not get the canned
+"Got it. Steering the run now." steer acknowledgement."""
+
+import asyncio
+
+from fastapi.testclient import TestClient
+from redcell_core import seed
+from redcell_core.db import engine
+
+CANNED = "Got it. Steering the run now."
+
+
+async def _boot():
+    await seed.bootstrap()
+    await engine.dispose()
+
+
+from app.main import app  # noqa: E402
+
+
+def test_live_run_chat_question_is_not_canned_steer():
+    asyncio.run(_boot())
+    with TestClient(app) as c:
+        assert c.post("/api/v1/auth/login",
+                      json={"username": "admin", "password": "admin"}).status_code == 200
+
+        sid = c.post("/api/v1/sessions", json={"name": "ChatIntent", "client": "QA",
+                                               "scope": ["*.t"], "targets": ["https://t"]}).json()["id"]
+        rid = c.post(f"/api/v1/sessions/{sid}/runs",
+                     json={"name": "assess", "model": "kimi-k3"}).json()["id"]
+
+        assert c.post(f"/api/v1/runs/{rid}/resume").json()["status"] == "running"
+
+        r = c.post(f"/api/v1/runs/{rid}/chat", json={"text": "what is the orchestrator doing?"})
+        assert r.status_code == 200 and r.json()["role"] == "operator"
+
+        texts = [m["text"] for m in c.get(f"/api/v1/runs/{rid}/chat").json()]
+        assert CANNED not in texts, f"chat returned the canned steer ack for a question: {texts}"

--- a/apps/api/tests/test_chat_intent.py
+++ b/apps/api/tests/test_chat_intent.py
@@ -2,6 +2,7 @@
 "Got it. Steering the run now." steer acknowledgement."""
 
 import asyncio
+import time
 
 from fastapi.testclient import TestClient
 from redcell_core import seed
@@ -34,5 +35,13 @@ def test_live_run_chat_question_is_not_canned_steer():
         r = c.post(f"/api/v1/runs/{rid}/chat", json={"text": "what is the orchestrator doing?"})
         assert r.status_code == 200 and r.json()["role"] == "operator"
 
-        texts = [m["text"] for m in c.get(f"/api/v1/runs/{rid}/chat").json()]
-        assert CANNED not in texts, f"chat returned the canned steer ack for a question: {texts}"
+        assistant_texts = []
+        for _ in range(40):
+            messages = c.get(f"/api/v1/runs/{rid}/chat").json()
+            assistant_texts = [m["text"] for m in messages if m["role"] == "assistant"]
+            if assistant_texts:
+                break
+            time.sleep(0.05)
+
+        assert assistant_texts, "chat did not produce an assistant reply"
+        assert CANNED not in assistant_texts, f"chat returned the canned steer ack for a question: {assistant_texts}"

--- a/apps/web/src/app/panels/Terminal.tsx
+++ b/apps/web/src/app/panels/Terminal.tsx
@@ -1,85 +1,26 @@
 import { useEffect, useRef } from 'react';
-import { Terminal as XTerm } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { apiClient, apiMode } from '@/lib/api';
+import { acquireTerminal } from '@/lib/terminals';
 
-// xterm.js terminal: streams output from shellIO, sends keystrokes to
-// shells.write. Mock mode has no server echo, so echo locally.
 export function Terminal({ shellId, prompt = 'operator@kali' }: { shellId: string; prompt?: string }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const host = ref.current;
     if (!host) return;
+    const { el, fit } = acquireTerminal(shellId, prompt);
+    host.appendChild(el);
 
-    const term = new XTerm({
-      convertEol: true,
-      cursorBlink: true,
-      fontFamily: 'ui-monospace, "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace',
-      fontSize: 12.5,
-      lineHeight: 1.25,
-      theme: {
-        background: '#000000',
-        foreground: '#c6cdd8',
-        cursor: '#ff3344',
-        cursorAccent: '#000000',
-        selectionBackground: 'rgba(255,51,68,0.30)',
-        black: '#0b0e13',
-        red: '#ff4d5e',
-        green: '#31d0c0',
-        yellow: '#ffcf4a',
-        blue: '#5ab0ff',
-        magenta: '#ff7ad9',
-        cyan: '#5ee0d0',
-        white: '#eef3fa',
-        brightBlack: '#5f7286',
-        brightRed: '#ff6b7a',
-        brightGreen: '#4de0d0',
-        brightYellow: '#ffd76a',
-        brightBlue: '#7ac0ff',
-        brightMagenta: '#ff9ae0',
-        brightCyan: '#7ef0e2',
-        brightWhite: '#ffffff',
-      },
-    });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.open(host);
-    try {
-      fit.fit();
-    } catch {
-      /* container not sized yet */
-    }
-
-    // Server-driven shells send their own prompt; only the mock needs a local one.
-    if (apiMode === 'mock') term.write(`\x1b[38;5;43m${prompt}\x1b[0m:~$ `);
-
-    const ro = new ResizeObserver(() => {
-      try {
-        fit.fit();
-      } catch {
-        /* ignore */
-      }
-    });
+    const refit = () => {
+      if (host.clientWidth > 0 && host.clientHeight > 0) fit.fit();
+    };
+    const raf = requestAnimationFrame(refit);
+    const ro = new ResizeObserver(refit);
     ro.observe(host);
 
-    const unsub = apiClient.shellIO.subscribe(shellId, (chunk) => term.write(chunk));
-
-    const onData = term.onData((data) => {
-      void apiClient.shells.write(shellId, data);
-      // The backend echoes keystrokes back, so a local echo would double them.
-      // Only the mock needs one.
-      if (apiMode !== 'mock') return;
-      if (data === '\r') term.write(`\r\n\x1b[38;5;43m${prompt}\x1b[0m:~$ `);
-      else if (data === '') term.write('\b \b');
-      else term.write(data);
-    });
-
     return () => {
-      onData.dispose();
-      unsub();
+      cancelAnimationFrame(raf);
       ro.disconnect();
-      term.dispose();
+      if (el.parentNode === host) host.removeChild(el);
     };
   }, [shellId, prompt]);
 

--- a/apps/web/src/app/panels/TerminalsPanel.tsx
+++ b/apps/web/src/app/panels/TerminalsPanel.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/cn';
 import { useUI } from '@/store/ui';
 import { useShellList, useOpenShell, useCloseShell } from '@/features/hooks';
 import { useShells } from '@/store/shells';
+import { disposeTerminal, reapTerminals } from '@/lib/terminals';
 import { Terminal } from './Terminal';
 import { Empty, Spinner, StatusDot } from '@/components/ui/primitives';
 import { Icon } from '@/components/ui/Icon';
@@ -31,6 +32,11 @@ export function TerminalsPanel() {
     }
   }, [shells, active, setActive]);
 
+  useEffect(() => {
+    if (!shells) return;
+    reapTerminals(shells.map((s) => s.id));
+  }, [shells]);
+
   const newTerminal = async () => {
     const shell = await openShell.mutateAsync(undefined);
     setActive(shell.id);
@@ -38,6 +44,7 @@ export function TerminalsPanel() {
 
   const closeTab = async (id: string) => {
     await closeShell.mutateAsync(id);
+    disposeTerminal(id);
     if (active === id) setActive(null);
   };
 

--- a/apps/web/src/lib/terminals.ts
+++ b/apps/web/src/lib/terminals.ts
@@ -1,0 +1,97 @@
+import { FitAddon } from '@xterm/addon-fit';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { apiClient, apiMode } from '@/lib/api';
+
+export type TerminalEntry = {
+  el: HTMLDivElement;
+  term: XTerm;
+  fit: FitAddon;
+};
+
+type InternalEntry = TerminalEntry & { teardown: () => void };
+
+const registry = new Map<string, InternalEntry>();
+
+const THEME = {
+  background: '#000000',
+  foreground: '#c6cdd8',
+  cursor: '#ff3344',
+  cursorAccent: '#000000',
+  selectionBackground: 'rgba(255,51,68,0.30)',
+  black: '#0b0e13',
+  red: '#ff4d5e',
+  green: '#31d0c0',
+  yellow: '#ffcf4a',
+  blue: '#5ab0ff',
+  magenta: '#ff7ad9',
+  cyan: '#5ee0d0',
+  white: '#eef3fa',
+  brightBlack: '#5f7286',
+  brightRed: '#ff6b7a',
+  brightGreen: '#4de0d0',
+  brightYellow: '#ffd76a',
+  brightBlue: '#7ac0ff',
+  brightMagenta: '#ff9ae0',
+  brightCyan: '#7ef0e2',
+  brightWhite: '#ffffff',
+};
+
+export function acquireTerminal(shellId: string, prompt: string): TerminalEntry {
+  const existing = registry.get(shellId);
+  if (existing) return existing;
+
+  const el = document.createElement('div');
+  el.className = 'h-full w-full';
+
+  const term = new XTerm({
+    convertEol: true,
+    cursorBlink: true,
+    fontFamily: 'ui-monospace, "JetBrains Mono", Menlo, Consolas, "Liberation Mono", monospace',
+    fontSize: 12.5,
+    lineHeight: 1.25,
+    theme: THEME,
+  });
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+  term.open(el);
+
+  if (apiMode === 'mock') term.write(`\x1b[38;5;43m${prompt}\x1b[0m:~$ `);
+
+  const unsub = apiClient.shellIO.subscribe(shellId, (chunk) => term.write(chunk));
+
+  const onData = term.onData((data) => {
+    void apiClient.shells.write(shellId, data);
+    if (apiMode !== 'mock') return;
+    if (data === '\r') term.write(`\r\n\x1b[38;5;43m${prompt}\x1b[0m:~$ `);
+    else if (data === '\x7f') term.write('\b \b');
+    else term.write(data);
+  });
+
+  const entry: InternalEntry = {
+    el,
+    term,
+    fit,
+    teardown: () => {
+      onData.dispose();
+      unsub();
+      term.dispose();
+      el.remove();
+    },
+  };
+  registry.set(shellId, entry);
+  return entry;
+}
+
+export function disposeTerminal(shellId: string): void {
+  const entry = registry.get(shellId);
+  if (!entry) return;
+  entry.teardown();
+  registry.delete(shellId);
+}
+
+export function reapTerminals(keep: Iterable<string>): void {
+  const alive = new Set(keep);
+  for (const id of [...registry.keys()]) {
+    if (!alive.has(id)) disposeTerminal(id);
+  }
+}


### PR DESCRIPTION
Two independent bugs found while testing a live engagement, one commit each.

## 1. Chat returned a canned steer to every message on a live run
`chat_send` treated any message sent while `run.status == "running"` as a steer directive and replied with a hardcoded `"Got it. Steering the run now."`. The assistant's intent classifier (`answer_run`) only ran for idle runs, so questions like "what is the orchestrator doing?" were never answered mid-run.

Live-run chat now goes through the same classifier as idle chat: a question gets a real answer, an action steers the running orchestrator, and only an idle run is reopened and resumed.

Covered by a new regression test (`apps/api/tests/test_chat_intent.py`) that asks a question on a live run and asserts the canned ack is not returned.

## 2. Terminal scrollback vanished on tab switch and panel moves
Shell output is a live-only stream with no server-side history, so a terminal's scrollback lived only inside its xterm instance. `TerminalsPanel` mounts only the active terminal, so switching tabs or swapping/closing/dragging the panel unmounted the component, disposed the xterm, and the terminal came back empty.

Each shell's xterm and its output subscription now live in a module-level registry outside React (`apps/web/src/lib/terminals.ts`). The component attaches the persistent element while mounted and detaches on unmount without disposing; terminals are torn down only when their shell is actually closed or gone.

## Verification
- `apps/api/tests/test_chat_intent.py` passes; existing API smoke test still passes.
- Web `tsc` typecheck clean, eslint clean, all 39 web unit tests pass.
- The terminal fix is a UI lifecycle change; browser-confirm by opening two terminals, switching tabs, and swapping the panel, then checking the scrollback persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat questions sent during an active run now receive a direct response instead of a canned steering acknowledgement.
  * Terminal sessions preserve their state more reliably across the web interface.

* **Bug Fixes**
  * Improved terminal cleanup when closing tabs or changing available shells.
  * Prevented stale terminal sessions and resources from accumulating during extended use.
  * Improved terminal resizing and behavior in environments with limited display space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->