### PR TITLE
observability: structured logging; log swallowed errors

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from redcell_core.bus import bus
 from redcell_core.config import settings
+from redcell_core.logs import configure as configure_logging
 
 from .routers import ai, auth, files, infra, reports, resources, ws
 from .routers import settings as settings_router
@@ -15,6 +16,7 @@ from .routers import settings as settings_router
 
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
+    configure_logging()
     await bus.connect()
     try:
         yield

--- a/apps/api/app/routers/resources.py
+++ b/apps/api/app/routers/resources.py
@@ -15,6 +15,7 @@ from redcell_core.bus import (
     shell_input_channel,
 )
 from redcell_core.db import session_scope
+from redcell_core.logs import get_logger
 from redcell_core.repositories import agents as agents_repo
 from redcell_core.repositories import chat as chat_repo
 from redcell_core.repositories import events as events_repo
@@ -421,4 +422,4 @@ async def _answer_chat(rid: str, text: str) -> None:
             else:
                 await bus.publish_json(control_channel(rid), {"action": "interrupt"})
     except Exception:
-        pass
+        get_logger("api.chat").exception("chat answer failed for run %s", rid)

--- a/apps/api/app/routers/ws.py
+++ b/apps/api/app/routers/ws.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from redcell_core.bus import bus, chat_channel, events_channel, shell_channel
 from redcell_core.config import settings
 from redcell_core.db import session_scope
+from redcell_core.logs import get_logger
 from redcell_core.repositories import sessions as sessions_repo
 from redcell_core.security import COOKIE_NAME
 
@@ -97,7 +98,10 @@ async def _bridge(ws: WebSocket, proc: asyncio.subprocess.Process) -> None:
                 data = await ws.receive_bytes()
                 proc.stdin.write(data)
                 await proc.stdin.drain()
-        except (WebSocketDisconnect, Exception):
+        except WebSocketDisconnect:
+            return
+        except Exception:
+            get_logger("api.ws").exception("noVNC bridge write error")
             return
 
     tasks = {asyncio.create_task(to_ws()), asyncio.create_task(to_proc())}

--- a/apps/worker/worker/settings.py
+++ b/apps/worker/worker/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from redcell_core.bus import bus
+from redcell_core.logs import configure as configure_logging
 from redcell_core.queue import redis_settings
 from redcell_core.storage import storage
 
@@ -10,6 +11,7 @@ from .tasks import generate_report, operate_shell, resume_running, run_engagemen
 
 
 async def on_startup(ctx) -> None:
+    configure_logging()
     await bus.connect()
     await storage.ensure_buckets()
     await ctx["redis"].enqueue_job("resume_running")

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -13,6 +13,7 @@ from .. import steer
 from ..bus import Bus, browser_channel, chat_channel, control_channel, shell_channel, shell_input_channel
 from ..config import settings
 from ..db import session_scope
+from ..logs import get_logger
 from ..repositories import agents as agents_repo
 from ..repositories import chat as chat_repo
 from ..repositories import files as files_repo
@@ -663,7 +664,7 @@ class LiveRunner:
         except asyncio.CancelledError:
             raise
         except Exception:
-            pass
+            get_logger("engine.control").exception("control watch error for run %s", self.run_id)
 
     async def _stage_assessment_files(self) -> None:
         for bucket, key, name in self._assessment_meta:

--- a/packages/core/redcell_core/logs.py
+++ b/packages/core/redcell_core/logs.py
@@ -1,0 +1,26 @@
+"""Application logging. `configure()` is called once at API/worker startup;
+`get_logger(name)` returns a child of the `redcell` logger."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+_configured = False
+
+
+def configure(level: str = "INFO") -> None:
+    global _configured
+    if _configured:
+        return
+    logger = logging.getLogger("redcell")
+    logger.setLevel(level)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)-7s %(name)s %(message)s"))
+    logger.addHandler(handler)
+    logger.propagate = False
+    _configured = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    return logging.getLogger("redcell." + name)

--- a/packages/core/tests/test_logs.py
+++ b/packages/core/tests/test_logs.py
@@ -1,0 +1,14 @@
+import logging
+
+from redcell_core.logs import configure, get_logger
+
+
+def test_get_logger_is_redcell_child():
+    assert get_logger("engine.test").name == "redcell.engine.test"
+
+
+def test_configure_is_idempotent():
+    configure()
+    n = len(logging.getLogger("redcell").handlers)
+    configure()
+    assert len(logging.getLogger("redcell").handlers) == n


### PR DESCRIPTION
Closes #39.

## Problem
Several broad `except Exception: pass` blocks (chat answer, control watcher, noVNC bridge) hid failures, and there was no application logging.

## Fix
- New `redcell_core/logs.py`: a configured `redcell` logger (stderr, timestamped) plus `get_logger(name)`. `configure()` is called once from the API lifespan and the worker `on_startup`.
- The named swallow sites now `log.exception(...)` with context before continuing instead of silently passing. The noVNC bridge also stops catching `WebSocketDisconnect` (normal) as if it were an error.
- Truly best-effort cleanup catches (e.g. `proc.kill()`) are left quiet to avoid noise.

## Verified
`test_logs.py` covers the logger naming + idempotent `configure()`; full backend suite **108 green**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)