### PR TITLE
feat(engine): advance the engagement phase as the run progresses

### DIFF
--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -366,6 +366,8 @@ class LiveRunner:
     async def _dispatch(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
         if name == "delegate":
             return self._launch_executor(args.get("agent", "executor"), args.get("objective", ""))
+        if name == "set_phase":
+            return {"phase": await self._advance_phase(str(args.get("phase", "")))}
         if name == "await_executors":
             return await self._await_executors()
         if name == "record_finding":
@@ -384,6 +386,7 @@ class LiveRunner:
             return {"operator_reply": await self._ask_operator(args.get("question", ""), args.get("options"))}
         if name == "finish":
             await self._await_executors()
+            await self._advance_phase("Reporting")
             await self._event("orchestrator", "steer", "run finished: " + args.get("summary", ""))
             return {"ok": True}
         return {"error": f"unknown tool {name}"}
@@ -791,6 +794,8 @@ class LiveRunner:
             })
             fid, sev = finding.id, finding.severity
         await self._event("orchestrator", "finding", f"[{sev}] {title} @ {loc}")
+        if self.kind != "code":
+            await self._advance_phase("Exploitation")
         return {"id": fid, "recorded": True}
 
     async def _record_loot(self, args: dict[str, Any]) -> dict[str, Any]:
@@ -840,6 +845,7 @@ class LiveRunner:
         result = await pm.open(shell_id)
         if result.get("ok"):
             self._pivot = pm
+            await self._advance_phase("Post-Exploitation")
             await self._event("orchestrator", "net", f"pivot up through {shell_id} -> {result.get('socks')}")
         else:
             await self._event("orchestrator", "steer", f"pivot failed: {result.get('detail', 'unknown')}")
@@ -870,6 +876,7 @@ class LiveRunner:
             status = await get_listener_manager().start(lid)
             callback = f"{settings.callback_host}:{port}"
         await self._event("listener", "net", f"listener {bind} ({status}); reverse-shell callback -> {callback}")
+        await self._advance_phase("Post-Exploitation")
         return {"listenerId": lid, "bind": bind, "status": status, "callback": callback,
                 "note": "Use this callback address (host:port) in the reverse-shell payload."}
 
@@ -937,6 +944,7 @@ class LiveRunner:
                                 lst.sessions_count += 1
                         await self._event("listener", "net",
                                           f"caught reverse shell from {remote} on {self.server.host}:{port}")
+                        await self._advance_phase("Post-Exploitation")
 
         out_t = asyncio.create_task(pump_out())
         in_t = asyncio.create_task(pump_in())
@@ -1001,6 +1009,16 @@ class LiveRunner:
             async with session_scope() as s:
                 await runs_repo.set_meters(s, self.run_id, tok, cost, 0)
         return out
+
+    async def _advance_phase(self, phase: str) -> str | None:
+        """Move the operator-visible engagement phase forward and log the transition."""
+        async with session_scope() as s:
+            run = await runs_repo.get(s, self.run_id)
+            before = run.phase if run else None
+            effective = await runs_repo.set_phase(s, self.run_id, phase)
+        if effective and effective != before:
+            await self._event("orchestrator", "steer", f"phase: {effective}")
+        return effective
 
     async def _status(self, text: str) -> None:
         await self._event("orchestrator", "steer", text)

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -174,7 +174,10 @@ class LiveRunner:
             await self._orchestrate()
             async with session_scope() as s:
                 run = await runs_repo.get(s, self.run_id)
-                if not self._stop_requested and run is not None and run.status != "stopped":
+                completing = not self._stop_requested and run is not None and run.status != "stopped"
+            if completing:
+                await self._advance_phase("Reporting")
+                async with session_scope() as s:
                     await runs_repo.set_status(s, self.run_id, "completed")
         except asyncio.CancelledError:
             raise
@@ -386,7 +389,6 @@ class LiveRunner:
             return {"operator_reply": await self._ask_operator(args.get("question", ""), args.get("options"))}
         if name == "finish":
             await self._await_executors()
-            await self._advance_phase("Reporting")
             await self._event("orchestrator", "steer", "run finished: " + args.get("summary", ""))
             return {"ok": True}
         return {"error": f"unknown tool {name}"}

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -22,6 +22,21 @@ ORCHESTRATOR_TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "set_phase",
+            "description": "Update the engagement phase shown on the operator's console. Phases only move forward (Reconnaissance -> Exploitation -> Post-Exploitation -> Reporting); call it as the engagement progresses, e.g. mark Exploitation once you start attacking a confirmed weakness.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "phase": {"type": "string",
+                              "enum": ["Reconnaissance", "Exploitation", "Post-Exploitation", "Reporting"]},
+                },
+                "required": ["phase"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "await_executors",
             "description": "Block until every running executor has finished and return their reports. Use when you have nothing to do until results come back.",
             "parameters": {"type": "object", "properties": {}},
@@ -369,6 +384,8 @@ def orchestrator_system(goal: str, scope: list[str], targets: list[str], roe: st
         "executors to scan or reach the internal hosts (nmap_scan is routed through the pivot "
         "automatically) and record what you find with record_host (source 'pivot'). Internal hosts "
         "still need to be in scope. Call close_pivot when the internal work is done.\n\n"
+        "Keep the operator's phase indicator current with set_phase as the engagement moves from "
+        "Reconnaissance to Exploitation, Post-Exploitation, and Reporting (it only moves forward).\n\n"
         "The operator may send you steering directives at any time (they appear as '[Operator steer]' "
         "messages); follow them. Call finish when the objective is met or no safe progress remains.\n\n"
         "Write any prose in plain text. Do not use em-dashes; use commas, periods, or parentheses instead."

--- a/packages/core/redcell_core/repositories/runs.py
+++ b/packages/core/redcell_core/repositories/runs.py
@@ -52,14 +52,19 @@ async def set_status(s: AsyncSession, rid: str, status: str) -> Run | None:
 async def set_phase(s: AsyncSession, rid: str, phase: str) -> str | None:
     """Advance the run's phase along the engagement pipeline, forward only:
     Reconnaissance -> Exploitation -> Post-Exploitation -> Reporting. Unknown phases
-    and backward moves are ignored. Returns the effective phase, or None if missing."""
+    and backward moves are ignored. Returns the effective phase, or None if missing.
+
+    The advance is one conditional UPDATE that matches only lower-ranked stored
+    phases, so concurrent milestones cannot race the phase backward."""
+    target = _PHASE_RANK.get(phase)
+    if target is not None:
+        lower = [p for p, r in _PHASE_RANK.items() if r < target]
+        await s.execute(update(Run).where(Run.id == rid, Run.phase.in_(lower)).values(phase=phase))
+        await s.flush()
     row = await s.get(Run, rid)
     if row is None:
         return None
-    target = _PHASE_RANK.get(phase)
-    if target is not None and target > _PHASE_RANK.get(row.phase, 0):
-        row.phase = phase
-        await s.flush()
+    await s.refresh(row)
     return row.phase
 
 

--- a/packages/core/redcell_core/repositories/runs.py
+++ b/packages/core/redcell_core/repositories/runs.py
@@ -6,6 +6,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ..models import Run
 from . import ids
 
+PHASES = ["Reconnaissance", "Exploitation", "Post-Exploitation", "Reporting"]
+_PHASE_RANK = {p: i for i, p in enumerate(PHASES)}
+
 
 async def list_for_session(s: AsyncSession, sid: str, *, status: str | None = None,
                            q: str | None = None, limit: int | None = None, offset: int = 0) -> list[Run]:
@@ -44,6 +47,20 @@ async def set_status(s: AsyncSession, rid: str, status: str) -> Run | None:
         row.status = status
         await s.flush()
     return row
+
+
+async def set_phase(s: AsyncSession, rid: str, phase: str) -> str | None:
+    """Advance the run's phase along the engagement pipeline, forward only:
+    Reconnaissance -> Exploitation -> Post-Exploitation -> Reporting. Unknown phases
+    and backward moves are ignored. Returns the effective phase, or None if missing."""
+    row = await s.get(Run, rid)
+    if row is None:
+        return None
+    target = _PHASE_RANK.get(phase)
+    if target is not None and target > _PHASE_RANK.get(row.phase, 0):
+        row.phase = phase
+        await s.flush()
+    return row.phase
 
 
 async def set_meters(s: AsyncSession, rid: str, tokens_delta: int, cost_delta: float, elapsed_delta: int) -> None:

--- a/packages/core/tests/test_phase_advances.py
+++ b/packages/core/tests/test_phase_advances.py
@@ -1,0 +1,92 @@
+"""The engagement phase advances as the run progresses and never moves backward."""
+
+import asyncio
+
+import pytest
+from redcell_core.bus import Bus
+from redcell_core.db import session_scope
+from redcell_core.engine.execution import SimBackend
+from redcell_core.engine.runner import LiveRunner
+from redcell_core.repositories import runs as runs_repo
+from redcell_core.repositories import sessions as sessions_repo
+
+
+class PhaseLLM:
+    """set_phase -> Exploitation, record a finding, then finish."""
+
+    def __init__(self):
+        self.n = 0
+
+    async def complete(self, messages, tools=None, tool_choice="auto"):
+        self.n += 1
+        if self.n == 1:
+            return _tc("set_phase", '{"phase": "Exploitation"}')
+        if self.n == 2:
+            return _tc("record_finding",
+                       '{"title": "SQLi in login", "severity": "high", "location": "/login"}')
+        return _tc("finish", '{"summary": "done"}')
+
+
+def _tc(name, args):
+    return {"role": "assistant", "content": "",
+            "tool_calls": [{"id": f"c_{name}", "name": name, "arguments": args}]}
+
+
+@pytest.mark.asyncio
+async def test_phase_advances_to_reporting():
+    from redcell_core.config import settings as _s
+    _s.checkpoint_db = ""
+
+    bus = Bus("redis://127.0.0.1:1")
+    await bus.connect()
+
+    async with session_scope() as s:
+        ses = await sessions_repo.create(s, {"name": "PhaseT", "client": "C",
+                                             "scope": ["*.t"], "targets": ["https://t"]})
+        run = await runs_repo.create(s, {"session_id": ses.id, "name": "r", "status": "running",
+                                         "phase": "Reconnaissance", "model": "kimi-k3"})
+        sid, rid = ses.id, run.id
+
+    runner = LiveRunner(bus, rid)
+    runner.llm = PhaseLLM()
+    runner.backend = SimBackend()
+    await asyncio.wait_for(runner.run(), timeout=30)
+
+    async with session_scope() as s:
+        run = await runs_repo.get(s, rid)
+
+    assert run.status == "completed"
+    assert run.phase == "Reporting"
+
+    from redcell_core.models import Agent, AgentEdge, Finding, Shell
+    from redcell_core.models import Run as _Run
+    from redcell_core.models import Session as _Session
+    from sqlalchemy import delete
+    async with session_scope() as s:
+        for m in (Agent, AgentEdge):
+            await s.execute(delete(m).where(m.run_id == rid))
+        for m in (Finding, Shell):
+            await s.execute(delete(m).where(m.session_id == sid))
+        await s.execute(delete(_Run).where(_Run.session_id == sid))
+        await s.execute(delete(_Session).where(_Session.id == sid))
+
+
+@pytest.mark.asyncio
+async def test_set_phase_is_forward_only():
+    async with session_scope() as s:
+        ses = await sessions_repo.create(s, {"name": "FwdT", "client": "C",
+                                             "scope": ["*.t"], "targets": ["https://t"]})
+        run = await runs_repo.create(s, {"session_id": ses.id, "name": "r", "status": "running",
+                                         "phase": "Reconnaissance", "model": "kimi-k3"})
+        rid, sid = run.id, ses.id
+
+        assert await runs_repo.set_phase(s, rid, "Post-Exploitation") == "Post-Exploitation"
+        assert await runs_repo.set_phase(s, rid, "Reconnaissance") == "Post-Exploitation"
+        assert await runs_repo.set_phase(s, rid, "bogus") == "Post-Exploitation"
+        assert await runs_repo.set_phase(s, rid, "Reporting") == "Reporting"
+
+        from redcell_core.models import Run as _Run
+        from redcell_core.models import Session as _Session
+        from sqlalchemy import delete
+        await s.execute(delete(_Run).where(_Run.session_id == sid))
+        await s.execute(delete(_Session).where(_Session.id == sid))


### PR DESCRIPTION
## Why

The run **Phase** shown on the operator console (SessionTopbar) was stuck on `Reconnaissance` for every run. Grepping the tree, `phase` was written exactly once (the model default in `models/run.py`) and never touched again by the engine, so it was a cosmetic placeholder that never reflected real progress.

## What

Advance the phase along a monotonic engagement pipeline: **Reconnaissance → Exploitation → Post-Exploitation → Reporting**.

- **`runs_repo.set_phase`** — forward-only setter over a ranked pipeline; ignores unknown phases and never moves backward, so the indicator can't flap.
- **Deterministic milestones** (robust even when the model ignores instructions):
  - first `record_finding` → **Exploitation** (network runs only; "Exploitation" doesn't fit a SAST review)
  - `start_listener` / `open_pivot` / caught reverse shell → **Post-Exploitation**
  - `finish` → **Reporting**
- **`set_phase` orchestrator tool** — lets a cooperative model mark Exploitation the moment it starts attacking a confirmed weakness, before the first finding lands. Same forward-only semantics.
- Each transition emits an activity event (`phase: <name>`) for the run log.

No frontend change: the console's Phase metric already polls the run every 4s and renders `run.phase`.

## Tests

`tests/test_phase_advances.py`:
- a scripted orchestrator (`set_phase` → finding → finish) ends at `Reporting`
- `set_phase` is forward-only (rejects backward + unknown values)

`ruff` clean; 26 engine/repo tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added engagement phase tracking across Reconnaissance, Exploitation, Post-Exploitation, and Reporting.
  * Phase updates now advance automatically as key engagement milestones occur, including findings, pivots, listeners, reverse-shell connections, and completion.
  * Added support for keeping the operator’s phase indicator current during an engagement.
* **Improvements**
  * Phase transitions only move forward, preventing invalid or backward updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->