### PR TITLE
resilience(llm): add retries and a request timeout to LlmClient

### DIFF
--- a/packages/core/redcell_core/config.py
+++ b/packages/core/redcell_core/config.py
@@ -56,6 +56,8 @@ class Settings(BaseSettings):
     # reverse-shell callback address. listener runs on the worker host; a Docker
     # target reaches it via host.docker.internal.
     callback_host: str = "host.docker.internal"
+    llm_num_retries: int = 2
+    llm_timeout_seconds: float = 120.0
 
     admin_username: str = "admin"
     admin_password: str = ""

--- a/packages/core/redcell_core/engine/llm.py
+++ b/packages/core/redcell_core/engine/llm.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..config import settings
 from ..schemas import LlmSettings
 
 # provider id -> LiteLLM model prefix. Providers LiteLLM does not route natively
@@ -50,6 +51,8 @@ class LlmClient:
             kw["api_base"] = "http://localhost:11434"
         if self.cfg.reasoning_effort and self.cfg.provider in ("openai", "anthropic"):
             kw["reasoning_effort"] = self.cfg.reasoning_effort
+        kw["num_retries"] = settings.llm_num_retries
+        kw["timeout"] = settings.llm_timeout_seconds
         return kw
 
     async def complete(

--- a/packages/core/tests/test_llm_retries.py
+++ b/packages/core/tests/test_llm_retries.py
@@ -1,0 +1,8 @@
+from redcell_core.engine.llm import LlmClient
+from redcell_core.schemas import LlmSettings
+
+
+def test_kwargs_include_retries_and_timeout():
+    kw = LlmClient(LlmSettings(provider="openai", model="gpt-5.6", api_key="x"))._kwargs()
+    assert kw["num_retries"] >= 1
+    assert kw["timeout"] > 0


### PR DESCRIPTION
Closes #36.

## Problem
`LlmClient.complete` called `litellm.acompletion` once with no `num_retries` or timeout, so a transient 429/5xx failed the plan/executor step and a hung request could block the run.

## Fix
`_kwargs()` now passes `num_retries` (`REDCELL_LLM_NUM_RETRIES`, default 2) and `timeout` (`REDCELL_LLM_TIMEOUT_SECONDS`, default 120) to `litellm.acompletion`. litellm retries retryable errors with backoff; the timeout bounds a hung request. Both are configurable.

## Verified
`test_llm_retries.py` asserts the kwargs carry retries + timeout; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)