### PR TITLE
scaling(worker): make max_jobs configurable and lower the default

### DIFF
--- a/apps/worker/worker/settings.py
+++ b/apps/worker/worker/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from redcell_core.bus import bus
+from redcell_core.config import settings
 from redcell_core.queue import redis_settings
 from redcell_core.storage import storage
 
@@ -24,7 +25,10 @@ class WorkerSettings:
     on_startup = on_startup
     on_shutdown = on_shutdown
     redis_settings = redis_settings()
-    max_jobs = 50
+    # Concurrently active runs are long-lived asyncio tasks in one loop; keep the
+    # ceiling modest and tunable (REDCELL_WORKER_MAX_JOBS) rather than arq's 10 or
+    # a fixed 50.
+    max_jobs = settings.worker_max_jobs
     # Run jobs stream far longer than arq's 300s default; a day is a ceiling,
     # not an expected duration (restart re-enqueues via resume_running).
     job_timeout = 60 * 60 * 24

--- a/packages/core/redcell_core/config.py
+++ b/packages/core/redcell_core/config.py
@@ -59,6 +59,7 @@ class Settings(BaseSettings):
     llm_num_retries: int = 2
     llm_timeout_seconds: float = 120.0
     rate_limit_enabled: bool = True
+    worker_max_jobs: int = 10
 
     admin_username: str = "admin"
     admin_password: str = ""

--- a/packages/core/tests/test_worker_config.py
+++ b/packages/core/tests/test_worker_config.py
@@ -1,0 +1,6 @@
+from redcell_core.config import Settings
+
+
+def test_worker_max_jobs_default_and_override():
+    assert Settings().worker_max_jobs == 10
+    assert Settings(worker_max_jobs=4).worker_max_jobs == 4


### PR DESCRIPTION
Closes #41 (with the audit's correction: a cap already existed at `max_jobs=50`).

## Change
Concurrently active runs are long-lived asyncio tasks sharing one event loop, so 50 is a lot. `max_jobs` now comes from `settings.worker_max_jobs` (`REDCELL_WORKER_MAX_JOBS`, default **10**), so the concurrency ceiling is tunable without editing code.

Deeper per-run resource isolation / worker-level sharding is called out as future work in the issue and not attempted here.

## Verified
Config test (default 10 + override); worker settings import cleanly with `max_jobs = 10`; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)