### PR TITLE
security: rate-limit /auth/login and /sessions/draft/chat

### DIFF
--- a/apps/api/app/ratelimit.py
+++ b/apps/api/app/ratelimit.py
@@ -1,0 +1,34 @@
+"""A small in-process sliding-window rate limiter, applied as a route dependency.
+Single-process/single-user by design; disabled when settings.rate_limit_enabled
+is false (tests)."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+
+from fastapi import HTTPException, Request
+from redcell_core.config import settings
+
+_HITS: dict[tuple[str, str], deque[float]] = defaultdict(deque)
+
+
+def _reset() -> None:
+    _HITS.clear()
+
+
+def rate_limit(name: str, max_calls: int, window_seconds: float):
+    async def dependency(request: Request) -> None:
+        if not settings.rate_limit_enabled:
+            return
+        ip = request.client.host if request.client else "unknown"
+        key = (name, ip)
+        now = time.monotonic()
+        hits = _HITS[key]
+        while hits and now - hits[0] > window_seconds:
+            hits.popleft()
+        if len(hits) >= max_calls:
+            raise HTTPException(status_code=429, detail="too many requests, slow down")
+        hits.append(now)
+
+    return dependency

--- a/apps/api/app/routers/ai.py
+++ b/apps/api/app/routers/ai.py
@@ -13,6 +13,7 @@ from redcell_core.security import current_user
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import db
+from ..ratelimit import rate_limit
 
 router = APIRouter(tags=["ai"], dependencies=[Depends(current_user)])
 
@@ -47,7 +48,8 @@ _PROPOSE_TOOL = [{
 }]
 
 
-@router.post("/sessions/draft/chat", response_model=DraftChatOutput)
+@router.post("/sessions/draft/chat", response_model=DraftChatOutput,
+             dependencies=[Depends(rate_limit("draft-chat", 20, 60))])
 async def draft_chat(body: DraftChatInput, s: AsyncSession = Depends(db)) -> DraftChatOutput:
     cfg = await settings_repo.get(s)
     base = LlmSettings(**cfg.llm) if cfg.llm else LlmSettings()

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -10,6 +10,7 @@ from redcell_core.security import clear_cookie, current_user, issue_cookie, veri
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..deps import db
+from ..ratelimit import rate_limit
 
 router = APIRouter(tags=["auth"])
 
@@ -20,7 +21,7 @@ async def first_run() -> FirstRun:
     return FirstRun(needs_setup=False, admin_password_hint=hint)
 
 
-@router.post("/auth/login", response_model=User)
+@router.post("/auth/login", response_model=User, dependencies=[Depends(rate_limit("login", 10, 60))])
 async def login(body: LoginInput, response: Response, s: AsyncSession = Depends(db)) -> User:
     user = await users_repo.get_by_username(s, body.username)
     if user is None or not verify_password(body.password, user.password_hash):

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -1,0 +1,34 @@
+"""Login is throttled when rate limiting is enabled."""
+
+import asyncio
+
+from app.ratelimit import _reset
+from fastapi.testclient import TestClient
+from redcell_core import seed
+from redcell_core.config import settings
+from redcell_core.db import engine
+
+
+async def _boot():
+    await seed.bootstrap()
+    await engine.dispose()
+
+
+from app.main import app  # noqa: E402
+
+
+def test_login_is_rate_limited():
+    asyncio.run(_boot())
+    settings.rate_limit_enabled = True
+    _reset()
+    try:
+        with TestClient(app) as c:
+            codes = [
+                c.post("/api/v1/auth/login", json={"username": "admin", "password": "nope"}).status_code
+                for _ in range(12)
+            ]
+        assert 429 in codes
+        assert 429 not in codes[:10]
+    finally:
+        settings.rate_limit_enabled = False
+        _reset()

--- a/conftest.py
+++ b/conftest.py
@@ -44,6 +44,9 @@ settings.checkpoint_db = ""
 # Pin tests to sim so the suite never shells out to real Docker, independent of
 # the app's default run mode.
 settings.run_mode = "sim"
+# The suite logs in many times from one client; rate limiting would cause spurious
+# 429s. The dedicated rate-limit test re-enables it explicitly.
+settings.rate_limit_enabled = False
 
 
 # 2) Create the test database + schema once, on a throwaway loop. -----------------

--- a/packages/core/redcell_core/config.py
+++ b/packages/core/redcell_core/config.py
@@ -58,6 +58,7 @@ class Settings(BaseSettings):
     callback_host: str = "host.docker.internal"
     llm_num_retries: int = 2
     llm_timeout_seconds: float = 120.0
+    rate_limit_enabled: bool = True
 
     admin_username: str = "admin"
     admin_password: str = ""


### PR DESCRIPTION
Closes #38.

## Problem
No rate limiting anywhere: `/auth/login` was brute-forceable and `/sessions/draft/chat` hit a paid model on every call.

## Fix
A small in-process sliding-window limiter (`apps/api/app/ratelimit.py`) applied as a route dependency:
- `/auth/login`: 10 / 60s per client IP.
- `/sessions/draft/chat`: 20 / 60s per client IP.

Returns 429 when exceeded. Gated by `settings.rate_limit_enabled` (default on); the test suite disables it (many logins from one client) and the dedicated test re-enables it. Single-process/single-user by design.

## Verified
`test_rate_limit.py` asserts the 11th login within the window is 429; full backend suite **97 green**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)