### PR TITLE
refactor(auth): resolve the real seeded user, drop the hardcoded user id

### DIFF
--- a/apps/api/tests/test_auth_identity.py
+++ b/apps/api/tests/test_auth_identity.py
@@ -1,0 +1,33 @@
+"""current_user resolves the real seeded user, not a hardcoded id."""
+
+import asyncio
+
+from fastapi.testclient import TestClient
+from redcell_core import seed
+from redcell_core.db import engine, session_scope
+from redcell_core.repositories import users as users_repo
+
+_admin_id = None
+
+
+async def _boot():
+    global _admin_id
+    await seed.bootstrap()
+    async with session_scope() as s:
+        u = await users_repo.get_by_username(s, "admin")
+        _admin_id = u.id
+    await engine.dispose()
+
+
+from app.main import app  # noqa: E402
+
+
+def test_me_returns_the_real_seeded_user():
+    asyncio.run(_boot())
+    with TestClient(app) as c:
+        assert c.post("/api/v1/auth/login",
+                      json={"username": "admin", "password": "admin"}).status_code == 200
+        me = c.get("/api/v1/auth/me").json()
+        assert me["username"] == "admin"
+        assert me["id"] != "u-1"
+        assert me["id"] == _admin_id

--- a/packages/core/redcell_core/security.py
+++ b/packages/core/redcell_core/security.py
@@ -9,6 +9,8 @@ import jwt
 from fastapi import Cookie, HTTPException, Response
 
 from .config import settings
+from .db import session_scope
+from .repositories import users as users_repo
 from .schemas import User
 
 COOKIE_NAME = "rc_session"
@@ -46,11 +48,16 @@ def clear_cookie(response: Response) -> None:
     response.delete_cookie(COOKIE_NAME, path="/")
 
 
-def current_user(rc_session: str | None = Cookie(default=None)) -> User:
+async def current_user(rc_session: str | None = Cookie(default=None)) -> User:
     if not rc_session:
         raise HTTPException(status_code=401, detail="not authenticated")
     try:
         payload = jwt.decode(rc_session, settings.jwt_secret, algorithms=[_ALGO])
     except jwt.PyJWTError:
         raise HTTPException(status_code=401, detail="invalid session") from None
-    return User(id="u-1", username=payload.get("sub", "admin"), role=payload.get("role", "admin"))
+    sub = payload.get("sub")
+    async with session_scope() as s:
+        user = await users_repo.get_by_username(s, sub) if sub else None
+    if user is None:
+        raise HTTPException(status_code=401, detail="invalid session")
+    return User(id=user.id, username=user.username, role=user.role)


### PR DESCRIPTION
Closes #33.

## Problem
`current_user` returned a hardcoded `User(id="u-1", ...)` regardless of who was logged in; the JWT only carried `sub` (username).

## Fix
`current_user` is now async and resolves the real user by the JWT `sub` via `users_repo.get_by_username`, returning the actual id/username/role (401 if the user no longer exists). No `u-1` anywhere.

RedCell stays single-user by design — no ownership columns, no per-resource authz. This just makes the one identity real.

## Verified
- New test `test_auth_identity.py`: after login, `/auth/me` returns the seeded admin's real id (not `u-1`). Full backend suite **95 green**, ruff clean.
- Live: `/auth/me` now returns `u-<id>` for the seeded admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)