### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.2.0"
+version = "0.3.0"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.2.0"
+version = "0.3.0"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/web": {
       "name": "@redcell/web",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "dependencies": {
         "@novnc/novnc": "1.7.0",
         "@redcell/api-client": "workspace:*",

--- a/uv.lock
+++ b/uv.lock
@@ -2117,7 +2117,7 @@ wheels = [
 
 [[package]]
 name = "redcell-api"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "apps/api" }
 dependencies = [
     { name = "fastapi" },
@@ -2197,7 +2197,7 @@ live = [
 
 [[package]]
 name = "redcell-worker"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "apps/worker" }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Cuts the **v0.3.0** release. Bumps `redcell-api`, `redcell-worker`, and `@redcell/web` to `0.3.0` and syncs `uv.lock`.

Once merged, tagging `v0.3.0` on the merge commit triggers `.github/workflows/release.yml`, which builds and pushes the api/worker/web images to GHCR (kali is unchanged at 1.0.0, so it is skipped) and publishes the GitHub release with auto-generated notes plus the image table.

## Highlights since v0.2.0
- **Operator UI rebuild** (#56): collapsible app shell, tabbed/resizable console, all pages (overview, sessions, findings, reports, servers, proxies, settings), light + dark themes.
- **Engine** (#53, #54, #55): parallel executors that keep planning while executors run; phase advances as the run progresses; hardened name-based-vhost and network engagements.
- **Security** (#43, #47, #48): no usable default secrets outside dev, per-deploy generation in compose; session scope enforced at the tool boundary; rate limits on login and draft chat.
- **Resilience / scaling / observability** (#46, #49, #50): LLM retries + timeout; structured logging of swallowed errors; configurable worker `max_jobs`.
- **Auth / models / docs** (#45, #44, #51, #52): resolve the real seeded user; GLM-5.3 model; ARCHITECTURE + HARDENING docs and dev Procfile; expanded authorization test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API, web app, and worker package versions to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->