### PR TITLE
feat(security): enforce session scope in code at the tool boundary

### DIFF
--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -30,7 +30,7 @@ from ..repositories import settings as settings_repo
 from ..repositories import shells as shells_repo
 from ..schemas import ExecutionSettings, LlmSettings
 from ..storage import safe_filename, storage
-from . import msf, nmap, pivot, webscan
+from . import msf, nmap, pivot, scope, webscan
 from .browser import BrowserManager
 from .execution import ExecResult, build_backend
 from .llm import LlmClient
@@ -428,6 +428,13 @@ class LiveRunner:
             await self._event("orchestrator", "steer", f"browser control watch ended: {exc}")
 
     # ---- structured tool integrations ----
+    async def _scope_block(self, target: str) -> dict[str, Any] | None:
+        if scope.in_scope(target, self.scope):
+            return None
+        await self._event("orchestrator", "steer", f"blocked out-of-scope target: {target}")
+        return {"error": f"target {target!r} is out of scope ({', '.join(self.scope) or 'unset'}); "
+                         "pick an in-scope target or ask the operator to widen the scope"}
+
     async def _dispatch_toolset(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
         if name == "nmap_scan":
             return await self._run_nmap(args)
@@ -445,6 +452,8 @@ class LiveRunner:
         target = str(args.get("target", "")).strip()
         if not target:
             return {"error": "target required"}
+        if (blocked := await self._scope_block(target)):
+            return blocked
         pivoting = self._pivot is not None and self._pivot.active
         cmd = nmap.build_nmap_command(target, ports=args.get("ports"),
                                       service_detection=bool(args.get("service_detection")),
@@ -472,6 +481,8 @@ class LiveRunner:
         target = str(args.get("target", "")).strip()
         if not target:
             return {"error": "target required"}
+        if (blocked := await self._scope_block(target)):
+            return blocked
         cmd = webscan.build_nuclei_command(target, severity=args.get("severity"))
         res = await self._exec(cmd)
         findings = webscan.parse_nuclei_jsonl(getattr(res, "output", "") or "", target=target)
@@ -483,6 +494,8 @@ class LiveRunner:
         url = str(args.get("url", "")).strip()
         if not url:
             return {"error": "url required"}
+        if (blocked := await self._scope_block(url)):
+            return blocked
         cmd = webscan.build_ffuf_command(url, wordlist=args.get("wordlist"),
                                          vhost=(args.get("mode") == "vhost"))
         res = await self._exec(cmd)
@@ -547,6 +560,11 @@ class LiveRunner:
                 cargs = _parse_args(call["arguments"])
                 if cname == "run_command":
                     cmd = cargs.get("command", "")
+                    if scope.is_destructive(cmd):
+                        await self._event(agent_name, "tool", f"blocked destructive command: {cmd[:80]}")
+                        messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
+                                         "content": "blocked: the scope guardrail refused a destructive command"})
+                        continue
                     calls += 1
                     async with session_scope() as s:
                         await agents_repo.update(s, agent_id, action=cmd[:80], calls=calls)

--- a/packages/core/redcell_core/engine/scope.py
+++ b/packages/core/redcell_core/engine/scope.py
@@ -1,0 +1,107 @@
+"""In-scope validation and a destructive-command denylist, enforced in code at the
+tool boundary so a hallucinated or injected target can't be scanned/exploited and
+an obviously destructive command can't run. Pure and unit-testable."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from urllib.parse import urlparse
+
+
+def _as_ip(value: str):
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _as_network(value: str):
+    if "/" not in value:
+        return None
+    try:
+        return ipaddress.ip_network(value, strict=False)
+    except ValueError:
+        return None
+
+
+def target_host(target: str) -> str:
+    """Reduce a URL / host:port / host / IP to a bare lowercase host or IP."""
+    t = (target or "").strip()
+    if not t:
+        return ""
+    if "://" in t:
+        t = urlparse(t).hostname or ""
+    else:
+        t = t.split("/", 1)[0]
+        if t.count(":") == 1 and _as_ip(t) is None:  # host:port, not bare IPv6
+            t = t.split(":", 1)[0]
+    return t.lower().rstrip(".")
+
+
+def _scope_host(entry: str) -> str:
+    e = (entry or "").strip().lower()
+    if "://" in e:
+        e = urlparse(e).hostname or ""
+    return e.split("/", 1)[0].rstrip(".")
+
+
+def in_scope(target: str, scope: list[str] | None) -> bool:
+    """True if target falls within scope. An empty scope is unrestricted by design
+    (the UI documents this); a non-empty scope is enforced."""
+    entries = [s.strip() for s in (scope or []) if s and s.strip()]
+    if not entries:
+        return True
+    host = target_host(target)
+    if not host:
+        return False
+    ip = _as_ip(host)
+    for entry in entries:
+        net = _as_network(entry)
+        if net is not None:
+            if ip is not None and ip in net:
+                return True
+            continue
+        eh = _scope_host(entry)
+        if not eh:
+            continue
+        if eh.startswith("*."):
+            base = eh[2:]
+            if host == base or host.endswith("." + base):
+                return True
+        elif host == eh or host.endswith("." + eh):
+            return True
+    return False
+
+
+_DESTRUCTIVE = [
+    re.compile(r"\bmkfs(\.\w+)?\b", re.I),
+    re.compile(r"\bdd\b[^\n]*\bof=/dev/(sd|nvme|vd|hd)", re.I),
+    re.compile(r">\s*/dev/(sd|nvme|vd|hd)\w+", re.I),
+    re.compile(r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:", re.I),
+    re.compile(r"\b(shutdown|reboot|halt|poweroff|init\s+0|init\s+6)\b", re.I),
+    re.compile(r"\bchmod\s+-R\s+0?00\s+/(?:\s|$)", re.I),
+    re.compile(r"\b(wipefs|shred)\b[^\n]*\b/dev/", re.I),
+]
+
+_RM = re.compile(r"\brm\b((?:\s+-\S+)+)\s+(\S.*)?", re.I)
+_WIPE_TARGETS = {"/", "/*", "~", "$HOME", "/etc", "/var", "/usr", "/bin", "/sbin",
+                 "/boot", "/lib", "/lib64", "/root", "/home", "/opt", "/sys", "/proc",
+                 "/dev", "/srv"}
+
+
+def _dangerous_rm(command: str) -> bool:
+    for m in _RM.finditer(command):
+        flags = m.group(1).lower()
+        if "r" not in flags or "f" not in flags:
+            continue
+        for tok in (m.group(2) or "").split():
+            norm = tok.rstrip("/") or "/"
+            if tok in _WIPE_TARGETS or norm in _WIPE_TARGETS:
+                return True
+    return False
+
+
+def is_destructive(command: str) -> bool:
+    c = command or ""
+    return _dangerous_rm(c) or any(p.search(c) for p in _DESTRUCTIVE)

--- a/packages/core/tests/test_runner_scope.py
+++ b/packages/core/tests/test_runner_scope.py
@@ -1,0 +1,31 @@
+import pytest
+from redcell_core.bus import Bus
+from redcell_core.config import settings
+from redcell_core.engine.runner import LiveRunner
+
+
+@pytest.mark.asyncio
+async def test_scope_block_gates_targets():
+    bus = Bus(settings.redis_url)
+    await bus.connect()
+    r = LiveRunner(bus=bus, run_id="run-scope")
+    r.scope = ["*.example.com", "10.0.0.0/16"]
+    try:
+        assert await r._scope_block("https://api.example.com") is None
+        assert await r._scope_block("10.0.5.5") is None
+        blocked = await r._scope_block("http://evil.com")
+        assert blocked is not None and "out of scope" in blocked["error"]
+    finally:
+        await bus.close()
+
+
+@pytest.mark.asyncio
+async def test_scope_block_unrestricted_when_scope_empty():
+    bus = Bus(settings.redis_url)
+    await bus.connect()
+    r = LiveRunner(bus=bus, run_id="run-scope2")
+    r.scope = []
+    try:
+        assert await r._scope_block("http://anything.example.org") is None
+    finally:
+        await bus.close()

--- a/packages/core/tests/test_scope.py
+++ b/packages/core/tests/test_scope.py
@@ -1,0 +1,57 @@
+from redcell_core.engine.scope import in_scope, is_destructive, target_host
+
+
+def test_target_host_forms():
+    assert target_host("https://app.example.com/path?q=1") == "app.example.com"
+    assert target_host("app.example.com:8080") == "app.example.com"
+    assert target_host("http://10.1.2.3:80") == "10.1.2.3"
+    assert target_host("EXAMPLE.com.") == "example.com"
+
+
+def test_empty_scope_is_unrestricted():
+    assert in_scope("anything.com", []) is True
+    assert in_scope("10.0.0.1", None) is True
+
+
+def test_exact_and_subdomain():
+    scope = ["example.com"]
+    assert in_scope("example.com", scope) is True
+    assert in_scope("https://api.example.com", scope) is True
+    assert in_scope("evil.com", scope) is False
+    assert in_scope("notexample.com", scope) is False
+
+
+def test_wildcard():
+    scope = ["*.example.com"]
+    assert in_scope("api.example.com", scope) is True
+    assert in_scope("example.com", scope) is True
+    assert in_scope("api.other.com", scope) is False
+
+
+def test_cidr():
+    scope = ["10.0.0.0/16"]
+    assert in_scope("10.0.5.9", scope) is True
+    assert in_scope("http://10.0.1.1:8080", scope) is True
+    assert in_scope("10.1.0.1", scope) is False
+    assert in_scope("example.com", scope) is False
+
+
+def test_out_of_scope_when_unparseable():
+    assert in_scope("", ["example.com"]) is False
+
+
+def test_destructive_matches():
+    assert is_destructive("rm -rf /")
+    assert is_destructive("rm -rf /*")
+    assert is_destructive("sudo rm -fr /etc")
+    assert is_destructive("mkfs.ext4 /dev/sda1")
+    assert is_destructive("dd if=/dev/zero of=/dev/sda")
+    assert is_destructive(":(){ :|:& };:")
+    assert is_destructive("shutdown -h now")
+
+
+def test_destructive_allows_normal_commands():
+    assert not is_destructive("nmap -sV 10.0.0.1")
+    assert not is_destructive("rm -rf /tmp/scan-output")
+    assert not is_destructive("curl -s https://target/api")
+    assert not is_destructive("cat /etc/passwd")


### PR DESCRIPTION
Closes #34 (and folds in the P0-4 concern).

## Problem
Scope was enforced only by the prompt. `_run_nmap`/`_run_nuclei`/`_run_web_discover` ran whatever target the model emitted; `run_command` ran anything. A hallucinated or prompt-injected out-of-scope target had no code backstop.

## Fix
New `engine/scope.py` (pure, unit-tested):
- `in_scope(target, scope)` — matches a URL / `host:port` / host / IP against scope entries: exact, subdomain, `*.wildcard`, and CIDR. **Empty scope stays unrestricted** (as the UI documents); a set scope is enforced.
- `is_destructive(command)` — denylist for `run_command`: wiping `/` or a whole system dir, `mkfs`, `dd` to a raw disk, fork bomb, `shutdown`/`reboot`, `wipefs`/`shred` a device. Tuned to **not** flag normal cleanup like `rm -rf /tmp/scan-output`.

Wired into the runner: the three structured tools reject an out-of-scope target with an error that tells the model to pick an in-scope target or ask the operator; `run_command` refuses a destructive command. Pivot scans of internal hosts are gated the same way (include internal ranges in scope, or leave scope empty).

On P0-4: the tool builders already `shlex.quote` inputs (no shell-escape), so the real gap was semantic validation — that's this.

## Verified
- `test_scope.py` (8) covers host parsing, exact/subdomain/wildcard/CIDR, empty-scope, and the denylist (matches + normal-command false-positive guards).
- `test_runner_scope.py` (2) covers the runner gate (in/out of scope, empty-scope unrestricted).
- Full backend suite **105 green**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)