### PR TITLE
feat(engine): parallel executors — keep planning while executors run

### DIFF
--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -46,6 +46,7 @@ from .tools import (
 
 MAX_ORCH_STEPS = 40
 MAX_EXEC_STEPS = 10
+MAX_CONCURRENT_EXECUTORS = 3
 
 # Fallback CVSS when a finding is recorded without a numeric score.
 _CVSS_BY_SEVERITY = {"critical": 9.5, "high": 8.0, "medium": 5.5, "low": 3.1, "info": 0.0}
@@ -143,8 +144,9 @@ class LiveRunner:
         self._listener_tasks: list[asyncio.Task] = []
         self._browser: BrowserManager | None = None
         self._pivot: pivot.PivotManager | None = None
-        self._current_cmd_task: asyncio.Task | None = None
-        self._interrupted = False
+        self._cmd_tasks: set[asyncio.Task] = set()
+        self._executor_tasks: set[asyncio.Task] = set()
+        self._executor_reports: list[dict[str, Any]] = []
         self._stop_requested = False
 
     async def run(self) -> None:
@@ -182,6 +184,8 @@ class LiveRunner:
                 await runs_repo.set_status(s, self.run_id, "failed")
         finally:
             for t in self._listener_tasks:
+                t.cancel()
+            for t in list(self._executor_tasks):
                 t.cancel()
             if self._pivot is not None:
                 try:
@@ -335,6 +339,9 @@ class LiveRunner:
         for d in directives:
             messages_in = messages_in + [{"role": "user", "content": f"[Operator steer] {d}"}]
             await self._event("orchestrator", "steer", f"operator: {d[:80]}")
+        for rep in self._drain_reports():
+            summary = json.dumps(rep["report"])[:1500]
+            messages_in = messages_in + [{"role": "user", "content": f"[Executor {rep['agent']} finished] {summary}"}]
         msg = await self._complete(messages_in, ORCHESTRATOR_TOOLS)
         messages = messages_in + [self._assistant_msg(msg)]
         return {**state, "messages": messages, "steps": state.get("steps", 0) + 1, "pending": msg}
@@ -358,7 +365,9 @@ class LiveRunner:
 
     async def _dispatch(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
         if name == "delegate":
-            return await self._delegate(args.get("agent", "executor"), args.get("objective", ""))
+            return self._launch_executor(args.get("agent", "executor"), args.get("objective", ""))
+        if name == "await_executors":
+            return await self._await_executors()
         if name == "record_finding":
             return await self._record_finding(args)
         if name == "record_loot":
@@ -374,6 +383,7 @@ class LiveRunner:
         if name == "ask_operator":
             return {"operator_reply": await self._ask_operator(args.get("question", ""), args.get("options"))}
         if name == "finish":
+            await self._await_executors()
             await self._event("orchestrator", "steer", "run finished: " + args.get("summary", ""))
             return {"ok": True}
         return {"error": f"unknown tool {name}"}
@@ -464,6 +474,8 @@ class LiveRunner:
         # hosts are reachable; discovered hosts are tagged as pivot-sourced.
         cmd = pivot.proxychains_wrap(cmd, pivoting)
         res = await self._exec(cmd)
+        if self._was_interrupted(res):
+            return {"interrupted": True}
         hosts = nmap.parse_nmap_xml(getattr(res, "output", "") or "")
         for h in hosts:
             await self._record_host({
@@ -486,6 +498,8 @@ class LiveRunner:
             return blocked
         cmd = webscan.build_nuclei_command(target, severity=args.get("severity"))
         res = await self._exec(cmd)
+        if self._was_interrupted(res):
+            return {"interrupted": True}
         findings = webscan.parse_nuclei_jsonl(getattr(res, "output", "") or "", target=target)
         for f in findings:
             await self._record_finding(f)
@@ -500,6 +514,8 @@ class LiveRunner:
         cmd = webscan.build_ffuf_command(url, wordlist=args.get("wordlist"),
                                          vhost=(args.get("mode") == "vhost"))
         res = await self._exec(cmd)
+        if self._was_interrupted(res):
+            return {"interrupted": True}
         results = webscan.parse_ffuf_json(getattr(res, "output", "") or "")
         return {"ok": True, "found": len(results), "results": results[:50]}
 
@@ -508,6 +524,8 @@ class LiveRunner:
         if not query:
             return {"error": "query required"}
         res = await self._exec(msf.build_msf_search(query))
+        if self._was_interrupted(res):
+            return {"interrupted": True}
         modules = msf.parse_msf_search(getattr(res, "output", "") or "")
         return {"ok": True, "count": len(modules), "modules": modules[:40]}
 
@@ -518,9 +536,45 @@ class LiveRunner:
         options = args.get("options") if isinstance(args.get("options"), dict) else {}
         cmd = msf.build_msf_run(module, {str(k): str(v) for k, v in options.items()})
         res = await self._exec(cmd)
+        if self._was_interrupted(res):
+            return {"interrupted": True}
         return {"ok": True, "output": (getattr(res, "output", "") or "")[-3000:]}
 
     # ---- executor sub-agent ----
+    def _launch_executor(self, agent_name: str, objective: str) -> dict[str, Any]:
+        running = [t for t in self._executor_tasks if not t.done()]
+        if len(running) >= MAX_CONCURRENT_EXECUTORS:
+            return {"at_capacity": True,
+                    "note": f"{len(running)} executors already running (max {MAX_CONCURRENT_EXECUTORS}); "
+                            "wait for one to finish (call await_executors) before delegating more"}
+        task = asyncio.create_task(self._run_executor(agent_name, objective))
+        self._executor_tasks.add(task)
+        task.add_done_callback(self._executor_tasks.discard)
+        return {"launched": agent_name, "objective": objective,
+                "note": "running in the background; its report arrives as a later message"}
+
+    async def _run_executor(self, agent_name: str, objective: str) -> None:
+        try:
+            report = await self._delegate(agent_name, objective)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            get_logger("engine.executor").exception("executor %s failed", agent_name)
+            report = {"executor": agent_name, "summary": f"executor error: {exc}"}
+        self._executor_reports.append({"agent": agent_name, "report": report})
+
+    def _drain_reports(self) -> list[dict[str, Any]]:
+        reports = self._executor_reports
+        self._executor_reports = []
+        return reports
+
+    async def _await_executors(self) -> dict[str, Any]:
+        running = [t for t in self._executor_tasks if not t.done()]
+        if running:
+            await asyncio.gather(*running, return_exceptions=True)
+        reports = self._drain_reports()
+        return {"executor_reports": reports} if reports else {"note": "no executor reports pending"}
+
     async def _delegate(self, agent_name: str, objective: str) -> dict[str, Any]:
         async with session_scope() as s:
             agent = await agents_repo.add(s, {"run_id": self.run_id, "name": agent_name, "role": "executor",
@@ -540,6 +594,7 @@ class LiveRunner:
         outputs: list[str] = []
         findings_here: list[str] = []
         calls = 0
+        interrupted = False
         for i in range(MAX_EXEC_STEPS):
             await self._gate()
             if await self._stopped():
@@ -574,6 +629,9 @@ class LiveRunner:
                     outputs.append(f"$ {cmd}\n{res.output}")
                     messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
                                      "content": res.output[:4000]})
+                    if self._was_interrupted(res):
+                        interrupted = True
+                        break
                 elif cname == "report":
                     report = cargs
                     fnd = cargs.get("finding")
@@ -601,11 +659,13 @@ class LiveRunner:
                     res = await self._dispatch_toolset(cname, cargs)
                     messages.append({"role": "tool", "tool_call_id": call["id"], "name": cname,
                                      "content": json.dumps(res)[:4000]})
-            if stop or self._interrupted:
+                    if res.get("interrupted"):
+                        interrupted = True
+                        break
+            if stop or interrupted:
                 break
 
-        if self._interrupted:
-            self._interrupted = False
+        if interrupted:
             await self._event(agent_name, "steer", "interrupted by operator; returning to the orchestrator")
 
         async with session_scope() as s:
@@ -658,9 +718,9 @@ class LiveRunner:
                 if action in ("stop", "interrupt"):
                     if action == "stop":
                         self._stop_requested = True
-                    task = self._current_cmd_task
-                    if task is not None and not task.done():
-                        task.cancel()
+                    for task in list(self._cmd_tasks):
+                        if not task.done():
+                            task.cancel()
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -680,18 +740,23 @@ class LiveRunner:
             self.assessment_files.append(name)
             await self._event("orchestrator", "steer", f"staged assessment file: {name}")
 
+    _INTERRUPT_MARK = "[interrupted by operator]"
+
     async def _exec(self, command: str, on_output=None) -> ExecResult:
         task = asyncio.create_task(self.backend.run(command, on_output=on_output))
-        self._current_cmd_task = task
+        self._cmd_tasks.add(task)
         try:
             return await task
         except asyncio.CancelledError:
             if task.cancelled():
-                self._interrupted = True
-                return ExecResult(exit_code=130, output="[interrupted by operator]")
+                return ExecResult(exit_code=130, output=self._INTERRUPT_MARK)
             raise
         finally:
-            self._current_cmd_task = None
+            self._cmd_tasks.discard(task)
+
+    @classmethod
+    def _was_interrupted(cls, res) -> bool:
+        return getattr(res, "exit_code", 0) == 130 and getattr(res, "output", "").startswith(cls._INTERRUPT_MARK)
 
     async def _gate(self) -> None:
         while True:

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -8,7 +8,7 @@ ORCHESTRATOR_TOOLS = [
         "type": "function",
         "function": {
             "name": "delegate",
-            "description": "Assign an objective to a specialised executor agent (recon, web-exploit, auth-tester, idor-hunter, etc.).",
+            "description": "Assign an objective to a specialised executor agent (recon, web-exploit, auth-tester, idor-hunter, etc.). Returns immediately: the executor runs in the background and its report arrives as a later '[Executor ... finished]' message. You may delegate several at once (up to the concurrency limit) and keep planning meanwhile.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -17,6 +17,14 @@ ORCHESTRATOR_TOOLS = [
                 },
                 "required": ["agent", "objective"],
             },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "await_executors",
+            "description": "Block until every running executor has finished and return their reports. Use when you have nothing to do until results come back.",
+            "parameters": {"type": "object", "properties": {}},
         },
     },
     {
@@ -342,7 +350,11 @@ def orchestrator_system(goal: str, scope: list[str], targets: list[str], roe: st
         f"Targets: {', '.join(targets) or 'unspecified'}\n"
         f"Rules of engagement: {roe or 'standard, no DoS, no data destruction'}\n"
         f"{context}\n"
-        "Work in small steps. Delegate one objective at a time. As you go, record every "
+        "Executors run concurrently and in the background: delegate returns immediately and you "
+        "keep planning, so while one executor runs a long scan you can delegate others (OSINT, "
+        "enumerating another surface, auth testing) up to the concurrency limit. Their reports come "
+        "back as '[Executor ... finished]' messages; call await_executors when you have nothing to do "
+        "until results return. As you go, record every "
         "confirmed vulnerability with record_finding (always include a realistic cvss score 0-10), "
         "every credential/hash/token/file you obtain with record_loot, and every host/endpoint/service "
         "you discover with record_host. These populate the operator's Findings, Loot, and Attack "

--- a/packages/core/tests/test_execution_cancel.py
+++ b/packages/core/tests/test_execution_cancel.py
@@ -26,15 +26,15 @@ async def test_exec_returns_interrupted_when_current_command_cancelled():
     r.backend = SleepBackend()
     call = asyncio.create_task(r._exec("sleep 30"))
     for _ in range(50):
-        if r._current_cmd_task is not None:
+        if r._cmd_tasks:
             break
         await asyncio.sleep(0.01)
-    assert r._current_cmd_task is not None
-    r._current_cmd_task.cancel()
+    assert r._cmd_tasks
+    for t in list(r._cmd_tasks):
+        t.cancel()
     res = await asyncio.wait_for(call, timeout=5)
     assert res.exit_code == 130
     assert "interrupted" in res.output
-    assert r._interrupted is True
     assert r.backend.cancelled is True
 
 

--- a/packages/core/tests/test_parallel_executors.py
+++ b/packages/core/tests/test_parallel_executors.py
@@ -1,0 +1,92 @@
+"""The orchestrator delegates multiple executors concurrently; their reports come
+back and both findings are recorded."""
+
+import asyncio
+import json
+import re
+
+import pytest
+from redcell_core.bus import Bus
+from redcell_core.db import session_scope
+from redcell_core.engine.execution import SimBackend
+from redcell_core.engine.runner import LiveRunner
+from redcell_core.repositories import agents as agents_repo
+from redcell_core.repositories import findings as findings_repo
+from redcell_core.repositories import runs as runs_repo
+from redcell_core.repositories import sessions as sessions_repo
+
+
+def _tc(name, args):
+    return {"role": "assistant", "content": "",
+            "tool_calls": [{"id": f"c_{name}", "name": name, "arguments": args}]}
+
+
+class ParallelLLM:
+    def __init__(self):
+        self.orch = 0
+        self.exec_counts = {}
+
+    async def complete(self, messages, tools=None, tool_choice="auto"):
+        system = messages[0]["content"]
+        if "orchestrator" in system:
+            self.orch += 1
+            if self.orch == 1:
+                return _tc("delegate", '{"agent": "recon", "objective": "map"}')
+            if self.orch == 2:
+                return _tc("delegate", '{"agent": "web-exploit", "objective": "exploit"}')
+            if self.orch == 3:
+                return _tc("await_executors", "{}")
+            return _tc("finish", '{"summary": "done"}')
+        n = self.exec_counts.get(system, 0) + 1
+        self.exec_counts[system] = n
+        agent = (re.search(r"'([^']+)' executor", system) or [None, "exec"])[1]
+        if n == 1:
+            return _tc("run_command", '{"command": "echo hi"}')
+        return _tc("report", json.dumps({"summary": "ok",
+                                         "finding": {"title": f"{agent} finding", "severity": "low",
+                                                     "location": "x"}}))
+
+
+@pytest.mark.asyncio
+async def test_two_executors_run_concurrently():
+    from redcell_core.config import settings as _s
+    _s.checkpoint_db = ""
+
+    bus = Bus("redis://127.0.0.1:1")  # memory backend
+    await bus.connect()
+
+    async with session_scope() as s:
+        ses = await sessions_repo.create(s, {"name": "ParT", "client": "C",
+                                             "scope": ["*.t"], "targets": ["https://t"]})
+        run = await runs_repo.create(s, {"session_id": ses.id, "name": "r", "status": "running",
+                                         "phase": "Recon", "model": "kimi-k3"})
+        sid, rid = ses.id, run.id
+
+    runner = LiveRunner(bus, rid)
+    runner.llm = ParallelLLM()
+    runner.backend = SimBackend()
+    await asyncio.wait_for(runner.run(), timeout=30)
+
+    async with session_scope() as s:
+        run = await runs_repo.get(s, rid)
+        nodes, edges = await agents_repo.graph(s, rid)
+        finds = await findings_repo.list_for_session(s, sid)
+
+    names = {a.name for a in nodes}
+    titles = {f.title for f in finds}
+    assert run.status == "completed"
+    assert "recon" in names and "web-exploit" in names
+    assert len(edges) >= 2
+    assert "recon finding" in titles and "web-exploit finding" in titles
+
+    from redcell_core.models import Agent, AgentEdge, Finding, Shell
+    from redcell_core.models import Run as _Run
+    from redcell_core.models import Session as _Session
+    from sqlalchemy import delete
+    async with session_scope() as s:
+        for m in (Agent, AgentEdge):
+            await s.execute(delete(m).where(m.run_id == rid))
+        for m in (Finding, Shell):
+            await s.execute(delete(m).where(m.session_id == sid))
+        await s.execute(delete(_Run).where(_Run.session_id == sid))
+        await s.execute(delete(_Session).where(_Session.id == sid))


### PR DESCRIPTION
Closes #32.

## Problem
The orchestrator loop was strictly sequential: `delegate` awaited an executor's full run, so a multi-minute `nmap` blocked the entire run — no OSINT, no other surfaces, nothing else happened meanwhile.

## Change
- **Non-blocking delegation.** `delegate` launches an executor as a background task (up to `MAX_CONCURRENT_EXECUTORS=3`) and returns immediately. The orchestrator keeps planning and can delegate several at once.
- **Report injection.** Completed executor reports are folded into the next plan step as `[Executor … finished]` messages (like operator steers).
- **`await_executors` tool** blocks for outstanding results; **`finish` drains stragglers** so their findings are always recorded before the run completes.
- **Concurrency-safe cancellation.** The single `_current_cmd_task` + shared `_interrupted` flag (which would race across concurrent executors) is replaced with a `_cmd_tasks` set that stop/interrupt cancels; each executor detects its own interruption locally from the command result. No shared mutable interrupt state.

Prompt + tool schema updated so the model knows executors run concurrently and how to await them.

## Verified
- New `test_parallel_executors`: two executors run concurrently, both reports return, both findings recorded, run completes.
- Existing `test_engine_offline` (full plan/act loop) still passes with non-blocking delegation, as do the cancellation tests (updated to the task-set model).
- Full backend suite **111 green**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)