### PR TITLE
feat: operator context to the orchestrator + cancellable execution

### DIFF
--- a/apps/api/app/routers/ai.py
+++ b/apps/api/app/routers/ai.py
@@ -21,8 +21,11 @@ _SYSTEM = (
     "assessment. Ask focused questions about the target, the in-scope domains/IPs, and the "
     "rules of engagement. Keep replies short and practical. As soon as you have a reasonable "
     "picture, call propose_session with your best draft (the operator can edit it). Refine the "
-    "proposal as the conversation continues. Only in-scope, authorized targets. "
-    "Write in plain text; do not use em-dashes (use commas, periods, or parentheses instead)."
+    "proposal as the conversation continues. Include a short brief: a few sentences capturing the "
+    "objectives, constraints, and any specifics the operator gave (target type, what to focus on, "
+    "what to skip). The brief is handed to the agents that run the engagement. Only in-scope, "
+    "authorized targets. Write in plain text; do not use em-dashes (use commas, periods, or "
+    "parentheses instead)."
 )
 
 _PROPOSE_TOOL = [{
@@ -37,6 +40,7 @@ _PROPOSE_TOOL = [{
                 "client": {"type": "string", "description": "Client / org name."},
                 "scope": {"type": "array", "items": {"type": "string"}, "description": "In-scope domains, wildcards, or CIDRs."},
                 "targets": {"type": "array", "items": {"type": "string"}, "description": "Concrete target URLs or IPs."},
+                "brief": {"type": "string", "description": "A few sentences: objectives, constraints, and specifics for the agents running the engagement."},
             },
         },
     },
@@ -82,6 +86,7 @@ async def draft_chat(body: DraftChatInput, s: AsyncSession = Depends(db)) -> Dra
             proposal = SessionProposal(
                 name=args.get("name"), client=args.get("client"),
                 scope=args.get("scope") or [], targets=args.get("targets") or [],
+                brief=args.get("brief"),
             )
     if proposal and not reply:
         reply = "I've drafted the session on the right. Review and adjust, or tell me what to change."

--- a/apps/api/app/routers/files.py
+++ b/apps/api/app/routers/files.py
@@ -9,7 +9,7 @@ from redcell_core.repositories import files as files_repo
 from redcell_core.repositories import ids
 from redcell_core.schemas import FileMeta
 from redcell_core.security import current_user
-from redcell_core.storage import storage
+from redcell_core.storage import safe_filename, storage
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import db
@@ -20,6 +20,8 @@ router = APIRouter(tags=["files"], dependencies=[Depends(current_user)])
 @router.post("/sessions/{sid}/files", response_model=FileMeta)
 async def upload(sid: str, file: UploadFile, kind: str = Form("upload"),
                  s: AsyncSession = Depends(db)) -> FileMeta:
+    if not safe_filename(file.filename):
+        raise HTTPException(400, "invalid filename")
     data = await file.read()
     key = f"{sid}/{ids.new_id('f')}/{file.filename}"
     content_type = file.content_type or "application/octet-stream"

--- a/apps/api/app/routers/files.py
+++ b/apps/api/app/routers/files.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse
 from redcell_core.config import settings
 from redcell_core.repositories import files as files_repo
@@ -18,14 +18,15 @@ router = APIRouter(tags=["files"], dependencies=[Depends(current_user)])
 
 
 @router.post("/sessions/{sid}/files", response_model=FileMeta)
-async def upload(sid: str, file: UploadFile, s: AsyncSession = Depends(db)) -> FileMeta:
+async def upload(sid: str, file: UploadFile, kind: str = Form("upload"),
+                 s: AsyncSession = Depends(db)) -> FileMeta:
     data = await file.read()
     key = f"{sid}/{ids.new_id('f')}/{file.filename}"
     content_type = file.content_type or "application/octet-stream"
     await storage.put(settings.bucket_uploads, key, data, content_type)
     row = await files_repo.create(s, {
         "session_id": sid, "bucket": settings.bucket_uploads, "object_key": key,
-        "filename": file.filename, "kind": "upload", "content_type": content_type,
+        "filename": file.filename, "kind": kind or "upload", "content_type": content_type,
         "size": len(data), "visibility": "private", "source": "operator",
     })
     return FileMeta.model_validate(row)

--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -102,8 +102,8 @@ async def get_session(sid: str, s: AsyncSession = Depends(db)) -> Session:
 async def create_session(body: CreateSessionInput, s: AsyncSession = Depends(db)) -> Session:
     row = await sessions_repo.create(s, {
         "name": body.name, "client": body.client, "kind": body.kind, "source": body.source,
-        "scope": body.scope, "targets": body.targets, "roe": body.roe, "status": "active",
-        "server_id": body.server_id, "proxy_id": body.proxy_id,
+        "scope": body.scope, "targets": body.targets, "roe": body.roe, "brief": body.brief,
+        "status": "active", "server_id": body.server_id, "proxy_id": body.proxy_id,
         "provider": body.provider, "model": body.model,
     })
     return await _session_schema(s, row)
@@ -128,7 +128,7 @@ async def create_run(sid: str, body: CreateRunInput, s: AsyncSession = Depends(d
     await _get_session(s, sid)
     run = await runs_repo.create(s, {"session_id": sid, "name": body.name, "status": "queued",
                                      "phase": "Reconnaissance", "model": body.model,
-                                     "provider": body.provider})
+                                     "provider": body.provider, "instruction": body.instruction})
     await sessions_repo.set_active_run(s, sid, run.id)
     await agents_repo.add(s, {"run_id": run.id, "name": "orchestrator", "role": "root",
                              "status": "running", "action": body.instruction or "planning the engagement",
@@ -414,7 +414,9 @@ async def _answer_chat(rid: str, text: str, running: bool) -> None:
         # operator asked for action; hand the instruction to the orchestrator
         if result.get("kind") == "continue":
             await steer.push_steer(rid, result.get("instruction") or text)
-            if not running:
+            if running:
+                await bus.publish_json(control_channel(rid), {"action": "interrupt"})
+            else:
                 async with session_scope() as s:
                     await runs_repo.set_status(s, rid, "running")
                 await queue.enqueue("run_engagement", rid)

--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -386,7 +386,7 @@ async def run_events(rid: str, s: AsyncSession = Depends(db), p: ListParams = De
 
 @router.post("/runs/{rid}/chat", response_model=ChatMessage)
 async def chat_send(rid: str, body: ChatSendInput, s: AsyncSession = Depends(db)) -> ChatMessage:
-    run = await _get_run(s, rid)
+    await _get_run(s, rid)
     msg = await chat_repo.create(s, rid, "operator", body.text)
     schema = ChatMessage.model_validate(msg)
     await s.commit()
@@ -397,11 +397,11 @@ async def chat_send(rid: str, body: ChatSendInput, s: AsyncSession = Depends(db)
     if await steer.is_awaiting(rid):
         # orchestrator asked a question; this message is the answer
         return schema
-    asyncio.create_task(_answer_chat(rid, body.text, running=(run.status == "running")))
+    asyncio.create_task(_answer_chat(rid, body.text))
     return schema
 
 
-async def _answer_chat(rid: str, text: str, running: bool) -> None:
+async def _answer_chat(rid: str, text: str) -> None:
     from redcell_core.engine.assistant import answer_run
     try:
         result = await answer_run(rid, text)
@@ -414,11 +414,11 @@ async def _answer_chat(rid: str, text: str, running: bool) -> None:
         # operator asked for action; hand the instruction to the orchestrator
         if result.get("kind") == "continue":
             await steer.push_steer(rid, result.get("instruction") or text)
-            if running:
-                await bus.publish_json(control_channel(rid), {"action": "interrupt"})
-            else:
-                async with session_scope() as s:
-                    await runs_repo.set_status(s, rid, "running")
+            async with session_scope() as s:
+                transitioned = await runs_repo.start_if_not_running(s, rid)
+            if transitioned:
                 await queue.enqueue("run_engagement", rid)
+            else:
+                await bus.publish_json(control_channel(rid), {"action": "interrupt"})
     except Exception:
         pass

--- a/apps/api/tests/test_context_roundtrip.py
+++ b/apps/api/tests/test_context_roundtrip.py
@@ -1,0 +1,45 @@
+"""Session brief, run instruction, and assessment files persist and read back."""
+
+import asyncio
+
+from fastapi.testclient import TestClient
+from redcell_core import seed
+from redcell_core.db import engine
+
+
+async def _boot():
+    await seed.bootstrap()
+    await engine.dispose()
+
+
+from app.main import app  # noqa: E402
+
+
+def test_brief_instruction_and_assessment_file_roundtrip():
+    asyncio.run(_boot())
+    with TestClient(app) as c:
+        assert c.post("/api/v1/auth/login",
+                      json={"username": "admin", "password": "admin"}).status_code == 200
+
+        r = c.post("/api/v1/sessions", json={
+            "name": "Ctx", "client": "QA", "scope": ["*.t"], "targets": ["https://t"],
+            "roe": "no dos", "brief": "CTF: prompt injection, find the flag, skip recon",
+        })
+        assert r.status_code == 200
+        sid = r.json()["id"]
+        assert r.json()["brief"] == "CTF: prompt injection, find the flag, skip recon"
+        assert c.get(f"/api/v1/sessions/{sid}").json()["brief"].startswith("CTF:")
+
+        r = c.post(f"/api/v1/sessions/{sid}/runs",
+                   json={"name": "assess", "model": "kimi-k3", "instruction": "this run: try IDOR"})
+        assert r.status_code == 200
+        rid = r.json()["id"]
+        assert r.json()["instruction"] == "this run: try IDOR"
+        assert c.get(f"/api/v1/runs/{rid}").json()["instruction"] == "this run: try IDOR"
+
+        r = c.post(f"/api/v1/sessions/{sid}/files",
+                   files={"file": ("challenge.bin", b"\x7fELFbinary", "application/octet-stream")},
+                   data={"kind": "assessment"})
+        assert r.status_code == 200 and r.json()["kind"] == "assessment"
+        files = c.get(f"/api/v1/sessions/{sid}/files").json()
+        assert any(f["filename"] == "challenge.bin" and f["kind"] == "assessment" for f in files)

--- a/apps/api/tests/test_context_roundtrip.py
+++ b/apps/api/tests/test_context_roundtrip.py
@@ -43,3 +43,8 @@ def test_brief_instruction_and_assessment_file_roundtrip():
         assert r.status_code == 200 and r.json()["kind"] == "assessment"
         files = c.get(f"/api/v1/sessions/{sid}/files").json()
         assert any(f["filename"] == "challenge.bin" and f["kind"] == "assessment" for f in files)
+
+        bad = c.post(f"/api/v1/sessions/{sid}/files",
+                     files={"file": ("../../evil.sh", b"x", "text/plain")},
+                     data={"kind": "assessment"})
+        assert bad.status_code == 400

--- a/apps/web/src/app/pages/NewSessionPage.tsx
+++ b/apps/web/src/app/pages/NewSessionPage.tsx
@@ -21,12 +21,15 @@ type Draft = {
   targets: string[];
   scope: string[];
   roe: string;
+  brief: string;
   source: string;
   serverId: string;
   proxyId: string;
   provider: string;
   model: string;
 };
+
+const apiBase = (import.meta.env.VITE_API_BASE_URL ?? '/api/v1') as string;
 
 function dedupe(a: string[]): string[] {
   return [...new Set(a)];
@@ -135,12 +138,14 @@ export function NewSessionPage() {
     targets: [],
     scope: [],
     roe: '',
+    brief: '',
     source: '',
     serverId: '',
     proxyId: '',
     provider: '',
     model: '',
   });
+  const [files, setFiles] = useState<File[]>([]);
   const [messages, setMessages] = useState<Msg[]>([
     mkMsg(
       'assistant',
@@ -198,6 +203,7 @@ export function NewSessionPage() {
           client: p.client ?? d.client,
           scope: p.scope && p.scope.length ? dedupe(p.scope) : d.scope,
           targets: p.targets && p.targets.length ? dedupe(p.targets) : d.targets,
+          brief: p.brief ?? d.brief,
         }));
       }
     } catch {
@@ -226,11 +232,26 @@ export function NewSessionPage() {
       targets: isCode ? [] : draft.targets,
       scope: isCode ? [] : draft.scope,
       roe: draft.roe.trim() || undefined,
+      brief: draft.brief.trim() || undefined,
       serverId: draft.serverId || undefined,
       proxyId: draft.proxyId || undefined,
       provider: provider || undefined,
       model: model || undefined,
     });
+    for (const f of files) {
+      const fd = new FormData();
+      fd.append('file', f);
+      fd.append('kind', 'assessment');
+      try {
+        await fetch(`${apiBase}/sessions/${created.id}/files`, {
+          method: 'POST',
+          body: fd,
+          credentials: 'include',
+        });
+      } catch {
+        toast(`Could not upload ${f.name}`, 'error');
+      }
+    }
     toast('Session created', 'success');
     nav(`/sessions/${created.id}`);
   };
@@ -377,6 +398,49 @@ export function NewSessionPage() {
                 placeholder="Testing window, no-DoS, exclusions..."
                 className="w-full rounded-[var(--radius)] border border-border2 bg-black px-3 py-2 text-[13px] text-text outline-none placeholder:text-faint focus:border-accent"
               />
+            </Field>
+
+            <Field label="Engagement brief" hint="Objectives and constraints handed to the agents. Drafted from the chat; edit freely.">
+              <textarea
+                value={draft.brief}
+                onChange={(e) => patch({ brief: e.target.value })}
+                rows={4}
+                placeholder="What to focus on, what to skip, the objective..."
+                className="w-full rounded-[var(--radius)] border border-border2 bg-black px-3 py-2 text-[13px] text-text outline-none placeholder:text-faint focus:border-accent"
+              />
+            </Field>
+
+            <Field label="Assessment files" hint="Files the agents work on (a binary, a pcap). Staged in the container at /root/assessment.">
+              <div className="grid gap-1.5">
+                {files.map((f, i) => (
+                  <div
+                    key={`${f.name}-${i}`}
+                    className="flex items-center justify-between rounded-[var(--radius)] border border-border2 bg-black px-2.5 py-1.5 font-mono text-[11px] text-text"
+                  >
+                    <span className="truncate">{f.name}</span>
+                    <button
+                      onClick={() => setFiles((xs) => xs.filter((_, j) => j !== i))}
+                      className="flex-none text-faint hover:text-crit"
+                    >
+                      <Icon name="close" size={12} />
+                    </button>
+                  </div>
+                ))}
+                <label className="flex cursor-pointer items-center justify-center gap-1.5 rounded-[var(--radius)] border border-dashed border-border2 px-2.5 py-2 text-[12px] text-muted hover:border-accent hover:text-text">
+                  <Icon name="plus" size={13} />
+                  Add files
+                  <input
+                    type="file"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => {
+                      const picked = Array.from(e.target.files ?? []);
+                      if (picked.length) setFiles((xs) => [...xs, ...picked]);
+                      e.target.value = '';
+                    }}
+                  />
+                </label>
+              </div>
             </Field>
           </div>
         </div>

--- a/apps/web/src/app/pages/NewSessionPage.tsx
+++ b/apps/web/src/app/pages/NewSessionPage.tsx
@@ -243,11 +243,12 @@ export function NewSessionPage() {
       fd.append('file', f);
       fd.append('kind', 'assessment');
       try {
-        await fetch(`${apiBase}/sessions/${created.id}/files`, {
+        const res = await fetch(`${apiBase}/sessions/${created.id}/files`, {
           method: 'POST',
           body: fd,
           credentials: 'include',
         });
+        if (!res.ok) throw new Error(`upload failed: ${res.status}`);
       } catch {
         toast(`Could not upload ${f.name}`, 'error');
       }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -45,6 +45,7 @@ export interface CreateSessionInput {
   scope: string[];
   targets: string[];
   roe?: string;
+  brief?: string;
   serverId?: ID;
   proxyId?: ID;
   provider?: string;

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -32,6 +32,7 @@ export interface Session {
   status: 'active' | 'archived';
   /** Rules of engagement. */
   roe?: string;
+  brief?: string;
   createdAt: ISODate;
   activeRunId?: ID;
   /** Saved server where runs execute (undefined = local). */
@@ -50,6 +51,7 @@ export interface Run {
   id: ID;
   sessionId: ID;
   name: string;
+  instruction?: string;
   status: RunStatus;
   phase: string;
   startedAt: ISODate;
@@ -225,6 +227,7 @@ export interface SessionProposal {
   client?: string;
   scope: string[];
   targets: string[];
+  brief?: string;
 }
 
 export interface DraftChatInput {

--- a/packages/core/redcell_core/alembic/versions/b7c8d9e0f1a2_session_brief_run_instruction.py
+++ b/packages/core/redcell_core/alembic/versions/b7c8d9e0f1a2_session_brief_run_instruction.py
@@ -1,0 +1,28 @@
+"""session brief + run instruction
+
+Adds a distilled engagement brief on sessions and a per-run instruction on runs,
+both fed to the orchestrator as operator context.
+
+Revision ID: b7c8d9e0f1a2
+Revises: a5b6c7d8e9f0
+Create Date: 2026-08-17
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, None] = "a5b6c7d8e9f0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("sessions", sa.Column("brief", sa.Text(), nullable=True))
+    op.add_column("runs", sa.Column("instruction", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "instruction")
+    op.drop_column("sessions", "brief")

--- a/packages/core/redcell_core/engine/execution.py
+++ b/packages/core/redcell_core/engine/execution.py
@@ -36,6 +36,17 @@ def _write_bytes(fd: int, data: bytes) -> None:
         f.write(data)
 
 
+def _kill_script(tag: str, setsid: bool) -> str:
+    f = f"/tmp/rc-{tag}.pg"
+    if setsid:
+        return (f'pg=$(cat {f} 2>/dev/null); [ -n "$pg" ] && '
+                f'{{ kill -TERM -"$pg" 2>/dev/null; sleep 0.2; kill -KILL -"$pg" 2>/dev/null; }}; '
+                f'rm -f {f}; true')
+    return (f'pg=$(cat {f} 2>/dev/null); [ -n "$pg" ] && '
+            f'{{ pkill -TERM -P "$pg" 2>/dev/null; kill -TERM "$pg" 2>/dev/null; sleep 0.2; '
+            f'pkill -KILL -P "$pg" 2>/dev/null; kill -KILL "$pg" 2>/dev/null; }}; rm -f {f}; true')
+
+
 class ExecutionBackend:
     kind = "base"
 
@@ -139,13 +150,10 @@ class LocalDockerBackend(ExecutionBackend):
         for k, v in self.proxy_env.items():
             env_args += ["-e", f"{k}={v}"]
         tag = _job_tag()
+        wrapped = f"echo $$ > /tmp/rc-{tag}.pg; {command}"
         if self._setsid:
-            # New session/process group whose leader pid ($$) we record, so a cancel
-            # can kill the whole tree (the command and its children), not just the client.
-            wrapped = f"echo $$ > /tmp/rc-{tag}.pg; {command}"
             proc_args = ["exec", *env_args, self.name, "setsid", "-w", "sh", "-c", wrapped]
         else:
-            wrapped = f": RC_JOB_{tag}; {command}"
             proc_args = ["exec", *env_args, self.name, "sh", "-c", wrapped]
         proc = await asyncio.create_subprocess_exec(
             "docker", *proc_args,
@@ -185,7 +193,7 @@ class LocalDockerBackend(ExecutionBackend):
         fd, tmp = tempfile.mkstemp(prefix="rc-stage-")
         try:
             await asyncio.to_thread(_write_bytes, fd, data)
-            await self._docker("cp", tmp, f"{self.name}:{path}", check=False)
+            await self._docker("cp", tmp, f"{self.name}:{path}", check=True)
         finally:
             try:
                 os.unlink(tmp)
@@ -193,13 +201,7 @@ class LocalDockerBackend(ExecutionBackend):
                 pass
 
     async def _kill_job(self, tag: str) -> None:
-        if self._setsid:
-            script = (f'pg=$(cat /tmp/rc-{tag}.pg 2>/dev/null); '
-                      f'[ -n "$pg" ] && {{ kill -TERM -"$pg" 2>/dev/null; sleep 0.2; '
-                      f'kill -KILL -"$pg" 2>/dev/null; }}; rm -f /tmp/rc-{tag}.pg; true')
-        else:
-            script = (f"pkill -TERM -f 'RC_JOB_{tag}' 2>/dev/null; sleep 0.2; "
-                      f"pkill -KILL -f 'RC_JOB_{tag}' 2>/dev/null; true")
+        script = _kill_script(tag, bool(self._setsid))
         try:
             proc = await asyncio.create_subprocess_exec(
                 "docker", "exec", self.name, "sh", "-c", script,
@@ -291,12 +293,11 @@ class SSHBackend(ExecutionBackend):
         directory = path.rsplit("/", 1)[0] or "/"
         inner = f"mkdir -p {_shq(directory)}; cat > {_shq(path)}"
         proc = await self._conn.create_process(f"sh -c {_shq(inner)}", encoding=None)
-        try:
-            proc.stdin.write(data)
-            proc.stdin.write_eof()
-            await proc.wait()
-        except Exception:
-            pass
+        proc.stdin.write(data)
+        proc.stdin.write_eof()
+        result = await proc.wait()
+        if result.exit_status not in (0, None):
+            raise RuntimeError(f"stage_file failed ({result.exit_status})")
 
     async def close(self) -> None:
         if self._conn is not None:
@@ -435,11 +436,10 @@ class RemoteDockerBackend(ExecutionBackend):
             self._setsid = (await self._sh(f"docker exec {self.name} sh -c 'setsid -w true'"))[0] == 0
         envs = "".join(f"-e {_shq(f'{k}={v}')} " for k, v in self.proxy_env.items())
         tag = _job_tag()
+        inner = f"echo $$ > /tmp/rc-{tag}.pg; {command}"
         if self._setsid:
-            inner = f"echo $$ > /tmp/rc-{tag}.pg; {command}"
             full = f"docker exec {envs}{self.name} setsid -w sh -c {_shq(inner)}"
         else:
-            inner = f": RC_JOB_{tag}; {command}"
             full = f"docker exec {envs}{self.name} sh -c {_shq(inner)}"
         proc = await conn.create_process(full, stderr=asyncssh.STDOUT)
         chunks: list[str] = []
@@ -459,12 +459,7 @@ class RemoteDockerBackend(ExecutionBackend):
             raise
 
     async def _kill_job(self, tag: str) -> None:
-        if self._setsid:
-            script = (f'pg=$(cat /tmp/rc-{tag}.pg 2>/dev/null); '
-                      f'[ -n "$pg" ] && {{ kill -TERM -"$pg" 2>/dev/null; sleep 0.2; '
-                      f'kill -KILL -"$pg" 2>/dev/null; }}; rm -f /tmp/rc-{tag}.pg; true')
-        else:
-            script = (f"pkill -TERM -f 'RC_JOB_{tag}'; sleep 0.2; pkill -KILL -f 'RC_JOB_{tag}'; true")
+        script = _kill_script(tag, bool(self._setsid))
         try:
             await self._sh(f"docker exec {self.name} sh -c {_shq(script)}")
         except Exception:
@@ -476,12 +471,11 @@ class RemoteDockerBackend(ExecutionBackend):
         inner = f"mkdir -p {_shq(directory)}; cat > {_shq(path)}"
         full = f"docker exec -i {self.name} sh -c {_shq(inner)}"
         proc = await conn.create_process(full, encoding=None)
-        try:
-            proc.stdin.write(data)
-            proc.stdin.write_eof()
-            await proc.wait()
-        except Exception:
-            pass
+        proc.stdin.write(data)
+        proc.stdin.write_eof()
+        result = await proc.wait()
+        if result.exit_status not in (0, None):
+            raise RuntimeError(f"stage_file failed on remote ({result.exit_status})")
 
     async def close(self) -> None:
         # Leave the container running on the remote (caught shells / artifacts

--- a/packages/core/redcell_core/engine/execution.py
+++ b/packages/core/redcell_core/engine/execution.py
@@ -9,6 +9,9 @@ Backends stream output line by line through an async callback."""
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
+import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -24,6 +27,15 @@ class ExecResult:
     output: str
 
 
+def _job_tag() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def _write_bytes(fd: int, data: bytes) -> None:
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+
+
 class ExecutionBackend:
     kind = "base"
 
@@ -32,6 +44,10 @@ class ExecutionBackend:
 
     async def run(self, command: str, on_output: OnOutput | None = None) -> ExecResult:
         raise NotImplementedError
+
+    async def stage_file(self, path: str, data: bytes) -> None:
+        """Place a file inside the execution environment. No-op by default."""
+        return None
 
     async def close(self) -> None:
         return None
@@ -67,6 +83,7 @@ class LocalDockerBackend(ExecutionBackend):
         self.name = name
         self.proxy_env = proxy_env or {}
         self.mounts = mounts or []  # entries like "/host/path:/src:ro"
+        self._setsid: bool | None = None  # probed once: can we group-kill via setsid?
 
     async def start(self, on_status: OnOutput | None = None) -> None:
         await self._docker("rm", "-f", self.name, check=False)
@@ -116,11 +133,22 @@ class LocalDockerBackend(ExecutionBackend):
             raise RuntimeError(f"docker pull {self.image} failed: {lines[-1] if lines else 'unknown error'}")
 
     async def run(self, command: str, on_output: OnOutput | None = None) -> ExecResult:
+        if self._setsid is None:
+            self._setsid = await self._check("setsid -w true")
         env_args: list[str] = []
         for k, v in self.proxy_env.items():
             env_args += ["-e", f"{k}={v}"]
+        tag = _job_tag()
+        if self._setsid:
+            # New session/process group whose leader pid ($$) we record, so a cancel
+            # can kill the whole tree (the command and its children), not just the client.
+            wrapped = f"echo $$ > /tmp/rc-{tag}.pg; {command}"
+            proc_args = ["exec", *env_args, self.name, "setsid", "-w", "sh", "-c", wrapped]
+        else:
+            wrapped = f": RC_JOB_{tag}; {command}"
+            proc_args = ["exec", *env_args, self.name, "sh", "-c", wrapped]
         proc = await asyncio.create_subprocess_exec(
-            "docker", "exec", *env_args, self.name, "sh", "-c", command,
+            "docker", *proc_args,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
         )
         # Read in fixed chunks, not line-iteration: readline() caps a single line at
@@ -128,20 +156,67 @@ class LocalDockerBackend(ExecutionBackend):
         assert proc.stdout is not None
         raw = bytearray()
         pending = b""
-        while True:
-            data = await proc.stdout.read(65536)
-            if not data:
-                break
-            raw += data
-            if on_output:
-                pending += data
-                while b"\n" in pending:
-                    line, pending = pending.split(b"\n", 1)
-                    await on_output(line.decode(errors="replace").rstrip("\r") + "\r\n")
-        if on_output and pending:
-            await on_output(pending.decode(errors="replace") + "\r\n")
-        await proc.wait()
-        return ExecResult(exit_code=proc.returncode or 0, output=raw.decode(errors="replace"))
+        try:
+            while True:
+                data = await proc.stdout.read(65536)
+                if not data:
+                    break
+                raw += data
+                if on_output:
+                    pending += data
+                    while b"\n" in pending:
+                        line, pending = pending.split(b"\n", 1)
+                        await on_output(line.decode(errors="replace").rstrip("\r") + "\r\n")
+            if on_output and pending:
+                await on_output(pending.decode(errors="replace") + "\r\n")
+            await proc.wait()
+            return ExecResult(exit_code=proc.returncode or 0, output=raw.decode(errors="replace"))
+        except asyncio.CancelledError:
+            await self._kill_job(tag)
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            raise
+
+    async def stage_file(self, path: str, data: bytes) -> None:
+        directory = path.rsplit("/", 1)[0] or "/"
+        await self._docker("exec", self.name, "mkdir", "-p", directory, check=False)
+        fd, tmp = tempfile.mkstemp(prefix="rc-stage-")
+        try:
+            await asyncio.to_thread(_write_bytes, fd, data)
+            await self._docker("cp", tmp, f"{self.name}:{path}", check=False)
+        finally:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+    async def _kill_job(self, tag: str) -> None:
+        if self._setsid:
+            script = (f'pg=$(cat /tmp/rc-{tag}.pg 2>/dev/null); '
+                      f'[ -n "$pg" ] && {{ kill -TERM -"$pg" 2>/dev/null; sleep 0.2; '
+                      f'kill -KILL -"$pg" 2>/dev/null; }}; rm -f /tmp/rc-{tag}.pg; true')
+        else:
+            script = (f"pkill -TERM -f 'RC_JOB_{tag}' 2>/dev/null; sleep 0.2; "
+                      f"pkill -KILL -f 'RC_JOB_{tag}' 2>/dev/null; true")
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "exec", self.name, "sh", "-c", script,
+                stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+            await proc.wait()
+        except Exception:
+            pass
+
+    async def _check(self, script: str) -> bool:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "exec", self.name, "sh", "-c", script,
+                stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+            await proc.wait()
+            return proc.returncode == 0
+        except Exception:
+            return False
 
     async def close(self) -> None:
         await self._docker("rm", "-f", self.name, check=False)
@@ -195,12 +270,33 @@ class SSHBackend(ExecutionBackend):
         # handle is invalid" on Windows and breaks every SSH command.
         proc = await self._conn.create_process(self._wrap(command), stderr=asyncssh.STDOUT)
         chunks: list[str] = []
-        async for line in proc.stdout:
-            chunks.append(line)
-            if on_output:
-                await on_output(line.rstrip("\n") + "\r\n")
-        result = await proc.wait()
-        return ExecResult(exit_code=result.exit_status or 0, output="".join(chunks))
+        try:
+            async for line in proc.stdout:
+                chunks.append(line)
+                if on_output:
+                    await on_output(line.rstrip("\n") + "\r\n")
+            result = await proc.wait()
+            return ExecResult(exit_code=result.exit_status or 0, output="".join(chunks))
+        except asyncio.CancelledError:
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            raise
+
+    async def stage_file(self, path: str, data: bytes) -> None:
+        if self._conn is None:
+            await self.start()
+        assert self._conn is not None
+        directory = path.rsplit("/", 1)[0] or "/"
+        inner = f"mkdir -p {_shq(directory)}; cat > {_shq(path)}"
+        proc = await self._conn.create_process(f"sh -c {_shq(inner)}", encoding=None)
+        try:
+            proc.stdin.write(data)
+            proc.stdin.write_eof()
+            await proc.wait()
+        except Exception:
+            pass
 
     async def close(self) -> None:
         if self._conn is not None:
@@ -228,6 +324,7 @@ class RemoteDockerBackend(ExecutionBackend):
         self.proxy_env = proxy_env or {}
         self.mounts = mounts or []
         self._conn = None
+        self._setsid: bool | None = None
 
     async def connection(self):
         if self._conn is None:
@@ -334,16 +431,57 @@ class RemoteDockerBackend(ExecutionBackend):
         import asyncssh
 
         conn = await self.connection()
+        if self._setsid is None:
+            self._setsid = (await self._sh(f"docker exec {self.name} sh -c 'setsid -w true'"))[0] == 0
         envs = "".join(f"-e {_shq(f'{k}={v}')} " for k, v in self.proxy_env.items())
-        full = f"docker exec {envs}{self.name} sh -c {_shq(command)}"
+        tag = _job_tag()
+        if self._setsid:
+            inner = f"echo $$ > /tmp/rc-{tag}.pg; {command}"
+            full = f"docker exec {envs}{self.name} setsid -w sh -c {_shq(inner)}"
+        else:
+            inner = f": RC_JOB_{tag}; {command}"
+            full = f"docker exec {envs}{self.name} sh -c {_shq(inner)}"
         proc = await conn.create_process(full, stderr=asyncssh.STDOUT)
         chunks: list[str] = []
-        async for line in proc.stdout:
-            chunks.append(line)
-            if on_output:
-                await on_output(line.rstrip("\n") + "\r\n")
-        result = await proc.wait()
-        return ExecResult(exit_code=result.exit_status or 0, output="".join(chunks))
+        try:
+            async for line in proc.stdout:
+                chunks.append(line)
+                if on_output:
+                    await on_output(line.rstrip("\n") + "\r\n")
+            result = await proc.wait()
+            return ExecResult(exit_code=result.exit_status or 0, output="".join(chunks))
+        except asyncio.CancelledError:
+            await self._kill_job(tag)
+            try:
+                proc.terminate()
+            except Exception:
+                pass
+            raise
+
+    async def _kill_job(self, tag: str) -> None:
+        if self._setsid:
+            script = (f'pg=$(cat /tmp/rc-{tag}.pg 2>/dev/null); '
+                      f'[ -n "$pg" ] && {{ kill -TERM -"$pg" 2>/dev/null; sleep 0.2; '
+                      f'kill -KILL -"$pg" 2>/dev/null; }}; rm -f /tmp/rc-{tag}.pg; true')
+        else:
+            script = (f"pkill -TERM -f 'RC_JOB_{tag}'; sleep 0.2; pkill -KILL -f 'RC_JOB_{tag}'; true")
+        try:
+            await self._sh(f"docker exec {self.name} sh -c {_shq(script)}")
+        except Exception:
+            pass
+
+    async def stage_file(self, path: str, data: bytes) -> None:
+        conn = await self.connection()
+        directory = path.rsplit("/", 1)[0] or "/"
+        inner = f"mkdir -p {_shq(directory)}; cat > {_shq(path)}"
+        full = f"docker exec -i {self.name} sh -c {_shq(inner)}"
+        proc = await conn.create_process(full, encoding=None)
+        try:
+            proc.stdin.write(data)
+            proc.stdin.write_eof()
+            await proc.wait()
+        except Exception:
+            pass
 
     async def close(self) -> None:
         # Leave the container running on the remote (caught shells / artifacts

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -29,7 +29,7 @@ from ..repositories import sessions as sessions_repo
 from ..repositories import settings as settings_repo
 from ..repositories import shells as shells_repo
 from ..schemas import ExecutionSettings, LlmSettings
-from ..storage import storage
+from ..storage import safe_filename, storage
 from . import msf, nmap, pivot, webscan
 from .browser import BrowserManager
 from .execution import ExecResult, build_backend
@@ -144,6 +144,7 @@ class LiveRunner:
         self._pivot: pivot.PivotManager | None = None
         self._current_cmd_task: asyncio.Task | None = None
         self._interrupted = False
+        self._stop_requested = False
 
     async def run(self) -> None:
         await self._load()
@@ -169,7 +170,9 @@ class LiveRunner:
                 await self._prepare_source()
             await self._orchestrate()
             async with session_scope() as s:
-                await runs_repo.set_status(s, self.run_id, "completed")
+                run = await runs_repo.get(s, self.run_id)
+                if not self._stop_requested and run is not None and run.status != "stopped":
+                    await runs_repo.set_status(s, self.run_id, "completed")
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -209,7 +212,7 @@ class LiveRunner:
             self.brief = session.brief
             self.instruction = run.instruction
             afiles = await files_repo.list_for_session(s, session.id, kind="assessment")
-            self.assessment_files = [f.filename for f in afiles]
+            self.assessment_files = []
             self._assessment_meta = [(f.bucket, f.object_key, f.filename) for f in afiles]
             base = LlmSettings(**cfg.llm) if cfg.llm else LlmSettings()
             # Run picks provider + model; key comes from that provider's stored
@@ -632,7 +635,10 @@ class LiveRunner:
                     msg = json.loads(raw)
                 except Exception:
                     continue
-                if msg.get("action") in ("stop", "interrupt"):
+                action = msg.get("action")
+                if action in ("stop", "interrupt"):
+                    if action == "stop":
+                        self._stop_requested = True
                     task = self._current_cmd_task
                     if task is not None and not task.done():
                         task.cancel()
@@ -643,12 +649,17 @@ class LiveRunner:
 
     async def _stage_assessment_files(self) -> None:
         for bucket, key, name in self._assessment_meta:
+            if not safe_filename(name):
+                await self._event("orchestrator", "steer", f"skipped unsafe assessment filename: {name}")
+                continue
             try:
                 data = await storage.get_bytes(bucket, key)
                 await self.backend.stage_file(f"/root/assessment/{name}", data)
-                await self._event("orchestrator", "steer", f"staged assessment file: {name}")
             except Exception as exc:
                 await self._event("orchestrator", "steer", f"could not stage {name}: {exc}")
+                continue
+            self.assessment_files.append(name)
+            await self._event("orchestrator", "steer", f"staged assessment file: {name}")
 
     async def _exec(self, command: str, on_output=None) -> ExecResult:
         task = asyncio.create_task(self.backend.run(command, on_output=on_output))
@@ -673,6 +684,8 @@ class LiveRunner:
             await asyncio.sleep(0.5)
 
     async def _stopped(self) -> bool:
+        if self._stop_requested:
+            return True
         async with session_scope() as s:
             run = await runs_repo.get(s, self.run_id)
         return run is None or run.status == "stopped"
@@ -870,7 +883,7 @@ class LiveRunner:
         if _is_source_url(self.source):
             await self._event("recon", "tool", f"cloning {self.source}")
             try:
-                res = await self.backend.run(
+                res = await self._exec(
                     f"rm -rf /src && git clone --depth 1 {self.source} /src && "
                     f"echo CLONED && (find /src -type f | wc -l) ",
                     on_output=lambda line: self._event("recon", "tool", line.rstrip()))

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -10,11 +10,12 @@ import json
 from typing import Any, TypedDict
 
 from .. import steer
-from ..bus import Bus, browser_channel, chat_channel, shell_channel, shell_input_channel
+from ..bus import Bus, browser_channel, chat_channel, control_channel, shell_channel, shell_input_channel
 from ..config import settings
 from ..db import session_scope
 from ..repositories import agents as agents_repo
 from ..repositories import chat as chat_repo
+from ..repositories import files as files_repo
 from ..repositories import findings as findings_repo
 from ..repositories import hosts as hosts_repo
 from ..repositories import ids
@@ -31,7 +32,7 @@ from ..schemas import ExecutionSettings, LlmSettings
 from ..storage import storage
 from . import msf, nmap, pivot, webscan
 from .browser import BrowserManager
-from .execution import build_backend
+from .execution import ExecResult, build_backend
 from .llm import LlmClient
 from .tools import (
     EXECUTOR_TOOLS,
@@ -133,10 +134,16 @@ class LiveRunner:
         self.run_name = ""
         self.kind = "network"
         self.source: str | None = None
+        self.brief: str | None = None
+        self.instruction: str | None = None
+        self.assessment_files: list[str] = []
+        self._assessment_meta: list[tuple[str, str, str]] = []  # (bucket, key, filename)
         self.server = None  # the chosen remote Server row, or None for local
         self._listener_tasks: list[asyncio.Task] = []
         self._browser: BrowserManager | None = None
         self._pivot: pivot.PivotManager | None = None
+        self._current_cmd_task: asyncio.Task | None = None
+        self._interrupted = False
 
     async def run(self) -> None:
         await self._load()
@@ -155,6 +162,9 @@ class LiveRunner:
                 self.backend = SimBackend()
                 if self._browser is not None:
                     self._browser.backend = self.backend
+            self._listener_tasks.append(asyncio.create_task(self._watch_control()))
+            if self._assessment_meta:
+                await self._stage_assessment_files()
             if self.kind == "code":
                 await self._prepare_source()
             await self._orchestrate()
@@ -196,6 +206,11 @@ class LiveRunner:
             self.run_name = run.name
             self.kind = session.kind or "network"
             self.source = session.source
+            self.brief = session.brief
+            self.instruction = run.instruction
+            afiles = await files_repo.list_for_session(s, session.id, kind="assessment")
+            self.assessment_files = [f.filename for f in afiles]
+            self._assessment_meta = [(f.bucket, f.object_key, f.filename) for f in afiles]
             base = LlmSettings(**cfg.llm) if cfg.llm else LlmSettings()
             # Run picks provider + model; key comes from that provider's stored
             # credential, falling back to the legacy single key.
@@ -275,7 +290,9 @@ class LiveRunner:
 
         system = (codescan_orchestrator_system(self.run_name, self.source or "")
                   if self.kind == "code"
-                  else orchestrator_system(self.run_name, self.scope, self.targets, self.roe))
+                  else orchestrator_system(self.run_name, self.scope, self.targets, self.roe,
+                                           brief=self.brief, instruction=self.instruction,
+                                           files=self.assessment_files))
         init: _State = {
             "messages": [{"role": "system", "content": system},
                          {"role": "user", "content": "Begin the engagement."}],
@@ -433,7 +450,7 @@ class LiveRunner:
         # Through a pivot, tunnel the connect scan over the SOCKS proxy so internal
         # hosts are reachable; discovered hosts are tagged as pivot-sourced.
         cmd = pivot.proxychains_wrap(cmd, pivoting)
-        res = await self.backend.run(cmd)
+        res = await self._exec(cmd)
         hosts = nmap.parse_nmap_xml(getattr(res, "output", "") or "")
         for h in hosts:
             await self._record_host({
@@ -453,7 +470,7 @@ class LiveRunner:
         if not target:
             return {"error": "target required"}
         cmd = webscan.build_nuclei_command(target, severity=args.get("severity"))
-        res = await self.backend.run(cmd)
+        res = await self._exec(cmd)
         findings = webscan.parse_nuclei_jsonl(getattr(res, "output", "") or "", target=target)
         for f in findings:
             await self._record_finding(f)
@@ -465,7 +482,7 @@ class LiveRunner:
             return {"error": "url required"}
         cmd = webscan.build_ffuf_command(url, wordlist=args.get("wordlist"),
                                          vhost=(args.get("mode") == "vhost"))
-        res = await self.backend.run(cmd)
+        res = await self._exec(cmd)
         results = webscan.parse_ffuf_json(getattr(res, "output", "") or "")
         return {"ok": True, "found": len(results), "results": results[:50]}
 
@@ -473,7 +490,7 @@ class LiveRunner:
         query = str(args.get("query", "")).strip()
         if not query:
             return {"error": "query required"}
-        res = await self.backend.run(msf.build_msf_search(query))
+        res = await self._exec(msf.build_msf_search(query))
         modules = msf.parse_msf_search(getattr(res, "output", "") or "")
         return {"ok": True, "count": len(modules), "modules": modules[:40]}
 
@@ -483,7 +500,7 @@ class LiveRunner:
             return {"error": "invalid module path"}
         options = args.get("options") if isinstance(args.get("options"), dict) else {}
         cmd = msf.build_msf_run(module, {str(k): str(v) for k, v in options.items()})
-        res = await self.backend.run(cmd)
+        res = await self._exec(cmd)
         return {"ok": True, "output": (getattr(res, "output", "") or "")[-3000:]}
 
     # ---- executor sub-agent ----
@@ -531,7 +548,7 @@ class LiveRunner:
                     async with session_scope() as s:
                         await agents_repo.update(s, agent_id, action=cmd[:80], calls=calls)
                     await self._event(agent_name, "tool", f"$ {cmd}")
-                    res = await self.backend.run(cmd, on_output=lambda line: self._shell_out(shell_id, line))
+                    res = await self._exec(cmd, on_output=lambda line: self._shell_out(shell_id, line))
                     outputs.append(f"$ {cmd}\n{res.output}")
                     messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
                                      "content": res.output[:4000]})
@@ -562,8 +579,12 @@ class LiveRunner:
                     res = await self._dispatch_toolset(cname, cargs)
                     messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
                                      "content": json.dumps(res)[:4000]})
-            if stop:
+            if stop or self._interrupted:
                 break
+
+        if self._interrupted:
+            self._interrupted = False
+            await self._event(agent_name, "steer", "interrupted by operator; returning to the orchestrator")
 
         async with session_scope() as s:
             await agents_repo.update(s, agent_id, status="done")
@@ -603,6 +624,44 @@ class LiveRunner:
         except TimeoutError:
             await self._event("orchestrator", "steer", "operator did not answer; proceeding conservatively")
             return None
+
+    async def _watch_control(self) -> None:
+        try:
+            async for raw in self.bus.subscribe(control_channel(self.run_id)):
+                try:
+                    msg = json.loads(raw)
+                except Exception:
+                    continue
+                if msg.get("action") in ("stop", "interrupt"):
+                    task = self._current_cmd_task
+                    if task is not None and not task.done():
+                        task.cancel()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            pass
+
+    async def _stage_assessment_files(self) -> None:
+        for bucket, key, name in self._assessment_meta:
+            try:
+                data = await storage.get_bytes(bucket, key)
+                await self.backend.stage_file(f"/root/assessment/{name}", data)
+                await self._event("orchestrator", "steer", f"staged assessment file: {name}")
+            except Exception as exc:
+                await self._event("orchestrator", "steer", f"could not stage {name}: {exc}")
+
+    async def _exec(self, command: str, on_output=None) -> ExecResult:
+        task = asyncio.create_task(self.backend.run(command, on_output=on_output))
+        self._current_cmd_task = task
+        try:
+            return await task
+        except asyncio.CancelledError:
+            if task.cancelled():
+                self._interrupted = True
+                return ExecResult(exit_code=130, output="[interrupted by operator]")
+            raise
+        finally:
+            self._current_cmd_task = None
 
     async def _gate(self) -> None:
         while True:

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -316,7 +316,22 @@ EXECUTOR_TOOLS = [
 ]
 
 
-def orchestrator_system(goal: str, scope: list[str], targets: list[str], roe: str | None) -> str:
+def orchestrator_system(goal: str, scope: list[str], targets: list[str], roe: str | None,
+                        brief: str | None = None, instruction: str | None = None,
+                        files: list[str] | None = None) -> str:
+    context = ""
+    if brief:
+        context += f"Engagement brief: {brief}\n"
+    if instruction:
+        context += (
+            f"This run's instructions: {instruction}\n"
+            "If this run's instructions conflict with the engagement brief, follow this run's "
+            "instructions.\n")
+    if files:
+        context += (
+            f"Assessment files the operator provided are staged in /root/assessment/: {', '.join(files)}. "
+            "Delegate executors to work on them with tools (file, strings, binwalk, and so on) as the "
+            "task requires.\n")
     return (
         "You are the orchestrator of an authorized red-team engagement. You plan and "
         "delegate; executors do the hands-on work. Stay strictly within scope, honor the "
@@ -325,7 +340,8 @@ def orchestrator_system(goal: str, scope: list[str], targets: list[str], roe: st
         f"Objective: {goal}\n"
         f"Scope: {', '.join(scope) or 'unspecified'}\n"
         f"Targets: {', '.join(targets) or 'unspecified'}\n"
-        f"Rules of engagement: {roe or 'standard, no DoS, no data destruction'}\n\n"
+        f"Rules of engagement: {roe or 'standard, no DoS, no data destruction'}\n"
+        f"{context}\n"
         "Work in small steps. Delegate one objective at a time. As you go, record every "
         "confirmed vulnerability with record_finding (always include a realistic cvss score 0-10), "
         "every credential/hash/token/file you obtain with record_loot, and every host/endpoint/service "

--- a/packages/core/redcell_core/models/run.py
+++ b/packages/core/redcell_core/models/run.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Float, Integer, String
+from sqlalchemy import BigInteger, Float, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from . import Base
@@ -9,6 +9,7 @@ class Run(Base):
     id: Mapped[str] = mapped_column(String, primary_key=True)
     session_id: Mapped[str] = mapped_column(String, index=True)
     name: Mapped[str] = mapped_column(String)
+    instruction: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String, default="queued")
     phase: Mapped[str] = mapped_column(String, default="Reconnaissance")
     provider: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/packages/core/redcell_core/models/session.py
+++ b/packages/core/redcell_core/models/session.py
@@ -18,6 +18,7 @@ class Session(Base):
     targets: Mapped[list] = mapped_column(JSONB, default=list)
     status: Mapped[str] = mapped_column(String, default="active")
     roe: Mapped[str | None] = mapped_column(Text, nullable=True)
+    brief: Mapped[str | None] = mapped_column(Text, nullable=True)
     active_run_id: Mapped[str | None] = mapped_column(String, nullable=True)
     # Where runs execute (a saved Server) and how they egress (a saved Proxy).
     # Null server_id => local execution; null proxy_id => direct (no proxy).

--- a/packages/core/redcell_core/repositories/files.py
+++ b/packages/core/redcell_core/repositories/files.py
@@ -19,9 +19,11 @@ async def get(s: AsyncSession, fid: str) -> File | None:
     return await s.get(File, fid)
 
 
-async def list_for_session(s: AsyncSession, sid: str) -> list[File]:
-    return list((await s.scalars(
-        select(File).where(File.session_id == sid).order_by(File.created_at.desc()))).all())
+async def list_for_session(s: AsyncSession, sid: str, *, kind: str | None = None) -> list[File]:
+    stmt = select(File).where(File.session_id == sid)
+    if kind is not None:
+        stmt = stmt.where(File.kind == kind)
+    return list((await s.scalars(stmt.order_by(File.created_at.desc()))).all())
 
 
 async def delete(s: AsyncSession, fid: str) -> bool:

--- a/packages/core/redcell_core/repositories/runs.py
+++ b/packages/core/redcell_core/repositories/runs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Run
@@ -29,6 +29,13 @@ async def create(s: AsyncSession, data: dict) -> Run:
     s.add(row)
     await s.flush()
     return row
+
+
+async def start_if_not_running(s: AsyncSession, rid: str) -> bool:
+    result = await s.execute(
+        update(Run).where(Run.id == rid, Run.status != "running").values(status="running"))
+    await s.flush()
+    return (result.rowcount or 0) > 0
 
 
 async def set_status(s: AsyncSession, rid: str, status: str) -> Run | None:

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -42,6 +42,7 @@ class Session(Camel):
     targets: list[str] = []
     status: str = "active"
     roe: str | None = None
+    brief: str | None = None
     created_at: str
     active_run_id: str | None = None
     server_id: str | None = None
@@ -60,6 +61,7 @@ class CreateSessionInput(Camel):
     scope: list[str] = []
     targets: list[str] = []
     roe: str | None = None
+    brief: str | None = None
     server_id: str | None = None
     proxy_id: str | None = None
     provider: str | None = None
@@ -70,6 +72,7 @@ class Run(Camel):
     id: str
     session_id: str
     name: str
+    instruction: str | None = None
     status: str
     phase: str
     started_at: str
@@ -441,6 +444,7 @@ class SessionProposal(Camel):
     client: str | None = None
     scope: list[str] = []
     targets: list[str] = []
+    brief: str | None = None
 
 
 class DraftChatInput(Camel):

--- a/packages/core/redcell_core/storage.py
+++ b/packages/core/redcell_core/storage.py
@@ -7,6 +7,11 @@ from botocore.config import Config as BotoConfig
 
 from .config import settings
 
+
+def safe_filename(name: str | None) -> bool:
+    return bool(name) and name not in (".", "..") and "/" not in name and "\\" not in name
+
+
 _PUBLIC_POLICY = {
     "Version": "2012-10-17",
     "Statement": [{

--- a/packages/core/tests/test_execution_cancel.py
+++ b/packages/core/tests/test_execution_cancel.py
@@ -39,6 +39,14 @@ async def test_exec_returns_interrupted_when_current_command_cancelled():
 
 
 @pytest.mark.asyncio
+async def test_stop_request_makes_stopped_true():
+    r = LiveRunner(bus=None, run_id="run-s")
+    assert r._stop_requested is False
+    r._stop_requested = True
+    assert await r._stopped() is True
+
+
+@pytest.mark.asyncio
 async def test_control_interrupt_cancels_the_running_command():
     bus = Bus(settings.redis_url)
     await bus.connect()
@@ -46,12 +54,16 @@ async def test_control_interrupt_cancels_the_running_command():
     r.backend = SleepBackend()
     watcher = asyncio.create_task(r._watch_control())
     call = asyncio.create_task(r._exec("sleep 30"))
-    await asyncio.sleep(0.3)
-    await bus.publish_json(control_channel("run-ctl"), {"action": "interrupt"})
     try:
+        for _ in range(50):
+            if call.done():
+                break
+            await bus.publish_json(control_channel("run-ctl"), {"action": "interrupt"})
+            await asyncio.sleep(0.1)
         res = await asyncio.wait_for(call, timeout=5)
         assert res.exit_code == 130
         assert r.backend.cancelled is True
     finally:
         watcher.cancel()
+        await asyncio.gather(watcher, return_exceptions=True)
         await bus.close()

--- a/packages/core/tests/test_execution_cancel.py
+++ b/packages/core/tests/test_execution_cancel.py
@@ -1,0 +1,57 @@
+import asyncio
+
+import pytest
+from redcell_core.bus import Bus, control_channel
+from redcell_core.config import settings
+from redcell_core.engine.execution import ExecResult
+from redcell_core.engine.runner import LiveRunner
+
+
+class SleepBackend:
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    async def run(self, command, on_output=None) -> ExecResult:
+        try:
+            await asyncio.sleep(30)
+            return ExecResult(exit_code=0, output="done")
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+@pytest.mark.asyncio
+async def test_exec_returns_interrupted_when_current_command_cancelled():
+    r = LiveRunner(bus=None, run_id="run-x")
+    r.backend = SleepBackend()
+    call = asyncio.create_task(r._exec("sleep 30"))
+    for _ in range(50):
+        if r._current_cmd_task is not None:
+            break
+        await asyncio.sleep(0.01)
+    assert r._current_cmd_task is not None
+    r._current_cmd_task.cancel()
+    res = await asyncio.wait_for(call, timeout=5)
+    assert res.exit_code == 130
+    assert "interrupted" in res.output
+    assert r._interrupted is True
+    assert r.backend.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_control_interrupt_cancels_the_running_command():
+    bus = Bus(settings.redis_url)
+    await bus.connect()
+    r = LiveRunner(bus=bus, run_id="run-ctl")
+    r.backend = SleepBackend()
+    watcher = asyncio.create_task(r._watch_control())
+    call = asyncio.create_task(r._exec("sleep 30"))
+    await asyncio.sleep(0.3)
+    await bus.publish_json(control_channel("run-ctl"), {"action": "interrupt"})
+    try:
+        res = await asyncio.wait_for(call, timeout=5)
+        assert res.exit_code == 130
+        assert r.backend.cancelled is True
+    finally:
+        watcher.cancel()
+        await bus.close()

--- a/packages/core/tests/test_orchestrator_prompt.py
+++ b/packages/core/tests/test_orchestrator_prompt.py
@@ -1,0 +1,26 @@
+import pytest
+from redcell_core.engine.execution import SimBackend
+from redcell_core.engine.tools import orchestrator_system
+
+
+def test_context_sections_render():
+    p = orchestrator_system("Goal", ["*.t"], ["t"], "no dos",
+                            brief="focus on prompt injection, skip recon",
+                            instruction="this run: try IDOR instead",
+                            files=["challenge.bin", "capture.pcap"])
+    assert "Engagement brief: focus on prompt injection, skip recon" in p
+    assert "This run's instructions: this run: try IDOR instead" in p
+    assert "follow this run's instructions" in p
+    assert "/root/assessment/: challenge.bin, capture.pcap" in p
+
+
+def test_empty_sections_omitted():
+    p = orchestrator_system("Goal", [], [], None)
+    assert "Engagement brief:" not in p
+    assert "This run's instructions:" not in p
+    assert "/root/assessment/" not in p
+
+
+@pytest.mark.asyncio
+async def test_sim_backend_stage_file_is_noop():
+    await SimBackend().stage_file("/root/assessment/x.bin", b"\x00\x01binary")


### PR DESCRIPTION
Two related capabilities the engine was missing, one PR.

## 1. Operator context reaches the orchestrator

Previously the orchestrator only saw scope, targets, ROE, and the run name. The setup chat was discarded, per-run instructions were dropped, and there was no way to hand the agents files to work on.

- **Engagement brief** (`sessions.brief`): the setup agent drafts a short brief (objectives, constraints, what to focus on / skip) via its `propose_session` tool. Editable on the New Session page, saved on create.
- **Per-run instruction** (`runs.instruction`): a directive for a specific run. Rendered into the orchestrator prompt with an explicit rule that it **overrides the brief on conflict**. The New Run dialog already collected this; now it is persisted and used.
- **Assessment files**: uploaded with `kind="assessment"`, stored in S3, and materialized into the execution container at `/root/assessment/<name>` at run start via a new `stage_file` backend method (docker cp locally, streamed over SSH for remote, no-op for sim). Files are operational (a binary to analyze, a pcap for forensics), not injected as prompt text; the prompt just lists what is staged.

Order in the orchestrator system prompt: scope/targets -> ROE -> engagement brief -> this run's instruction (+ precedence line) -> staged assessment files.

## 2. Cancellable execution

A tool command ran as a blocking `await backend.run(...)`; stop/steer were only seen at planning boundaries and nothing killed an in-flight command, so a long `nmap` finished before "stop the scan" took effect. `control_channel` was published by the API but nothing consumed it.

- The worker now subscribes to `control_channel`. Tool commands run through one tracked, cancellable task.
- A chat **steer** on a live run publishes `interrupt` (kill the current command, orchestrator re-plans with the steer); **Stop** publishes `stop`.
- Docker commands launch under a tagged `setsid` process group, so a cancel kills the in-container process tree, not just the `docker exec` client. A one-time probe falls back gracefully when `setsid` is unavailable.

## Migration

One migration adds two nullable columns (`sessions.brief`, `runs.instruction`); run `rc db upgrade`. Existing rows are unaffected.

## Testing

- `test_orchestrator_prompt`: prompt renders brief/instruction (with precedence) and staged files; omits empty sections; sim `stage_file` is a no-op.
- `test_execution_cancel`: `_exec` returns an interrupted result when its command task is cancelled; a `control_channel` interrupt cancels the running command.
- `test_context_roundtrip`: session brief, run instruction, and assessment-file `kind` persist and read back.
- Full backend suite (85) green; web typecheck + eslint + 39 unit tests green.

The in-container `setsid` group-kill and file staging are verified live against the Kali container (they can't be unit-tested); a restart of the worker + API is needed to activate the changes in a running deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added engagement briefs to session creation, AI proposals, and orchestration context.
  * Added run instructions and support for attaching assessment files to sessions.
  * Added file categorization and filtering.
  * Improved execution cancellation and cleanup across supported environments.

* **Bug Fixes**
  * Continuing a session now interrupts active runs safely.
  * Assessment files are staged before orchestration, with upload and staging errors reported clearly.

* **Tests**
  * Added coverage for context persistence, file staging, prompt generation, and command interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->