### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.1.0"
+version = "0.2.0"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.1.0"
+version = "0.2.0"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]


### PR DESCRIPTION
Release prep for **v0.2.0**. Bumps api, worker, and web to `0.2.0` so the tag-triggered release workflow rebuilds and republishes their GHCR images (and `:latest`) with the merged work.

## Included since v0.1.0
- Live-run chat answers questions instead of a canned steer; persistent terminal scrollback (#29)
- Operator context to the orchestrator (session brief + per-run instruction + assessment files) and cancellable execution (#30)

## Notes
- Kali image is unchanged, stays `1.0.0` (its build will skip as already published).
- **Deploy must run `rc db upgrade`** — this release adds two nullable columns (`sessions.brief`, `runs.instruction`).

After merge, push tag `v0.2.0` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the API, web application, and worker component versions to 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->