### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.3.0"
+version = "0.3.1"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.3.0"
+version = "0.3.1"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/web": {
       "name": "@redcell/web",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@novnc/novnc": "1.7.0",
         "@redcell/api-client": "workspace:*",

--- a/uv.lock
+++ b/uv.lock
@@ -2117,7 +2117,7 @@ wheels = [
 
 [[package]]
 name = "redcell-api"
-version = "0.3.0"
+version = "0.3.1"
 source = { virtual = "apps/api" }
 dependencies = [
     { name = "fastapi" },
@@ -2197,7 +2197,7 @@ live = [
 
 [[package]]
 name = "redcell-worker"
-version = "0.3.0"
+version = "0.3.1"
 source = { virtual = "apps/worker" }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Patch release to republish origin-agnostic container images so the reverse-proxy self-host flow (`deploy.sh`, PR #58) works from the published `:latest` / `0.3.1` tags. Bumps `redcell-api`, `redcell-worker`, and `@redcell/web` to `0.3.1` and syncs `uv.lock` + `bun.lock`.

Tagging `v0.3.1` after merge triggers `.github/workflows/release.yml`, which rebuilds and pushes the api/worker/web images (kali unchanged at 1.0.0, skipped) and publishes the GitHub release.

## Since v0.3.0
- Reverse proxy for single-origin self-hosting: Caddy edge, origin-agnostic web build, files streamed through the API (MinIO stays internal), and an interactive `deploy.sh` that installs Docker and optionally provisions HTTPS for a domain (#58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV