### PR TITLE
test: authorization coverage and an orchestrator finish-first branch

### DIFF
--- a/apps/api/tests/test_authz.py
+++ b/apps/api/tests/test_authz.py
@@ -1,0 +1,26 @@
+"""Protected endpoints reject unauthenticated requests."""
+
+import asyncio
+
+from fastapi.testclient import TestClient
+from redcell_core import seed
+from redcell_core.db import engine
+
+
+async def _boot():
+    await seed.bootstrap()
+    await engine.dispose()
+
+
+from app.main import app  # noqa: E402
+
+
+def test_protected_endpoints_require_auth():
+    asyncio.run(_boot())
+    with TestClient(app) as c:
+        assert c.get("/api/v1/auth/me").status_code == 401
+        assert c.get("/api/v1/sessions").status_code == 401
+        assert c.post("/api/v1/sessions", json={"name": "x", "client": "y"}).status_code == 401
+        assert c.get("/api/v1/settings").status_code == 401
+        assert c.get("/api/v1/servers").status_code == 401
+        assert c.get("/api/v1/runs/run-x/chat").status_code == 401

--- a/packages/core/tests/test_orchestrator_finish.py
+++ b/packages/core/tests/test_orchestrator_finish.py
@@ -1,0 +1,59 @@
+"""Branch coverage: the orchestrator can finish on the first plan step without
+delegating any executor."""
+
+import asyncio
+
+import pytest
+from redcell_core.bus import Bus
+from redcell_core.db import session_scope
+from redcell_core.engine.execution import SimBackend
+from redcell_core.engine.runner import LiveRunner
+from redcell_core.repositories import agents as agents_repo
+from redcell_core.repositories import runs as runs_repo
+from redcell_core.repositories import sessions as sessions_repo
+
+
+class FinishFirstLLM:
+    async def complete(self, messages, tools=None, tool_choice="auto"):
+        return {"role": "assistant", "content": "",
+                "tool_calls": [{"id": "c_finish", "name": "finish",
+                                "arguments": '{"summary": "nothing to do"}'}]}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_finishes_without_delegating():
+    from redcell_core.config import settings as _s
+    _s.checkpoint_db = ""
+
+    bus = Bus("redis://127.0.0.1:1")  # memory backend
+    await bus.connect()
+
+    async with session_scope() as s:
+        ses = await sessions_repo.create(s, {"name": "FinishT", "client": "C",
+                                             "scope": ["*.t"], "targets": ["https://t"]})
+        run = await runs_repo.create(s, {"session_id": ses.id, "name": "r", "status": "running",
+                                         "phase": "Recon", "model": "kimi-k3"})
+        sid, rid = ses.id, run.id
+
+    runner = LiveRunner(bus, rid)
+    runner.llm = FinishFirstLLM()
+    runner.backend = SimBackend()
+    await asyncio.wait_for(runner.run(), timeout=30)
+
+    async with session_scope() as s:
+        run = await runs_repo.get(s, rid)
+        nodes, edges = await agents_repo.graph(s, rid)
+
+    assert run.status == "completed"
+    assert "recon" not in {a.name for a in nodes}
+    assert len(edges) == 0
+
+    from redcell_core.models import Agent, AgentEdge
+    from redcell_core.models import Run as _Run
+    from redcell_core.models import Session as _Session
+    from sqlalchemy import delete
+    async with session_scope() as s:
+        for m in (Agent, AgentEdge):
+            await s.execute(delete(m).where(m.run_id == rid))
+        await s.execute(delete(_Run).where(_Run.session_id == sid))
+        await s.execute(delete(_Session).where(_Session.id == sid))


### PR DESCRIPTION
Closes #40.

## Context
The audit flagged the plan/act decision logic and authz as untested. The plan/act loop is in fact already covered end-to-end by `test_engine_offline` (a scripted fake LLM drives delegate → run_command → record_finding → ask_operator → finish, asserting persistence + published events). This PR fills the remaining gaps:

- **`test_authz`** — protected REST endpoints (`/auth/me`, `/sessions` GET+POST, `/settings`, `/servers`, run chat) return 401 without a session.
- **`test_orchestrator_finish`** — the orchestrator can `finish` on the first plan step without delegating; the run completes with no executor node/edge (a branch the delegate-heavy offline test doesn't hit).

Scope-gating is covered by `test_runner_scope` (#34) and identity resolution by `test_auth_identity` (#33).

## Verified
Full backend suite **112 green**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)