### PR TITLE
feat(deploy): make the deploy work in any case (direct, domain, behind a proxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,10 @@ REDCELL_CORS_ORIGINS=http://localhost:5183
 # Reverse-proxy site address. A domain (redcell.example.com) gets automatic HTTPS;
 # ":80" serves plain HTTP on the server IP. deploy.sh writes this for you.
 SITE_ADDRESS=:80
-# Login cookie flag. Must be false over plain HTTP on an IP, true over HTTPS.
+# Which Caddy config to mount. "Caddyfile" for direct access (no domain or a
+# domain pointed straight here). "Caddyfile.proxy" when a proxy or CDN
+# (Cloudflare, Coolify, a load balancer) terminates TLS in front of this server.
+CADDYFILE=Caddyfile
+# Login cookie flag. Must be false over plain HTTP on an IP, true over HTTPS
+# (including behind a proxy that serves HTTPS to the browser).
 REDCELL_COOKIE_SECURE=false

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The script installs Docker if it is missing, then asks how REDCELL will be reach
 
 1. **This server directly, no domain** — plain HTTP on the server IP. Good for a quick trial or a private network.
 2. **A domain pointed straight at this server** — Caddy provisions a Let's Encrypt certificate automatically (point an A or AAAA record at the server first) and serves `https://your-domain`.
-3. **A domain behind Cloudflare, Coolify, or another proxy or CDN** — the proxy provides the public HTTPS certificate and forwards to this server. The origin serves both plain HTTP and its own HTTPS, so it works however the proxy connects.
+3. **A domain behind Cloudflare, Coolify, or another proxy or CDN** — the proxy provides the public HTTPS certificate and forwards to this server. The origin serves both plain HTTP (:80) and a self-signed HTTPS (:443), so it works with a proxy that connects over HTTP or one that accepts the origin's certificate (for Cloudflare, SSL mode Full; Full (strict) needs a Cloudflare Origin Certificate).
 
 It writes your answers to `.env`, pulls the images, and starts the stack. Read the generated admin password with `docker compose logs init-secrets`, then sign in as `admin` and change it. To change how it is reached later, just re-run `./deploy.sh` and pick a different option.
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,15 @@ cd redcell
 ./deploy.sh
 ```
 
-The script installs Docker if it is missing, then asks whether you have a domain. With one, Caddy provisions a TLS certificate automatically (point an A or AAAA record at the server first) and serves `https://your-domain`. Without one, it serves plain HTTP on the server IP. It writes your answers to `.env`, pulls the images, and starts the stack. Read the generated admin password with `docker compose logs init-secrets`, then sign in as `admin` and change it.
+The script installs Docker if it is missing, then asks how REDCELL will be reached:
 
-Only ports 80 and 443 are published; Postgres, Redis, MinIO, the API, and the web app stay on the internal network. Stored files are streamed through the API, so object storage is never exposed.
+1. **This server directly, no domain** — plain HTTP on the server IP. Good for a quick trial or a private network.
+2. **A domain pointed straight at this server** — Caddy provisions a Let's Encrypt certificate automatically (point an A or AAAA record at the server first) and serves `https://your-domain`.
+3. **A domain behind Cloudflare, Coolify, or another proxy or CDN** — the proxy provides the public HTTPS certificate and forwards to this server. The origin serves both plain HTTP and its own HTTPS, so it works however the proxy connects.
+
+It writes your answers to `.env`, pulls the images, and starts the stack. Read the generated admin password with `docker compose logs init-secrets`, then sign in as `admin` and change it. To change how it is reached later, just re-run `./deploy.sh` and pick a different option.
+
+Only ports 80 and 443 are published; Postgres, Redis, MinIO, the API, and the web app stay on the internal network. Stored files are streamed through the API, so object storage is never exposed. See [docs/DEPLOY.md](docs/DEPLOY.md) for the details of each mode.
 
 ## Configuration
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ ask_domain() {
 }
 
 server_ip() {
-  curl -fsS https://api.ipify.org 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}' || echo "your-server-ip"
+  curl -fsS --connect-timeout 5 --max-time 8 https://api.ipify.org 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}' || echo "your-server-ip"
 }
 
 if ! command -v docker >/dev/null 2>&1; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 # REDCELL deployment helper.
 # Fronts the stack with a Caddy reverse proxy so the web app and API share one
-# origin (no CORS), and optionally provisions HTTPS for a domain.
+# origin (no CORS). Works with no domain, with a domain (automatic HTTPS), or
+# behind a proxy or CDN that terminates TLS.
 
 cd "$(dirname "$0")"
 ENV_FILE=".env"
@@ -19,6 +20,18 @@ set_env() {
   else
     printf '%s=%s\n' "$key" "$val" >> "$ENV_FILE"
   fi
+}
+
+ask_domain() {
+  local d=""
+  while ! printf '%s' "$d" | grep -qE '^[A-Za-z0-9][A-Za-z0-9.-]*$'; do
+    d=$(ask "  Domain (e.g. redcell.example.com): " "")
+  done
+  printf '%s' "$d"
+}
+
+server_ip() {
+  curl -fsS https://api.ipify.org 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}' || echo "your-server-ip"
 }
 
 if ! command -v docker >/dev/null 2>&1; then
@@ -44,22 +57,38 @@ say "=================================================="
 say " REDCELL deploy"
 say "=================================================="
 say ""
+say "How will REDCELL be reached?"
+say "  1) This server directly, no domain (plain HTTP on the server IP)"
+say "  2) A domain pointed straight at this server (automatic HTTPS)"
+say "  3) A domain behind Cloudflare, Coolify, or another proxy or CDN (the proxy provides HTTPS)"
+mode=$(ask "Choose [1/2/3] (default 1): " "1")
 
-has_domain=$(ask "Do you have a domain pointing at this server? [y/N]: " "n")
-case "$has_domain" in
-  y|Y|yes|YES)
-    domain=""
-    while ! printf '%s' "$domain" | grep -qE '^[A-Za-z0-9][A-Za-z0-9.-]*$'; do
-      domain=$(ask "  Domain (e.g. redcell.example.com): " "")
-    done
-    set_env "SITE_ADDRESS" "$domain"
-    set_env "REDCELL_COOKIE_SECURE" "true"
-    set_env "REDCELL_CORS_ORIGINS" "https://${domain}"
-    set_env "REDCELL_ENV" "production"
+case "$mode" in
+  2)
+    say ""
+    domain=$(ask_domain)
+    set_env SITE_ADDRESS "$domain"
+    set_env CADDYFILE "Caddyfile"
+    set_env REDCELL_COOKIE_SECURE "true"
+    set_env REDCELL_CORS_ORIGINS "https://${domain}"
+    set_env REDCELL_ENV "production"
     url="https://${domain}"
     say ""
-    say "Point an A/AAAA DNS record for ${domain} at this server before continuing."
-    say "Caddy will request a TLS certificate automatically on first request."
+    say "Point an A or AAAA record for ${domain} at this server before continuing."
+    say "Caddy requests a TLS certificate automatically on first request."
+    ;;
+  3)
+    say ""
+    domain=$(ask_domain)
+    set_env SITE_ADDRESS "$domain"
+    set_env CADDYFILE "Caddyfile.proxy"
+    set_env REDCELL_COOKIE_SECURE "true"
+    set_env REDCELL_CORS_ORIGINS "https://${domain}"
+    set_env REDCELL_ENV "production"
+    url="https://${domain}"
+    say ""
+    say "Point your proxy or CDN at this server. On Cloudflare, set the SSL mode to Full."
+    say "The proxy provides the public certificate; the origin serves its own."
     ;;
   *)
     say ""
@@ -68,15 +97,16 @@ case "$has_domain" in
     ok=$(ask "Continue with an insecure HTTP deployment? [y/N]: " "n")
     case "$ok" in
       y|Y|yes|YES) ;;
-      *) say "Aborted. Re-run and choose a domain for automatic HTTPS."; exit 1 ;;
+      *) say "Aborted. Re-run and choose a domain for HTTPS."; exit 1 ;;
     esac
-    ip=$(curl -fsS https://api.ipify.org 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}' || echo "your-server-ip")
+    ip=$(server_ip)
     host="$ip"
     case "$ip" in *:*) host="[$ip]" ;; esac
-    set_env "SITE_ADDRESS" ":80"
-    set_env "REDCELL_COOKIE_SECURE" "false"
-    set_env "REDCELL_CORS_ORIGINS" "http://${host}"
-    set_env "REDCELL_ENV" "production"
+    set_env SITE_ADDRESS ":80"
+    set_env CADDYFILE "Caddyfile"
+    set_env REDCELL_COOKIE_SECURE "false"
+    set_env REDCELL_CORS_ORIGINS "http://${host}"
+    set_env REDCELL_ENV "production"
     url="http://${host}"
     ;;
 esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
     environment:
       SITE_ADDRESS: ${SITE_ADDRESS:-:80}
     volumes:
-      - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./docker/caddy/${CADDYFILE:-Caddyfile}:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,4 +1,4 @@
-{$SITE_ADDRESS} {
+(app) {
 	encode gzip zstd
 
 	handle /api/* {
@@ -8,4 +8,8 @@
 	handle {
 		reverse_proxy web:80
 	}
+}
+
+{$SITE_ADDRESS} {
+	import app
 }

--- a/docker/caddy/Caddyfile.proxy
+++ b/docker/caddy/Caddyfile.proxy
@@ -1,0 +1,20 @@
+(app) {
+	encode gzip zstd
+
+	handle /api/* {
+		reverse_proxy api:8080
+	}
+
+	handle {
+		reverse_proxy web:80
+	}
+}
+
+http://{$SITE_ADDRESS} {
+	import app
+}
+
+https://{$SITE_ADDRESS} {
+	tls internal
+	import app
+}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -11,3 +11,5 @@ Caddy is the only service that publishes ports (80 and 443). It serves the web a
 Postgres, Redis, MinIO, the API, and the web app stay on the internal Docker network and are never exposed to the internet.
 
 Stored files (reports, loot, uploads) are streamed through the API, so MinIO never needs a public route.
+
+## What gets deployed

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -78,7 +78,7 @@ This mode mounts `docker/caddy/Caddyfile.proxy` by setting `CADDYFILE=Caddyfile.
 
 When a domain's DNS record is proxied (the orange cloud), it resolves to Cloudflare, not your server. Choose mode 3.
 
-Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the origin over HTTPS and accepts the self-signed certificate Caddy serves.
+Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the origin over HTTPS and accepts the self-signed certificate Caddy serves. Note that **Full** encrypts the origin hop but does not authenticate it (the self-signed certificate is not validated). If you need the origin authenticated, install a Cloudflare Origin Certificate and use **Full (strict)**.
 
 **Flexible** also works: Cloudflare connects to the origin over plain HTTP on :80, which the proxy config serves too.
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -150,3 +150,9 @@ docker compose exec -T postgres pg_dump -U redcell redcell > redcell.sql
 ```
 
 ## Verifying the deployment
+
+Check every container is up and the infra ones are healthy:
+
+```bash
+docker compose ps
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -175,3 +175,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **Cloudflare 526.** Full (strict) rejected the self-signed origin certificate. Switch Cloudflare to Full, install a Cloudflare Origin Certificate, or use DNS-only plus mode 2.
 
 **Login does not stick.** Over plain HTTP on an IP the secure cookie is dropped. Use a domain, or accept mode 1 which sets the cookie insecure.
+
+**CORS errors.** All traffic should go through Caddy on one origin. Reach REDCELL at its `SITE_ADDRESS`, not the API port directly.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -28,3 +28,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 
 - A Linux server you can SSH into as root (or a sudo user). 2 GB RAM is enough to start; more helps when engagements run.
 - Docker Engine with the Compose plugin. `deploy.sh` installs both if they are missing.
+- Ports 80 and 443 free on the host (nothing else bound to them).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -181,3 +181,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **Something is failing.** Read the logs of a service, for example `docker compose logs api` or `docker compose logs caddy`.
 
 ## Security notes
+
+Secrets are generated per deployment and stored in the `redcell_secrets` volume. There are no usable default credentials outside dev.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -79,3 +79,5 @@ This mode mounts `docker/caddy/Caddyfile.proxy` by setting `CADDYFILE=Caddyfile.
 When a domain's DNS record is proxied (the orange cloud), it resolves to Cloudflare, not your server. Choose mode 3.
 
 Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the origin over HTTPS and accepts the self-signed certificate Caddy serves.
+
+**Flexible** also works: Cloudflare connects to the origin over plain HTTP on :80, which the proxy config serves too.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -57,3 +57,5 @@ Serves plain HTTP on the server IP. Good for a quick trial or a trusted private 
 Credentials travel unencrypted, so `deploy.sh` asks you to confirm. Do not use this over the public internet for anything real.
 
 You reach it at `http://SERVER_IP`.
+
+### 2. A domain pointed straight at this server

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -203,3 +203,6 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 **How do I move to a new domain?** Re-run `./deploy.sh`, choose the mode, and enter the new domain. The stack restarts with the new certificate.
 
 ## More
+
+- [Architecture](ARCHITECTURE.md) — how the components fit together.
+- [Hardening](HARDENING.md) — secrets, scope, and data retention.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -7,3 +7,5 @@ The short version lives in the [README](../README.md#deploy-self-host); this gui
 ## Architecture
 
 Caddy is the only service that publishes ports (80 and 443). It serves the web app and proxies `/api/*` to the API on the same origin, so there is no CORS to configure.
+
+Postgres, Redis, MinIO, the API, and the web app stay on the internal Docker network and are never exposed to the internet.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -187,3 +187,5 @@ Secrets are generated per deployment and stored in the `redcell_secrets` volume.
 REDCELL runs offensive tooling. Only point it at systems you are authorized to test. See [HARDENING.md](HARDENING.md).
 
 ## Removing it
+
+`docker compose down` stops the stack and keeps your data. Add `-v` to delete the volumes and wipe everything.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -93,3 +93,5 @@ To skip Cloudflare's proxy entirely, set the DNS record to DNS-only (grey cloud)
 If Coolify, Traefik, nginx, or a cloud load balancer terminates TLS and forwards to this host, use mode 3. Point the proxy's upstream at the server on port 80 (HTTP) or 443 (HTTPS, self-signed accepted).
 
 The app marks its login cookie `Secure` based on `REDCELL_COOKIE_SECURE`, not the request scheme, so cookies work even though the proxy reaches the origin over HTTP. Mode 3 sets this to `true` for you.
+
+## DNS

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -138,3 +138,5 @@ Because the deploy mode lives entirely in `.env`, a `git pull` never conflicts w
 ## Changing how it is reached
 
 Re-run `./deploy.sh` and pick a different option, or edit `SITE_ADDRESS`, `CADDYFILE`, `REDCELL_COOKIE_SECURE`, and `REDCELL_CORS_ORIGINS` in `.env` and run `docker compose up -d`.
+
+## Backups

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -73,3 +73,5 @@ A proxy or CDN in front holds the public certificate and forwards traffic to thi
 Use this when the domain does not resolve directly to the server, for example when it is proxied through Cloudflare or fronted by Coolify. In that case Caddy cannot complete a Let's Encrypt challenge itself, so it uses an internal certificate instead.
 
 This mode mounts `docker/caddy/Caddyfile.proxy` by setting `CADDYFILE=Caddyfile.proxy` in `.env`.
+
+## Behind Cloudflare

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -9,3 +9,5 @@ The short version lives in the [README](../README.md#deploy-self-host); this gui
 Caddy is the only service that publishes ports (80 and 443). It serves the web app and proxies `/api/*` to the API on the same origin, so there is no CORS to configure.
 
 Postgres, Redis, MinIO, the API, and the web app stay on the internal Docker network and are never exposed to the internet.
+
+Stored files (reports, loot, uploads) are streamed through the API, so MinIO never needs a public route.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -111,3 +111,5 @@ Everything else (5432, 6379, 9000) stays on the internal network and should not 
 ## Cookies and HTTPS
 
 `REDCELL_COOKIE_SECURE=true` marks the session cookie `Secure`, so the browser only sends it over HTTPS. Modes 2 and 3 set it to `true`; mode 1 (plain HTTP) uses `false`.
+
+Browsers treat `http://localhost` as a secure context, so a local `docker compose up` still logs in even with a secure cookie. A plain-HTTP deploy on a public IP does not, which is why mode 1 uses `false`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -67,3 +67,5 @@ Point an `A` record (and `AAAA` if you use IPv6) for the domain at the server be
 Ports 80 and 443 must be reachable from the internet; Let's Encrypt validates over them.
 
 ### 3. A domain behind Cloudflare, Coolify, or another proxy
+
+A proxy or CDN in front holds the public certificate and forwards traffic to this server. Caddy here serves both plain HTTP on :80 and its own self-signed HTTPS on :443, so it answers whichever way the proxy connects.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -193,3 +193,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 ## FAQ
 
 **Can I run it locally to try it?** Yes: `docker compose up` serves it at `http://localhost`. Secure cookies work because browsers trust localhost.
+
+**Can I use a subdomain?** Yes, `redcell.example.com` works exactly like a bare domain in modes 2 and 3.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -65,3 +65,5 @@ Caddy obtains a Let's Encrypt certificate automatically and serves `https://your
 Point an `A` record (and `AAAA` if you use IPv6) for the domain at the server before you run it. Caddy needs the domain to resolve to this host to pass the ACME challenge.
 
 Ports 80 and 443 must be reachable from the internet; Let's Encrypt validates over them.
+
+### 3. A domain behind Cloudflare, Coolify, or another proxy

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,1 @@
+# Deploying REDCELL

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -97,3 +97,5 @@ The app marks its login cookie `Secure` based on `REDCELL_COOKIE_SECURE`, not th
 ## DNS
 
 For a direct domain (mode 2), create an `A` record for the domain pointing at the server's IPv4 address.
+
+Add an `AAAA` record too if the server has a public IPv6 address; otherwise an IPv6-only client cannot reach it.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -47,3 +47,4 @@ cd redcell
 | Mode | SITE_ADDRESS | CADDYFILE | Cookie secure |
 | --- | --- | --- | --- |
 | 1. Direct, no domain | `:80` | `Caddyfile` | false |
+| 2. Domain, direct | `your-domain` | `Caddyfile` | true |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -46,3 +46,4 @@ cd redcell
 
 | Mode | SITE_ADDRESS | CADDYFILE | Cookie secure |
 | --- | --- | --- | --- |
+| 1. Direct, no domain | `:80` | `Caddyfile` | false |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -25,3 +25,5 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **caddy** — the reverse proxy and TLS terminator (named volumes `caddy_data`, `caddy_config`).
 
 ## Prerequisites
+
+- A Linux server you can SSH into as root (or a sudo user). 2 GB RAM is enough to start; more helps when engagements run.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -69,3 +69,5 @@ Ports 80 and 443 must be reachable from the internet; Let's Encrypt validates ov
 ### 3. A domain behind Cloudflare, Coolify, or another proxy
 
 A proxy or CDN in front holds the public certificate and forwards traffic to this server. Caddy here serves both plain HTTP on :80 and its own self-signed HTTPS on :443, so it answers whichever way the proxy connects.
+
+Use this when the domain does not resolve directly to the server, for example when it is proxied through Cloudflare or fronted by Coolify. In that case Caddy cannot complete a Let's Encrypt challenge itself, so it uses an internal certificate instead.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -169,3 +169,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **Port 80 or 443 already in use.** Another service is bound to it. Stop it, or free the port before deploying. Caddy needs both.
 
 **Certificate never issues (mode 2).** The domain must resolve to this server and ports 80/443 must be reachable from the internet. If the domain is proxied by a CDN, use mode 3 instead.
+
+**Cloudflare 521.** The origin is not listening on the port Cloudflare uses. Use mode 3 so Caddy serves :443, and set Cloudflare SSL to Full.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -31,3 +31,9 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - Ports 80 and 443 free on the host (nothing else bound to them).
 
 ## Quick start
+
+```bash
+git clone https://github.com/martian56/redcell.git
+cd redcell
+./deploy.sh
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -107,3 +107,5 @@ Let DNS propagate before the first request so the certificate can be issued. `ge
 Only Caddy publishes ports: 80 and 443 (plus 443/udp for HTTP/3). Open both in any cloud firewall or security group.
 
 Everything else (5432, 6379, 9000) stays on the internal network and should not be opened.
+
+## Cookies and HTTPS

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -5,3 +5,5 @@ REDCELL self-hosts with Docker Compose behind a Caddy reverse proxy. One command
 The short version lives in the [README](../README.md#deploy-self-host); this guide covers every mode and the things that go wrong.
 
 ## Architecture
+
+Caddy is the only service that publishes ports (80 and 443). It serves the web app and proxies `/api/*` to the API on the same origin, so there is no CORS to configure.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -148,3 +148,5 @@ Database dump:
 ```bash
 docker compose exec -T postgres pg_dump -U redcell redcell > redcell.sql
 ```
+
+## Verifying the deployment

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -16,3 +16,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 
 - **postgres** — application database (named volume `redcell_pg`).
 - **redis** — job queue and pub/sub for live updates.
+- **minio** — S3-compatible object storage (named volume `redcell_minio`).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -140,3 +140,5 @@ Because the deploy mode lives entirely in `.env`, a `git pull` never conflicts w
 Re-run `./deploy.sh` and pick a different option, or edit `SITE_ADDRESS`, `CADDYFILE`, `REDCELL_COOKIE_SECURE`, and `REDCELL_CORS_ORIGINS` in `.env` and run `docker compose up -d`.
 
 ## Backups
+
+State lives in named volumes: `redcell_pg` (database), `redcell_minio` (files), and `redcell_secrets` (keys and admin password). Back these up.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -49,3 +49,5 @@ cd redcell
 | 1. Direct, no domain | `:80` | `Caddyfile` | false |
 | 2. Domain, direct | `your-domain` | `Caddyfile` | true |
 | 3. Domain, behind a proxy | `your-domain` | `Caddyfile.proxy` | true |
+
+### 1. This server directly, no domain

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -195,3 +195,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 **Can I run it locally to try it?** Yes: `docker compose up` serves it at `http://localhost`. Secure cookies work because browsers trust localhost.
 
 **Can I use a subdomain?** Yes, `redcell.example.com` works exactly like a bare domain in modes 2 and 3.
+
+**Sim vs live?** Set `REDCELL_RUN_MODE=sim` in `.env` to replay canned output and run no real tools; `live` (default) runs tools in the Kali container.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -83,3 +83,5 @@ Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the ori
 **Flexible** also works: Cloudflare connects to the origin over plain HTTP on :80, which the proxy config serves too.
 
 **Full (strict)** rejects the self-signed origin certificate. To use it, install a Cloudflare Origin Certificate on the server, or switch the record to DNS-only and use mode 2.
+
+A Cloudflare **521** means the origin refused the connection on the port Cloudflare tried. Usually the deploy is still in IP mode (:80 only) while Cloudflare is set to Full and reaching for :443. Re-run `deploy.sh` and choose mode 3.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -159,11 +159,12 @@ Check every container is up and the infra ones are healthy:
 docker compose ps
 ```
 
-The web app should return 200 and the API should return 401 (auth required) on the same origin:
+The web app should return 200 and the API should return 401 (auth required) on the same origin. Use your deployment's base URL: `https://your-domain` for modes 2 and 3, or `http://SERVER_IP` for mode 1.
 
 ```bash
-curl -sI https://your-domain/
-curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
+BASE_URL=https://your-domain   # mode 1: http://SERVER_IP
+curl -sI "$BASE_URL/"
+curl -so /dev/null -w '%{http_code}\n' "$BASE_URL/api/v1/sessions"
 ```
 
 ## Troubleshooting

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -59,3 +59,5 @@ Credentials travel unencrypted, so `deploy.sh` asks you to confirm. Do not use t
 You reach it at `http://SERVER_IP`.
 
 ### 2. A domain pointed straight at this server
+
+Caddy obtains a Let's Encrypt certificate automatically and serves `https://your-domain`. This is the simplest way to get real HTTPS.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -37,3 +37,5 @@ git clone https://github.com/martian56/redcell.git
 cd redcell
 ./deploy.sh
 ```
+
+`deploy.sh` installs Docker if needed, asks how REDCELL will be reached, writes `.env`, pulls the images, and starts the stack.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -199,3 +199,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 **Sim vs live?** Set `REDCELL_RUN_MODE=sim` in `.env` to replay canned output and run no real tools; `live` (default) runs tools in the Kali container.
 
 **Where do the images come from?** They are published to GHCR from tagged releases; `docker compose pull` fetches the latest.
+
+**How do I move to a new domain?** Re-run `./deploy.sh`, choose the mode, and enter the new domain. The stack restarts with the new certificate.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -21,3 +21,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **migrate** — applies database migrations and seeds the provider catalog, then exits.
 - **api** — the FastAPI backend.
 - **worker** — the arq worker that runs engagements and generates reports.
+- **web** — the built React console served by nginx.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -48,3 +48,4 @@ cd redcell
 | --- | --- | --- | --- |
 | 1. Direct, no domain | `:80` | `Caddyfile` | false |
 | 2. Domain, direct | `your-domain` | `Caddyfile` | true |
+| 3. Domain, behind a proxy | `your-domain` | `Caddyfile.proxy` | true |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -191,3 +191,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 `docker compose down` stops the stack and keeps your data. Add `-v` to delete the volumes and wipe everything.
 
 ## FAQ
+
+**Can I run it locally to try it?** Yes: `docker compose up` serves it at `http://localhost`. Secure cookies work because browsers trust localhost.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -99,3 +99,5 @@ The app marks its login cookie `Secure` based on `REDCELL_COOKIE_SECURE`, not th
 For a direct domain (mode 2), create an `A` record for the domain pointing at the server's IPv4 address.
 
 Add an `AAAA` record too if the server has a public IPv6 address; otherwise an IPv6-only client cannot reach it.
+
+Let DNS propagate before the first request so the certificate can be issued. `getent hosts your-domain` on the server should return the server's own IP.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -13,3 +13,5 @@ Postgres, Redis, MinIO, the API, and the web app stay on the internal Docker net
 Stored files (reports, loot, uploads) are streamed through the API, so MinIO never needs a public route.
 
 ## What gets deployed
+
+- **postgres** — application database (named volume `redcell_pg`).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -51,3 +51,5 @@ cd redcell
 | 3. Domain, behind a proxy | `your-domain` | `Caddyfile.proxy` | true |
 
 ### 1. This server directly, no domain
+
+Serves plain HTTP on the server IP. Good for a quick trial or a trusted private network.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -103,3 +103,5 @@ Add an `AAAA` record too if the server has a public IPv6 address; otherwise an I
 Let DNS propagate before the first request so the certificate can be issued. `getent hosts your-domain` on the server should return the server's own IP.
 
 ## Ports and firewall
+
+Only Caddy publishes ports: 80 and 443 (plus 443/udp for HTTP/3). Open both in any cloud firewall or security group.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -115,3 +115,9 @@ Everything else (5432, 6379, 9000) stays on the internal network and should not 
 Browsers treat `http://localhost` as a secure context, so a local `docker compose up` still logs in even with a secure cookie. A plain-HTTP deploy on a public IP does not, which is why mode 1 uses `false`.
 
 ## First login
+
+The first run generates an admin password. Read it with:
+
+```bash
+docker compose logs init-secrets
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -3,3 +3,5 @@
 REDCELL self-hosts with Docker Compose behind a Caddy reverse proxy. One command brings the whole stack up, with or without a domain.
 
 The short version lives in the [README](../README.md#deploy-self-host); this guide covers every mode and the things that go wrong.
+
+## Architecture

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -101,3 +101,5 @@ For a direct domain (mode 2), create an `A` record for the domain pointing at th
 Add an `AAAA` record too if the server has a public IPv6 address; otherwise an IPv6-only client cannot reach it.
 
 Let DNS propagate before the first request so the certificate can be issued. `getent hosts your-domain` on the server should return the server's own IP.
+
+## Ports and firewall

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -109,3 +109,5 @@ Only Caddy publishes ports: 80 and 443 (plus 443/udp for HTTP/3). Open both in a
 Everything else (5432, 6379, 9000) stays on the internal network and should not be opened.
 
 ## Cookies and HTTPS
+
+`REDCELL_COOKIE_SECURE=true` marks the session cookie `Secure`, so the browser only sends it over HTTPS. Modes 2 and 3 set it to `true`; mode 1 (plain HTTP) uses `false`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -55,3 +55,5 @@ cd redcell
 Serves plain HTTP on the server IP. Good for a quick trial or a trusted private network.
 
 Credentials travel unencrypted, so `deploy.sh` asks you to confirm. Do not use this over the public internet for anything real.
+
+You reach it at `http://SERVER_IP`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -156,3 +156,10 @@ Check every container is up and the infra ones are healthy:
 ```bash
 docker compose ps
 ```
+
+The web app should return 200 and the API should return 401 (auth required) on the same origin:
+
+```bash
+curl -sI https://your-domain/
+curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -20,3 +20,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **init-secrets** — generates the secret key, JWT secret, and first admin password on first run.
 - **migrate** — applies database migrations and seeds the provider catalog, then exits.
 - **api** — the FastAPI backend.
+- **worker** — the arq worker that runs engagements and generates reports.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -90,7 +90,9 @@ To skip Cloudflare's proxy entirely, set the DNS record to DNS-only (grey cloud)
 
 ## Behind Coolify or another reverse proxy
 
-If Coolify, Traefik, nginx, or a cloud load balancer terminates TLS and forwards to this host, use mode 3. Point the proxy's upstream at the server on port 80 (HTTP) or 443 (HTTPS, self-signed accepted).
+If Coolify, Traefik, nginx, or a cloud load balancer terminates TLS and forwards to this host, use mode 3. Point the proxy's upstream at the server on port 80 (HTTP) or 443 (HTTPS, self-signed).
+
+For a port 443 upstream, the proxy must trust Caddy's internal CA or skip upstream certificate verification, otherwise it will fail the TLS handshake and return 502. If you cannot configure that, use the port 80 upstream instead.
 
 The app marks its login cookie `Secure` based on `REDCELL_COOKIE_SECURE`, not the request scheme, so cookies work even though the proxy reaches the origin over HTTP. Mode 3 sets this to `true` for you.
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -17,3 +17,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **postgres** — application database (named volume `redcell_pg`).
 - **redis** — job queue and pub/sub for live updates.
 - **minio** — S3-compatible object storage (named volume `redcell_minio`).
+- **init-secrets** — generates the secret key, JWT secret, and first admin password on first run.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -18,3 +18,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **redis** — job queue and pub/sub for live updates.
 - **minio** — S3-compatible object storage (named volume `redcell_minio`).
 - **init-secrets** — generates the secret key, JWT secret, and first admin password on first run.
+- **migrate** — applies database migrations and seeds the provider catalog, then exits.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -171,3 +171,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **Certificate never issues (mode 2).** The domain must resolve to this server and ports 80/443 must be reachable from the internet. If the domain is proxied by a CDN, use mode 3 instead.
 
 **Cloudflare 521.** The origin is not listening on the port Cloudflare uses. Use mode 3 so Caddy serves :443, and set Cloudflare SSL to Full.
+
+**Cloudflare 526.** Full (strict) rejected the self-signed origin certificate. Switch Cloudflare to Full, install a Cloudflare Origin Certificate, or use DNS-only plus mode 2.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -187,6 +187,8 @@ curl -so /dev/null -w '%{http_code}\n' "$BASE_URL/api/v1/sessions"
 
 Secrets are generated per deployment and stored in the `redcell_secrets` volume. There are no usable default credentials outside dev.
 
+In proxy mode the origin serves plain HTTP on :80, so a client reaching the server IP directly would bypass the proxy's TLS. Restrict the origin to the proxy: firewall ports 80 and 443 to the proxy's source ranges (for Cloudflare, its published IP ranges, ideally with Authenticated Origin Pulls), or bind the server to a private network the proxy reaches.
+
 REDCELL runs offensive tooling. Only point it at systems you are authorized to test. See [HARDENING.md](HARDENING.md).
 
 ## Removing it

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -201,3 +201,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 **Where do the images come from?** They are published to GHCR from tagged releases; `docker compose pull` fetches the latest.
 
 **How do I move to a new domain?** Re-run `./deploy.sh`, choose the mode, and enter the new domain. The stack restarts with the new certificate.
+
+## More

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -197,3 +197,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 **Can I use a subdomain?** Yes, `redcell.example.com` works exactly like a bare domain in modes 2 and 3.
 
 **Sim vs live?** Set `REDCELL_RUN_MODE=sim` in `.env` to replay canned output and run no real tools; `live` (default) runs tools in the Kali container.
+
+**Where do the images come from?** They are published to GHCR from tagged releases; `docker compose pull` fetches the latest.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -142,3 +142,9 @@ Re-run `./deploy.sh` and pick a different option, or edit `SITE_ADDRESS`, `CADDY
 ## Backups
 
 State lives in named volumes: `redcell_pg` (database), `redcell_minio` (files), and `redcell_secrets` (keys and admin password). Back these up.
+
+Database dump:
+
+```bash
+docker compose exec -T postgres pg_dump -U redcell redcell > redcell.sql
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -81,3 +81,5 @@ When a domain's DNS record is proxied (the orange cloud), it resolves to Cloudfl
 Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the origin over HTTPS and accepts the self-signed certificate Caddy serves.
 
 **Flexible** also works: Cloudflare connects to the origin over plain HTTP on :80, which the proxy config serves too.
+
+**Full (strict)** rejects the self-signed origin certificate. To use it, install a Cloudflare Origin Certificate on the server, or switch the record to DNS-only and use mode 2.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -189,3 +189,5 @@ REDCELL runs offensive tooling. Only point it at systems you are authorized to t
 ## Removing it
 
 `docker compose down` stops the stack and keeps your data. Add `-v` to delete the volumes and wipe everything.
+
+## FAQ

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -165,3 +165,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 ```
 
 ## Troubleshooting
+
+**Port 80 or 443 already in use.** Another service is bound to it. Stop it, or free the port before deploying. Caddy needs both.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -39,3 +39,5 @@ cd redcell
 ```
 
 `deploy.sh` installs Docker if needed, asks how REDCELL will be reached, writes `.env`, pulls the images, and starts the stack.
+
+## Deployment modes

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -125,3 +125,10 @@ docker compose logs init-secrets
 Sign in as `admin` with that password, then change it in Settings. The password persists in the `redcell_secrets` volume across redeploys.
 
 ## Updating
+
+```bash
+cd redcell
+git pull
+docker compose pull
+docker compose up -d
+```

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -27,3 +27,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 ## Prerequisites
 
 - A Linux server you can SSH into as root (or a sudo user). 2 GB RAM is enough to start; more helps when engagements run.
+- Docker Engine with the Compose plugin. `deploy.sh` installs both if they are missing.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -177,3 +177,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **Login does not stick.** Over plain HTTP on an IP the secure cookie is dropped. Use a domain, or accept mode 1 which sets the cookie insecure.
 
 **CORS errors.** All traffic should go through Caddy on one origin. Reach REDCELL at its `SITE_ADDRESS`, not the API port directly.
+
+**Something is failing.** Read the logs of a service, for example `docker compose logs api` or `docker compose logs caddy`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -185,3 +185,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 Secrets are generated per deployment and stored in the `redcell_secrets` volume. There are no usable default credentials outside dev.
 
 REDCELL runs offensive tooling. Only point it at systems you are authorized to test. See [HARDENING.md](HARDENING.md).
+
+## Removing it

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -87,3 +87,5 @@ Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the ori
 A Cloudflare **521** means the origin refused the connection on the port Cloudflare tried. Usually the deploy is still in IP mode (:80 only) while Cloudflare is set to Full and reaching for :443. Re-run `deploy.sh` and choose mode 3.
 
 To skip Cloudflare's proxy entirely, set the DNS record to DNS-only (grey cloud) pointing at the server and use mode 2 for a direct Let's Encrypt certificate.
+
+## Behind Coolify or another reverse proxy

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -183,3 +183,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 ## Security notes
 
 Secrets are generated per deployment and stored in the `redcell_secrets` volume. There are no usable default credentials outside dev.
+
+REDCELL runs offensive tooling. Only point it at systems you are authorized to test. See [HARDENING.md](HARDENING.md).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -41,3 +41,5 @@ cd redcell
 `deploy.sh` installs Docker if needed, asks how REDCELL will be reached, writes `.env`, pulls the images, and starts the stack.
 
 ## Deployment modes
+
+`deploy.sh` offers three ways to reach REDCELL. Each writes a matching set of values to `.env`; nothing else needs editing.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -121,3 +121,5 @@ The first run generates an admin password. Read it with:
 ```bash
 docker compose logs init-secrets
 ```
+
+Sign in as `admin` with that password, then change it in Settings. The password persists in the `redcell_secrets` volume across redeploys.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -113,3 +113,5 @@ Everything else (5432, 6379, 9000) stays on the internal network and should not 
 `REDCELL_COOKIE_SECURE=true` marks the session cookie `Secure`, so the browser only sends it over HTTPS. Modes 2 and 3 set it to `true`; mode 1 (plain HTTP) uses `false`.
 
 Browsers treat `http://localhost` as a secure context, so a local `docker compose up` still logs in even with a secure cookie. A plain-HTTP deploy on a public IP does not, which is why mode 1 uses `false`.
+
+## First login

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -163,3 +163,5 @@ The web app should return 200 and the API should return 401 (auth required) on t
 curl -sI https://your-domain/
 curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 ```
+
+## Troubleshooting

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -167,3 +167,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 ## Troubleshooting
 
 **Port 80 or 443 already in use.** Another service is bound to it. Stop it, or free the port before deploying. Caddy needs both.
+
+**Certificate never issues (mode 2).** The domain must resolve to this server and ports 80/443 must be reachable from the internet. If the domain is proxied by a CDN, use mode 3 instead.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -15,3 +15,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 ## What gets deployed
 
 - **postgres** — application database (named volume `redcell_pg`).
+- **redis** — job queue and pub/sub for live updates.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,3 +1,5 @@
 # Deploying REDCELL
 
 REDCELL self-hosts with Docker Compose behind a Caddy reverse proxy. One command brings the whole stack up, with or without a domain.
+
+The short version lives in the [README](../README.md#deploy-self-host); this guide covers every mode and the things that go wrong.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -134,3 +134,5 @@ docker compose up -d
 ```
 
 Because the deploy mode lives entirely in `.env`, a `git pull` never conflicts with local changes. Your mode is preserved across updates.
+
+## Changing how it is reached

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -63,3 +63,5 @@ You reach it at `http://SERVER_IP`.
 Caddy obtains a Let's Encrypt certificate automatically and serves `https://your-domain`. This is the simplest way to get real HTTPS.
 
 Point an `A` record (and `AAAA` if you use IPv6) for the domain at the server before you run it. Caddy needs the domain to resolve to this host to pass the ACME challenge.
+
+Ports 80 and 443 must be reachable from the internet; Let's Encrypt validates over them.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -132,3 +132,5 @@ git pull
 docker compose pull
 docker compose up -d
 ```
+
+Because the deploy mode lives entirely in `.env`, a `git pull` never conflicts with local changes. Your mode is preserved across updates.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -95,3 +95,5 @@ If Coolify, Traefik, nginx, or a cloud load balancer terminates TLS and forwards
 The app marks its login cookie `Secure` based on `REDCELL_COOKIE_SECURE`, not the request scheme, so cookies work even though the proxy reaches the origin over HTTP. Mode 3 sets this to `true` for you.
 
 ## DNS
+
+For a direct domain (mode 2), create an `A` record for the domain pointing at the server's IPv4 address.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -53,3 +53,5 @@ cd redcell
 ### 1. This server directly, no domain
 
 Serves plain HTTP on the server IP. Good for a quick trial or a trusted private network.
+
+Credentials travel unencrypted, so `deploy.sh` asks you to confirm. Do not use this over the public internet for anything real.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -105,3 +105,5 @@ Let DNS propagate before the first request so the certificate can be issued. `ge
 ## Ports and firewall
 
 Only Caddy publishes ports: 80 and 443 (plus 443/udp for HTTP/3). Open both in any cloud firewall or security group.
+
+Everything else (5432, 6379, 9000) stays on the internal network and should not be opened.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -91,3 +91,5 @@ To skip Cloudflare's proxy entirely, set the DNS record to DNS-only (grey cloud)
 ## Behind Coolify or another reverse proxy
 
 If Coolify, Traefik, nginx, or a cloud load balancer terminates TLS and forwards to this host, use mode 3. Point the proxy's upstream at the server on port 80 (HTTP) or 443 (HTTPS, self-signed accepted).
+
+The app marks its login cookie `Secure` based on `REDCELL_COOKIE_SECURE`, not the request scheme, so cookies work even though the proxy reaches the origin over HTTP. Mode 3 sets this to `true` for you.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -75,3 +75,5 @@ Use this when the domain does not resolve directly to the server, for example wh
 This mode mounts `docker/caddy/Caddyfile.proxy` by setting `CADDYFILE=Caddyfile.proxy` in `.env`.
 
 ## Behind Cloudflare
+
+When a domain's DNS record is proxied (the orange cloud), it resolves to Cloudflare, not your server. Choose mode 3.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -85,3 +85,5 @@ Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the ori
 **Full (strict)** rejects the self-signed origin certificate. To use it, install a Cloudflare Origin Certificate on the server, or switch the record to DNS-only and use mode 2.
 
 A Cloudflare **521** means the origin refused the connection on the port Cloudflare tried. Usually the deploy is still in IP mode (:80 only) while Cloudflare is set to Full and reaching for :443. Re-run `deploy.sh` and choose mode 3.
+
+To skip Cloudflare's proxy entirely, set the DNS record to DNS-only (grey cloud) pointing at the server and use mode 2 for a direct Let's Encrypt certificate.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -43,3 +43,6 @@ cd redcell
 ## Deployment modes
 
 `deploy.sh` offers three ways to reach REDCELL. Each writes a matching set of values to `.env`; nothing else needs editing.
+
+| Mode | SITE_ADDRESS | CADDYFILE | Cookie secure |
+| --- | --- | --- | --- |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -29,3 +29,5 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - A Linux server you can SSH into as root (or a sudo user). 2 GB RAM is enough to start; more helps when engagements run.
 - Docker Engine with the Compose plugin. `deploy.sh` installs both if they are missing.
 - Ports 80 and 443 free on the host (nothing else bound to them).
+
+## Quick start

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -23,3 +23,5 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **worker** — the arq worker that runs engagements and generates reports.
 - **web** — the built React console served by nginx.
 - **caddy** — the reverse proxy and TLS terminator (named volumes `caddy_data`, `caddy_config`).
+
+## Prerequisites

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -77,3 +77,5 @@ This mode mounts `docker/caddy/Caddyfile.proxy` by setting `CADDYFILE=Caddyfile.
 ## Behind Cloudflare
 
 When a domain's DNS record is proxied (the orange cloud), it resolves to Cloudflare, not your server. Choose mode 3.
+
+Set the Cloudflare SSL/TLS mode to **Full**. Cloudflare then connects to the origin over HTTPS and accepts the self-signed certificate Caddy serves.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -179,3 +179,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **CORS errors.** All traffic should go through Caddy on one origin. Reach REDCELL at its `SITE_ADDRESS`, not the API port directly.
 
 **Something is failing.** Read the logs of a service, for example `docker compose logs api` or `docker compose logs caddy`.
+
+## Security notes

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -173,3 +173,5 @@ curl -so /dev/null -w '%{http_code}\n' https://your-domain/api/v1/sessions
 **Cloudflare 521.** The origin is not listening on the port Cloudflare uses. Use mode 3 so Caddy serves :443, and set Cloudflare SSL to Full.
 
 **Cloudflare 526.** Full (strict) rejected the self-signed origin certificate. Switch Cloudflare to Full, install a Cloudflare Origin Certificate, or use DNS-only plus mode 2.
+
+**Login does not stick.** Over plain HTTP on an IP the secure cookie is dropped. Use a domain, or accept mode 1 which sets the cookie insecure.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -71,3 +71,5 @@ Ports 80 and 443 must be reachable from the internet; Let's Encrypt validates ov
 A proxy or CDN in front holds the public certificate and forwards traffic to this server. Caddy here serves both plain HTTP on :80 and its own self-signed HTTPS on :443, so it answers whichever way the proxy connects.
 
 Use this when the domain does not resolve directly to the server, for example when it is proxied through Cloudflare or fronted by Coolify. In that case Caddy cannot complete a Let's Encrypt challenge itself, so it uses an internal certificate instead.
+
+This mode mounts `docker/caddy/Caddyfile.proxy` by setting `CADDYFILE=Caddyfile.proxy` in `.env`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,1 +1,3 @@
 # Deploying REDCELL
+
+REDCELL self-hosts with Docker Compose behind a Caddy reverse proxy. One command brings the whole stack up, with or without a domain.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -89,3 +89,5 @@ A Cloudflare **521** means the origin refused the connection on the port Cloudfl
 To skip Cloudflare's proxy entirely, set the DNS record to DNS-only (grey cloud) pointing at the server and use mode 2 for a direct Let's Encrypt certificate.
 
 ## Behind Coolify or another reverse proxy
+
+If Coolify, Traefik, nginx, or a cloud load balancer terminates TLS and forwards to this host, use mode 3. Point the proxy's upstream at the server on port 80 (HTTP) or 443 (HTTPS, self-signed accepted).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -22,3 +22,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **api** — the FastAPI backend.
 - **worker** — the arq worker that runs engagements and generates reports.
 - **web** — the built React console served by nginx.
+- **caddy** — the reverse proxy and TLS terminator (named volumes `caddy_data`, `caddy_config`).

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -19,3 +19,4 @@ Stored files (reports, loot, uploads) are streamed through the API, so MinIO nev
 - **minio** — S3-compatible object storage (named volume `redcell_minio`).
 - **init-secrets** — generates the secret key, JWT secret, and first admin password on first run.
 - **migrate** — applies database migrations and seeds the provider catalog, then exits.
+- **api** — the FastAPI backend.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -61,3 +61,5 @@ You reach it at `http://SERVER_IP`.
 ### 2. A domain pointed straight at this server
 
 Caddy obtains a Let's Encrypt certificate automatically and serves `https://your-domain`. This is the simplest way to get real HTTPS.
+
+Point an `A` record (and `AAAA` if you use IPv6) for the domain at the server before you run it. Caddy needs the domain to resolve to this host to pass the ACME challenge.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -136,3 +136,5 @@ docker compose up -d
 Because the deploy mode lives entirely in `.env`, a `git pull` never conflicts with local changes. Your mode is preserved across updates.
 
 ## Changing how it is reached
+
+Re-run `./deploy.sh` and pick a different option, or edit `SITE_ADDRESS`, `CADDYFILE`, `REDCELL_COOKIE_SECURE`, and `REDCELL_CORS_ORIGINS` in `.env` and run `docker compose up -d`.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -123,3 +123,5 @@ docker compose logs init-secrets
 ```
 
 Sign in as `admin` with that password, then change it in Settings. The password persists in the `redcell_secrets` volume across redeploys.
+
+## Updating


### PR DESCRIPTION
Makes `deploy.sh` cover every reachability case and keeps the config entirely in `.env`, so the Cloudflare fix (and any future mode) survives a `git pull` on the server. No image changes; this is deploy-time config only.

## Three modes
`deploy.sh` now asks how REDCELL will be reached:

1. **This server directly, no domain** — plain HTTP on the IP (`SITE_ADDRESS=:80`, `Caddyfile`).
2. **A domain pointed straight at this server** — automatic Let's Encrypt HTTPS (`SITE_ADDRESS=domain`, `Caddyfile`).
3. **A domain behind Cloudflare, Coolify, or another proxy/CDN** — the proxy provides the public cert; the origin serves both plain HTTP on :80 and self-signed HTTPS on :443, so it works however the proxy connects (`CADDYFILE=Caddyfile.proxy`).

## Why this shape
The mode is selected by a committed `CADDYFILE` variable that `docker-compose.yml` interpolates into the Caddy config mount (`./docker/caddy/${CADDYFILE:-Caddyfile}`). Two Caddyfiles are committed (`Caddyfile`, `Caddyfile.proxy`), and `deploy.sh` only ever writes `.env`. That was the bug behind the manual server edit: the fix now lives in the repo, and updating is just `git pull && docker compose pull && docker compose up -d`.

## Validation
- `bash -n deploy.sh` passes.
- `docker compose config` valid for both `CADDYFILE=Caddyfile` and `CADDYFILE=Caddyfile.proxy`.
- Both Caddyfiles pass `caddy validate`.

## Docs
New `docs/DEPLOY.md` covers all three modes, Cloudflare SSL modes (Full / Flexible / Full-strict) and the 521/526 cases, Coolify and generic proxies, DNS, ports, cookies, updating, backups, verification, and troubleshooting. README updated.

Please merge with a **merge commit** (not squash) to preserve the commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three deployment options: direct HTTP, automatic HTTPS for domains, and deployments behind Cloudflare or another proxy/CDN.
  - Added support for selecting a custom Caddy configuration.
  - Proxy-based deployments now support HTTP and HTTPS access with routing for web and API traffic.

- **Documentation**
  - Added a comprehensive deployment guide covering setup, configuration, security, backups, updates, troubleshooting, and removal.
  - Updated deployment instructions to explain all supported modes and how to switch modes later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->