### PR TITLE
docs: ARCHITECTURE + HARDENING, dev Procfile, README links

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+api: cd apps/api && uv run uvicorn app.main:app --host 127.0.0.1 --port 8080
+worker: cd apps/worker && uv run arq worker.settings.WorkerSettings
+web: cd apps/web && bun run dev

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ cd apps/worker && uv run arq worker.settings.WorkerSettings
 cd apps/web    && bun install && bun run dev
 ```
 
+Or start all three at once with a process manager (they are declared in the
+`Procfile`): `pipx install honcho` then `honcho start`.
+
 Open http://localhost:5183 and sign in with `admin` / `admin`.
 
 Runs execute real tools by default. Add a provider API key in Settings and make sure Docker can pull the Kali image (`martian56/kali:latest`). To dry-run against canned output instead, set `REDCELL_RUN_MODE=sim` in `.env`.
@@ -128,6 +131,11 @@ docker/                Kali execution image
 docker-compose.dev.yml       Postgres + Redis + MinIO
 docker-compose.targets.yml   local vulnerable targets
 ```
+
+## Documentation
+
+- [Architecture](docs/ARCHITECTURE.md) — the components, how a run flows, cross-process coordination.
+- [Hardening & threat model](docs/HARDENING.md) — deploy safely, secrets, scope, and data retention. Read this before running REDCELL anywhere but your own machine.
 
 ## Contributing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Architecture
+
+REDCELL runs a team of LLM agents through a penetration test. The operator watches
+and steers from a web console; the actual tools run inside a Kali container.
+
+```mermaid
+flowchart LR
+  UI["Operator console<br/>React + Vite"] -->|REST + WebSocket| API["FastAPI"]
+  API --> PG[(PostgreSQL)]
+  API --> RS[(Redis<br/>pub/sub + queue)]
+  API --> S3[(MinIO<br/>files & reports)]
+  RS --> W["Worker (arq)"]
+  W --> ENG["Engine<br/>LangGraph + LiteLLM"]
+  ENG -->|docker exec| KALI["Kali container<br/>local or remote over SSH"]
+  KALI --> TGT["Targets"]
+  W -->|events / chat / shell| RS
+  RS -->|stream| API
+```
+
+## The pieces
+
+- **`apps/web`** — the React operator console. Talks to the API through one typed
+  client (`packages/api-client`) that has a mock backend (demo, no server) and an
+  HTTP backend. Live data (activity feed, terminals, the agent's browser) streams
+  over WebSockets; the rest refreshes on a short poll.
+- **`apps/api`** — FastAPI. REST routers, WebSocket fan-out, cookie/JWT auth. It
+  does **not** run agents: it queues a run and relays worker output to the browser.
+- **`apps/worker`** — an `arq` worker. Consumes jobs from Redis and executes them:
+  `run_engagement`, `resume_running` (checkpoint recovery on restart),
+  `operate_shell`, `generate_report`.
+- **`packages/core/redcell_core`** — the shared library:
+  - `engine/` — the agent loop (`runner.py`, a LangGraph plan/act loop over an
+    orchestrator and executor agents), the structured tools (`nmap`, `webscan`,
+    `msf`), execution backends (`execution.py`: local Docker / remote Docker over
+    SSH / sim), the browser driver, pivoting, reporting, and the scope guardrail
+    (`scope.py`).
+  - `models/`, `repositories/` — async SQLAlchemy models and data access.
+  - `bus.py` — Redis pub/sub (with an in-process fallback) for events, chat, shell
+    I/O, and run control.
+  - `storage.py` — S3/MinIO for uploads, loot, and reports.
+  - `config.py`, `security.py`, `logs.py`, `steer.py`.
+
+## How a run flows
+
+1. The operator creates a session (scope, targets, ROE, an engagement brief, and
+   optional assessment files) and a run. The API persists it and enqueues
+   `run_engagement`.
+2. The worker's `LiveRunner` loads the run, starts the execution backend (a Kali
+   container), stages any assessment files into it, and runs the orchestrator loop.
+3. The orchestrator plans and delegates objectives to executor agents, which run
+   tools (scoped and shell-quoted) inside the container and record findings, loot,
+   and hosts. Every tool command is cancellable.
+4. Output streams to Redis; the API relays it to the console over WebSockets. The
+   operator can steer the live run through chat, or stop it.
+5. Every step checkpoints (SQLite), so a crash or restart resumes via
+   `resume_running`.
+
+## Cross-process coordination
+
+- **Events / chat / shell** — Redis pub/sub channels (`bus.py`), relayed to the
+  browser by the API's WebSocket routes.
+- **Run control** — the API publishes `pause`/`resume`/`stop`/`interrupt` on a
+  control channel; the worker's control watcher cancels in-flight work.
+- **Steer queue** — operator directives the orchestrator drains at each plan step.
+- **Checkpoints** — a SQLite store so runs survive restarts.

--- a/docs/HARDENING.md
+++ b/docs/HARDENING.md
@@ -1,0 +1,59 @@
+# Hardening & threat model
+
+REDCELL runs real offensive tooling, catches reverse shells, and stores provider
+API keys and SSH credentials. Treat it as sensitive infrastructure.
+
+> **Never expose REDCELL to the public internet.** Bind it to localhost or a
+> private network, put it behind a VPN or an authenticated reverse proxy with
+> TLS, and restrict who can reach it. The console has a single operator account;
+> it is not a multi-tenant, internet-facing service.
+
+## Threat model in one paragraph
+
+The console is the control plane for tools that can compromise machines. The main
+risks are: someone other than the operator reaching the console (or its API/WebSocket
+endpoints), a deployment running on the shipped/default secrets, the agent acting
+outside the authorized scope, and stored loot/credentials leaking. The items below
+address each.
+
+## Deploying safely
+
+- **Set `REDCELL_ENV` to something other than `dev`.** Outside dev the app refuses
+  to start on the built-in placeholder secrets and fails fast until real ones are
+  provided.
+- **Provide real secrets.** `REDCELL_JWT_SECRET`, `REDCELL_SECRET_KEY` (a Fernet
+  key), and `REDCELL_ADMIN_PASSWORD` — via env vars or `*_FILE` paths. The shipped
+  `docker compose up` generates unique ones into a volume on first run and prints
+  the admin password once; change it after logging in. Never reuse the dev values.
+- **Serve over HTTPS and keep secure cookies on.** The default compose sets
+  `REDCELL_COOKIE_SECURE=true`; the `docker-compose.local.yml` override turns it off
+  only for local http. Behind a TLS reverse proxy, keep it on.
+- **Lock down the network.** The API binds `127.0.0.1` by default. Do not publish
+  it, the worker, Postgres, Redis, or MinIO to untrusted networks. The Kali
+  container runs with host networking so it can reach targets and catch shells —
+  run REDCELL on a host you control and segment it from anything you care about.
+- **Scope every engagement.** Set the session scope; the engine enforces it in code
+  at the tool boundary (out-of-scope targets are refused, and an obviously
+  destructive `run_command` is blocked). An empty scope is unrestricted by design —
+  only leave it empty on a lab you own.
+- **Rotate provider keys** you add in Settings if the host is ever compromised;
+  they are encrypted at rest with `REDCELL_SECRET_KEY`, so that key is as sensitive
+  as the keys themselves.
+
+## Data retention
+
+- **Loot and credentials** the agent captures are stored in Postgres (the `loot`
+  table) and MinIO (the `loot` bucket), encrypted where marked sensitive. There is
+  no automatic expiry today — treat the database and buckets as holding live secrets
+  for the duration you keep them, and purge a session's data when the engagement
+  ends if you do not need the record.
+- **Reports** (PDF/JSON/SARIF) live in the `reports` bucket; delete them when no
+  longer needed.
+- **Checkpoints** (`redcell-checkpoints.sqlite`) contain run conversation state;
+  they are local to the worker host.
+
+## Authorized use only
+
+Point REDCELL only at systems you own or are contracted to test, and stay within
+the rules of engagement. See [SECURITY.md](../SECURITY.md) to report a vulnerability
+in REDCELL itself.


### PR DESCRIPTION
Closes #42.

- **`docs/ARCHITECTURE.md`** — components, how a run flows end to end, and the cross-process coordination (events/chat/shell, run control, steer queue, checkpoints).
- **`docs/HARDENING.md`** — a short threat model, a prominent "never expose to the internet without X", deploy-safely checklist (env, secrets, HTTPS/secure cookies, network isolation, scope), and a data-retention story for loot/credentials/reports.
- **`Procfile`** — a dev one-shot (`honcho start`) instead of three manual terminals.
- **README** links both docs and the Procfile option.

Docs/config only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)