### PR TITLE
fix(core): compute real session cost (OpenRouter cost, then price table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ deploy.sh                    interactive self-host deploy
 - [Architecture](docs/ARCHITECTURE.md) — the components, how a run flows, cross-process coordination.
 - [Hardening & threat model](docs/HARDENING.md) — deploy safely, secrets, scope, and data retention. Read this before running REDCELL anywhere but your own machine.
 - [Pre-authentication surface](docs/PRE-AUTH-SURFACE.md) — what an unauthenticated client can observe, and how to keep that minimal.
+- [Cost & token accounting](docs/COST.md) — how run spend is measured, the price table, and OpenRouter real cost.
 
 ## Contributing
 

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -55,3 +55,5 @@ It then reads `usage.cost` (USD). This reflects OpenRouter's actual charge, incl
 For non-OpenRouter providers the number is an estimate. It is only as accurate as the price table and the usage the provider reports.
 
 Prompt caching, batch discounts, and provider promotions are not modeled in the table, so estimated cost can run high or low.
+
+If a provider omits usage, tokens and cost for that call are 0.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -87,3 +87,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `deepseek-r2` - 0.7 / 2.4
 - `kimi-k3` - 0.6 / 2.5
 - `kimi-k2.7-code` - 0.5 / 2.0
+- `glm-5.3` - 0.6 / 2.2

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -47,3 +47,5 @@ For OpenRouter you usually do not need a table entry, since the real cost comes 
 ## OpenRouter details
 
 The client adds `extra_body={"usage": {"include": true}}` for the `openrouter` provider so the response includes accounting.
+
+It then reads `usage.cost` (USD). This reflects OpenRouter's actual charge, including any per-model routing and discounts.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -137,3 +137,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 - Set a token budget on the run so it stops before overspending.
 
 - Keep scope tight; fewer targets and turns means fewer tokens.
+
+- OpenRouter gives you real per-call cost, which makes tuning spend easier.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -89,3 +89,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `kimi-k2.7-code` - 0.5 / 2.0
 - `glm-5.3` - 0.6 / 2.2
 - `glm-5.2` - 0.5 / 1.8
+- `glm-4.6` - 0.4 / 1.6

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -71,3 +71,4 @@ On OpenRouter, compare the shown cost against your OpenRouter dashboard for the 
 ## Model price reference
 
 USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRouter reports its own.
+- `gpt-5.6` - 5.0 / 15.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -57,3 +57,5 @@ For non-OpenRouter providers the number is an estimate. It is only as accurate a
 Prompt caching, batch discounts, and provider promotions are not modeled in the table, so estimated cost can run high or low.
 
 If a provider omits usage, tokens and cost for that call are 0.
+
+## Budgets

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -131,3 +131,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 5. The header reflects the new totals on the next update.
 
 ## Controlling cost
+
+- Pick a cheaper model for routine work; reserve flagship models for hard steps.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -75,3 +75,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gpt-5.5` - 3.0 / 10.0
 - `gpt-5.4` - 2.5 / 8.0
 - `gpt-5.4-mini` - 0.4 / 1.6
+- `o4-mini` - 1.1 / 4.4

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -113,3 +113,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - Issue #64 - the \$0.00 bug this documents.
 
 ## Tokens explained
+
+**Prompt (input) tokens** are everything sent to the model: system prompt, prior turns, tool definitions, and the current message.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -51,3 +51,5 @@ The client adds `extra_body={"usage": {"include": true}}` for the `openrouter` p
 It then reads `usage.cost` (USD). This reflects OpenRouter's actual charge, including any per-model routing and discounts.
 
 ## Accuracy and caveats
+
+For non-OpenRouter providers the number is an estimate. It is only as accurate as the price table and the usage the provider reports.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -27,3 +27,5 @@ The model catalog uses names like `glm-5.3`, `claude-opus-5`, and `deepseek-v4-p
 Each metered call adds its tokens and cost onto the run via `runs.set_meters`. The run's `tokens` and `cost_usd` grow as the engagement proceeds.
 
 The console header shows the running totals next to Elapsed and Model.
+
+## The price table

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -74,3 +74,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gpt-5.6` - 5.0 / 15.0
 - `gpt-5.5` - 3.0 / 10.0
 - `gpt-5.4` - 2.5 / 8.0
+- `gpt-5.4-mini` - 0.4 / 1.6

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -85,3 +85,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `deepseek-v4-pro` - 0.6 / 1.7
 - `deepseek-v4-flash` - 0.3 / 0.9
 - `deepseek-r2` - 0.7 / 2.4
+- `kimi-k3` - 0.6 / 2.5

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -147,3 +147,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 ## Glossary
 
 - **per 1M tokens** - prices are quoted per one million tokens; divide token counts by 1,000,000 before multiplying.
+
+- **usage** - the accounting block a provider returns alongside the message.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -107,3 +107,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **Local models show \$0.00.** Expected - self-hosted models have no API cost.
 
 ## References
+
+- `packages/core/redcell_core/engine/pricing.py` - the price table and estimator.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -105,3 +105,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **Still \$0.00 on a live run.** The provider may not be returning usage, the model may be unknown on a direct provider, or no LLM calls have completed yet.
 
 **Local models show \$0.00.** Expected - self-hosted models have no API cost.
+
+## References

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -78,3 +78,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `o4-mini` - 1.1 / 4.4
 - `claude-opus-5` - 15.0 / 75.0
 - `claude-sonnet-5` - 3.0 / 15.0
+- `claude-haiku-4-5` - 0.8 / 4.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -37,3 +37,5 @@ Lookup is by the last path segment, lowercased, so `z-ai/glm-5.2` and `glm-5.2` 
 An unknown variant falls back to its family (for example an unlisted `glm-5.x` uses a listed GLM price), so a new model still gets a sensible estimate.
 
 Local providers (Ollama) cost nothing, so their estimate is 0 regardless of model.
+
+## Updating prices

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -91,3 +91,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `glm-5.2` - 0.5 / 1.8
 - `glm-4.6` - 0.4 / 1.6
 - `glm-4.5-air` - 0.2 / 1.1
+- `llama-4-70b` - 0.6 / 0.9

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -126,3 +126,4 @@ Output tokens usually cost more than input, which is why the table prices them s
 
 1. The client calls the provider and receives the message plus a usage block.
 2. It parses total, prompt, and completion tokens from usage.
+3. It resolves cost (OpenRouter real, then LiteLLM, then table).

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -86,3 +86,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `deepseek-v4-flash` - 0.3 / 0.9
 - `deepseek-r2` - 0.7 / 2.4
 - `kimi-k3` - 0.6 / 2.5
+- `kimi-k2.7-code` - 0.5 / 2.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -81,3 +81,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `claude-haiku-4-5` - 0.8 / 4.0
 - `gemini-3.1-pro` - 2.5 / 10.0
 - `gemini-3.6-flash` - 0.3 / 2.5
+- `gemini-3.1-flash-lite` - 0.1 / 0.4

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -15,3 +15,5 @@ For each LLM call, cost is resolved in order:
 1. **OpenRouter real cost** - for the `openrouter` provider, the request sets `usage.include`, and the response's `usage.cost` is the charge.
 2. **LiteLLM price map** - `litellm.completion_cost` multiplies the returned tokens by LiteLLM's own prices for models it knows.
 3. **REDCELL price table** - a fallback in `engine/pricing.py` for models LiteLLM does not price (the catalog uses forward-looking model names LiteLLM has no entry for).
+
+If none apply (an unknown model on a direct provider), cost is 0 rather than a wrong guess.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -90,3 +90,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `glm-5.3` - 0.6 / 2.2
 - `glm-5.2` - 0.5 / 1.8
 - `glm-4.6` - 0.4 / 1.6
+- `glm-4.5-air` - 0.2 / 1.1

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -125,3 +125,4 @@ Output tokens usually cost more than input, which is why the table prices them s
 ## How a call is metered
 
 1. The client calls the provider and receives the message plus a usage block.
+2. It parses total, prompt, and completion tokens from usage.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -111,3 +111,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `packages/core/redcell_core/engine/pricing.py` - the price table and estimator.
 - `packages/core/redcell_core/engine/llm.py` - cost resolution order.
 - Issue #64 - the \$0.00 bug this documents.
+
+## Tokens explained

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -3,3 +3,5 @@
 How REDCELL measures what a run spends, and why the number is what it is.
 
 ## Providers report tokens, not dollars
+
+Native LLM APIs (OpenAI, Anthropic, Google, DeepSeek, and so on) return token usage - `prompt_tokens`, `completion_tokens`, `total_tokens` - not a dollar amount. The cost is computed from those tokens and a per-model price.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -95,3 +95,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `qwen3-72b` - 0.6 / 0.9
 - `deepseek-v4` - 0.6 / 1.7
 - Ollama / local models - 0 (self-hosted, no API charge)
+
+## FAQ

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -155,3 +155,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 ## Note
 
 Cost is informational. Treat it as a close estimate for budgeting, not an invoice, except where OpenRouter reports the real charge.
+
+## See also

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -63,3 +63,5 @@ If a provider omits usage, tokens and cost for that call are 0.
 A run can carry a `budget_tokens` ceiling. Track spend against it to stop a run before it runs away.
 
 ## Verifying
+
+Start a live run and watch the header: tokens and dollars should climb as calls complete.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -13,3 +13,4 @@ The exception is OpenRouter, which can return the actual charge in `usage.cost` 
 For each LLM call, cost is resolved in order:
 
 1. **OpenRouter real cost** - for the `openrouter` provider, the request sets `usage.include`, and the response's `usage.cost` is the charge.
+2. **LiteLLM price map** - `litellm.completion_cost` multiplies the returned tokens by LiteLLM's own prices for models it knows.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -127,3 +127,4 @@ Output tokens usually cost more than input, which is why the table prices them s
 1. The client calls the provider and receives the message plus a usage block.
 2. It parses total, prompt, and completion tokens from usage.
 3. It resolves cost (OpenRouter real, then LiteLLM, then table).
+4. The runner books tokens and cost onto the run with `set_meters`.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -45,3 +45,5 @@ Edit `PRICES` in `engine/pricing.py`. Keep entries as USD per 1M tokens `(input,
 For OpenRouter you usually do not need a table entry, since the real cost comes back on the response.
 
 ## OpenRouter details
+
+The client adds `extra_body={"usage": {"include": true}}` for the `openrouter` provider so the response includes accounting.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -149,3 +149,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 - **per 1M tokens** - prices are quoted per one million tokens; divide token counts by 1,000,000 before multiplying.
 
 - **usage** - the accounting block a provider returns alongside the message.
+
+- **metered call** - an LLM call whose tokens and cost are booked onto the run.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -103,3 +103,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **The cost looks off.** Check the price-table entry for the model, and remember caching and discounts are not modeled.
 
 **Still \$0.00 on a live run.** The provider may not be returning usage, the model may be unknown on a direct provider, or no LLM calls have completed yet.
+
+**Local models show \$0.00.** Expected - self-hosted models have no API cost.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -119,3 +119,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **Completion (output) tokens** are what the model generates, including tool-call arguments.
 
 **Total** is prompt plus completion. When a provider omits the total, REDCELL derives it from the two parts.
+
+Output tokens usually cost more than input, which is why the table prices them separately.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -139,3 +139,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 - Keep scope tight; fewer targets and turns means fewer tokens.
 
 - OpenRouter gives you real per-call cost, which makes tuning spend easier.
+
+## Related

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -61,3 +61,5 @@ If a provider omits usage, tokens and cost for that call are 0.
 ## Budgets
 
 A run can carry a `budget_tokens` ceiling. Track spend against it to stop a run before it runs away.
+
+## Verifying

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -151,3 +151,7 @@ Output tokens usually cost more than input, which is why the table prices them s
 - **usage** - the accounting block a provider returns alongside the message.
 
 - **metered call** - an LLM call whose tokens and cost are booked onto the run.
+
+## Note
+
+Cost is informational. Treat it as a close estimate for budgeting, not an invoice, except where OpenRouter reports the real charge.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -41,3 +41,5 @@ Local providers (Ollama) cost nothing, so their estimate is 0 regardless of mode
 ## Updating prices
 
 Edit `PRICES` in `engine/pricing.py`. Keep entries as USD per 1M tokens `(input, output)`. Prefer real published prices where a model exists.
+
+For OpenRouter you usually do not need a table entry, since the real cost comes back on the response.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -39,3 +39,5 @@ An unknown variant falls back to its family (for example an unlisted `glm-5.x` u
 Local providers (Ollama) cost nothing, so their estimate is 0 regardless of model.
 
 ## Updating prices
+
+Edit `PRICES` in `engine/pricing.py`. Keep entries as USD per 1M tokens `(input, output)`. Prefer real published prices where a model exists.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -5,3 +5,5 @@ How REDCELL measures what a run spends, and why the number is what it is.
 ## Providers report tokens, not dollars
 
 Native LLM APIs (OpenAI, Anthropic, Google, DeepSeek, and so on) return token usage - `prompt_tokens`, `completion_tokens`, `total_tokens` - not a dollar amount. The cost is computed from those tokens and a per-model price.
+
+The exception is OpenRouter, which can return the actual charge in `usage.cost` when the request asks for it. REDCELL uses that real number when available.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -77,3 +77,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gpt-5.4-mini` - 0.4 / 1.6
 - `o4-mini` - 1.1 / 4.4
 - `claude-opus-5` - 15.0 / 75.0
+- `claude-sonnet-5` - 3.0 / 15.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -145,3 +145,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 - Provider keys and model selection live in Settings; see the README configuration notes.
 
 ## Glossary
+
+- **per 1M tokens** - prices are quoted per one million tokens; divide token counts by 1,000,000 before multiplying.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -110,3 +110,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 
 - `packages/core/redcell_core/engine/pricing.py` - the price table and estimator.
 - `packages/core/redcell_core/engine/llm.py` - cost resolution order.
+- Issue #64 - the \$0.00 bug this documents.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -117,3 +117,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **Prompt (input) tokens** are everything sent to the model: system prompt, prior turns, tool definitions, and the current message.
 
 **Completion (output) tokens** are what the model generates, including tool-call arguments.
+
+**Total** is prompt plus completion. When a provider omits the total, REDCELL derives it from the two parts.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -7,3 +7,5 @@ How REDCELL measures what a run spends, and why the number is what it is.
 Native LLM APIs (OpenAI, Anthropic, Google, DeepSeek, and so on) return token usage - `prompt_tokens`, `completion_tokens`, `total_tokens` - not a dollar amount. The cost is computed from those tokens and a per-model price.
 
 The exception is OpenRouter, which can return the actual charge in `usage.cost` when the request asks for it. REDCELL uses that real number when available.
+
+## How cost is resolved

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -159,3 +159,4 @@ Cost is informational. Treat it as a close estimate for budgeting, not an invoic
 ## See also
 
 - [DEPLOY.md](DEPLOY.md) - running the stack.
+- Settings in the console - provider keys, model selection, and per-run model override.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -23,3 +23,5 @@ If none apply (an unknown model on a direct provider), cost is 0 rather than a w
 The model catalog uses names like `glm-5.3`, `claude-opus-5`, and `deepseek-v4-pro`. LiteLLM has no prices for them, so `completion_cost` returned 0 and the run never accumulated any cost. The price-table fallback fixes this.
 
 ## Per-run accumulation
+
+Each metered call adds its tokens and cost onto the run via `runs.set_meters`. The run's `tokens` and `cost_usd` grow as the engagement proceeds.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -49,3 +49,5 @@ For OpenRouter you usually do not need a table entry, since the real cost comes 
 The client adds `extra_body={"usage": {"include": true}}` for the `openrouter` provider so the response includes accounting.
 
 It then reads `usage.cost` (USD). This reflects OpenRouter's actual charge, including any per-model routing and discounts.
+
+## Accuracy and caveats

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -67,3 +67,7 @@ A run can carry a `budget_tokens` ceiling. Track spend against it to stop a run 
 Start a live run and watch the header: tokens and dollars should climb as calls complete.
 
 On OpenRouter, compare the shown cost against your OpenRouter dashboard for the same period; they should track closely.
+
+## Model price reference
+
+USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRouter reports its own.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -88,3 +88,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `kimi-k3` - 0.6 / 2.5
 - `kimi-k2.7-code` - 0.5 / 2.0
 - `glm-5.3` - 0.6 / 2.2
+- `glm-5.2` - 0.5 / 1.8

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -33,3 +33,5 @@ The console header shows the running totals next to Elapsed and Model.
 `engine/pricing.py` maps a model to `(input, output)` in USD per 1M tokens. Cost is `prompt/1e6 * input + completion/1e6 * output`.
 
 Lookup is by the last path segment, lowercased, so `z-ai/glm-5.2` and `glm-5.2` resolve the same.
+
+An unknown variant falls back to its family (for example an unlisted `glm-5.x` uses a listed GLM price), so a new model still gets a sensible estimate.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -29,3 +29,5 @@ Each metered call adds its tokens and cost onto the run via `runs.set_meters`. T
 The console header shows the running totals next to Elapsed and Model.
 
 ## The price table
+
+`engine/pricing.py` maps a model to `(input, output)` in USD per 1M tokens. Cost is `prompt/1e6 * input + completion/1e6 * output`.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -83,3 +83,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gemini-3.6-flash` - 0.3 / 2.5
 - `gemini-3.1-flash-lite` - 0.1 / 0.4
 - `deepseek-v4-pro` - 0.6 / 1.7
+- `deepseek-v4-flash` - 0.3 / 0.9

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -35,3 +35,5 @@ The console header shows the running totals next to Elapsed and Model.
 Lookup is by the last path segment, lowercased, so `z-ai/glm-5.2` and `glm-5.2` resolve the same.
 
 An unknown variant falls back to its family (for example an unlisted `glm-5.x` uses a listed GLM price), so a new model still gets a sensible estimate.
+
+Local providers (Ollama) cost nothing, so their estimate is 0 regardless of model.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -9,3 +9,5 @@ Native LLM APIs (OpenAI, Anthropic, Google, DeepSeek, and so on) return token us
 The exception is OpenRouter, which can return the actual charge in `usage.cost` when the request asks for it. REDCELL uses that real number when available.
 
 ## How cost is resolved
+
+For each LLM call, cost is resolved in order:

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -99,3 +99,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 ## FAQ
 
 **Why is it an estimate?** Because most providers do not return a dollar figure; REDCELL multiplies reported tokens by a price. OpenRouter is the exception and returns a real charge.
+
+**The cost looks off.** Check the price-table entry for the model, and remember caching and discounts are not modeled.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -133,3 +133,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 ## Controlling cost
 
 - Pick a cheaper model for routine work; reserve flagship models for hard steps.
+
+- Set a token budget on the run so it stops before overspending.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -1,3 +1,5 @@
 # Cost and token accounting
 
 How REDCELL measures what a run spends, and why the number is what it is.
+
+## Providers report tokens, not dollars

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -101,3 +101,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **Why is it an estimate?** Because most providers do not return a dollar figure; REDCELL multiplies reported tokens by a price. OpenRouter is the exception and returns a real charge.
 
 **The cost looks off.** Check the price-table entry for the model, and remember caching and discounts are not modeled.
+
+**Still \$0.00 on a live run.** The provider may not be returning usage, the model may be unknown on a direct provider, or no LLM calls have completed yet.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -80,3 +80,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `claude-sonnet-5` - 3.0 / 15.0
 - `claude-haiku-4-5` - 0.8 / 4.0
 - `gemini-3.1-pro` - 2.5 / 10.0
+- `gemini-3.6-flash` - 0.3 / 2.5

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -157,3 +157,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 Cost is informational. Treat it as a close estimate for budgeting, not an invoice, except where OpenRouter reports the real charge.
 
 ## See also
+
+- [DEPLOY.md](DEPLOY.md) - running the stack.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -84,3 +84,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gemini-3.1-flash-lite` - 0.1 / 0.4
 - `deepseek-v4-pro` - 0.6 / 1.7
 - `deepseek-v4-flash` - 0.3 / 0.9
+- `deepseek-r2` - 0.7 / 2.4

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -79,3 +79,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `claude-opus-5` - 15.0 / 75.0
 - `claude-sonnet-5` - 3.0 / 15.0
 - `claude-haiku-4-5` - 0.8 / 4.0
+- `gemini-3.1-pro` - 2.5 / 10.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -19,3 +19,5 @@ For each LLM call, cost is resolved in order:
 If none apply (an unknown model on a direct provider), cost is 0 rather than a wrong guess.
 
 ## Why spend used to read \$0.00
+
+The model catalog uses names like `glm-5.3`, `claude-opus-5`, and `deepseek-v4-pro`. LiteLLM has no prices for them, so `completion_cost` returned 0 and the run never accumulated any cost. The price-table fallback fixes this.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -65,3 +65,5 @@ A run can carry a `budget_tokens` ceiling. Track spend against it to stop a run 
 ## Verifying
 
 Start a live run and watch the header: tokens and dollars should climb as calls complete.
+
+On OpenRouter, compare the shown cost against your OpenRouter dashboard for the same period; they should track closely.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -17,3 +17,5 @@ For each LLM call, cost is resolved in order:
 3. **REDCELL price table** - a fallback in `engine/pricing.py` for models LiteLLM does not price (the catalog uses forward-looking model names LiteLLM has no entry for).
 
 If none apply (an unknown model on a direct provider), cost is 0 rather than a wrong guess.
+
+## Why spend used to read \$0.00

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -1,0 +1,1 @@
+# Cost and token accounting

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -21,3 +21,5 @@ If none apply (an unknown model on a direct provider), cost is 0 rather than a w
 ## Why spend used to read \$0.00
 
 The model catalog uses names like `glm-5.3`, `claude-opus-5`, and `deepseek-v4-pro`. LiteLLM has no prices for them, so `completion_cost` returned 0 and the run never accumulated any cost. The price-table fallback fixes this.
+
+## Per-run accumulation

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -123,3 +123,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 Output tokens usually cost more than input, which is why the table prices them separately.
 
 ## How a call is metered
+
+1. The client calls the provider and receives the message plus a usage block.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -143,3 +143,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 ## Related
 
 - Provider keys and model selection live in Settings; see the README configuration notes.
+
+## Glossary

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -43,3 +43,5 @@ Local providers (Ollama) cost nothing, so their estimate is 0 regardless of mode
 Edit `PRICES` in `engine/pricing.py`. Keep entries as USD per 1M tokens `(input, output)`. Prefer real published prices where a model exists.
 
 For OpenRouter you usually do not need a table entry, since the real cost comes back on the response.
+
+## OpenRouter details

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -141,3 +141,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 - OpenRouter gives you real per-call cost, which makes tuning spend easier.
 
 ## Related
+
+- Provider keys and model selection live in Settings; see the README configuration notes.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -97,3 +97,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - Ollama / local models - 0 (self-hosted, no API charge)
 
 ## FAQ
+
+**Why is it an estimate?** Because most providers do not return a dollar figure; REDCELL multiplies reported tokens by a price. OpenRouter is the exception and returns a real charge.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -11,3 +11,5 @@ The exception is OpenRouter, which can return the actual charge in `usage.cost` 
 ## How cost is resolved
 
 For each LLM call, cost is resolved in order:
+
+1. **OpenRouter real cost** - for the `openrouter` provider, the request sets `usage.include`, and the response's `usage.cost` is the charge.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -31,3 +31,5 @@ The console header shows the running totals next to Elapsed and Model.
 ## The price table
 
 `engine/pricing.py` maps a model to `(input, output)` in USD per 1M tokens. Cost is `prompt/1e6 * input + completion/1e6 * output`.
+
+Lookup is by the last path segment, lowercased, so `z-ai/glm-5.2` and `glm-5.2` resolve the same.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -82,3 +82,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gemini-3.1-pro` - 2.5 / 10.0
 - `gemini-3.6-flash` - 0.3 / 2.5
 - `gemini-3.1-flash-lite` - 0.1 / 0.4
+- `deepseek-v4-pro` - 0.6 / 1.7

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -121,3 +121,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 **Total** is prompt plus completion. When a provider omits the total, REDCELL derives it from the two parts.
 
 Output tokens usually cost more than input, which is why the table prices them separately.
+
+## How a call is metered

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -72,3 +72,4 @@ On OpenRouter, compare the shown cost against your OpenRouter dashboard for the 
 
 USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRouter reports its own.
 - `gpt-5.6` - 5.0 / 15.0
+- `gpt-5.5` - 3.0 / 10.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -129,3 +129,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 3. It resolves cost (OpenRouter real, then LiteLLM, then table).
 4. The runner books tokens and cost onto the run with `set_meters`.
 5. The header reflects the new totals on the next update.
+
+## Controlling cost

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -109,3 +109,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 ## References
 
 - `packages/core/redcell_core/engine/pricing.py` - the price table and estimator.
+- `packages/core/redcell_core/engine/llm.py` - cost resolution order.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -135,3 +135,5 @@ Output tokens usually cost more than input, which is why the table prices them s
 - Pick a cheaper model for routine work; reserve flagship models for hard steps.
 
 - Set a token budget on the run so it stops before overspending.
+
+- Keep scope tight; fewer targets and turns means fewer tokens.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -59,3 +59,5 @@ Prompt caching, batch discounts, and provider promotions are not modeled in the 
 If a provider omits usage, tokens and cost for that call are 0.
 
 ## Budgets
+
+A run can carry a `budget_tokens` ceiling. Track spend against it to stop a run before it runs away.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -93,3 +93,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `glm-4.5-air` - 0.2 / 1.1
 - `llama-4-70b` - 0.6 / 0.9
 - `qwen3-72b` - 0.6 / 0.9
+- `deepseek-v4` - 0.6 / 1.7

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -73,3 +73,4 @@ On OpenRouter, compare the shown cost against your OpenRouter dashboard for the 
 USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRouter reports its own.
 - `gpt-5.6` - 5.0 / 15.0
 - `gpt-5.5` - 3.0 / 10.0
+- `gpt-5.4` - 2.5 / 8.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -76,3 +76,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `gpt-5.4` - 2.5 / 8.0
 - `gpt-5.4-mini` - 0.4 / 1.6
 - `o4-mini` - 1.1 / 4.4
+- `claude-opus-5` - 15.0 / 75.0

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -1,1 +1,3 @@
 # Cost and token accounting
+
+How REDCELL measures what a run spends, and why the number is what it is.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -53,3 +53,5 @@ It then reads `usage.cost` (USD). This reflects OpenRouter's actual charge, incl
 ## Accuracy and caveats
 
 For non-OpenRouter providers the number is an estimate. It is only as accurate as the price table and the usage the provider reports.
+
+Prompt caching, batch discounts, and provider promotions are not modeled in the table, so estimated cost can run high or low.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -25,3 +25,5 @@ The model catalog uses names like `glm-5.3`, `claude-opus-5`, and `deepseek-v4-p
 ## Per-run accumulation
 
 Each metered call adds its tokens and cost onto the run via `runs.set_meters`. The run's `tokens` and `cost_usd` grow as the engagement proceeds.
+
+The console header shows the running totals next to Elapsed and Model.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -128,3 +128,4 @@ Output tokens usually cost more than input, which is why the table prices them s
 2. It parses total, prompt, and completion tokens from usage.
 3. It resolves cost (OpenRouter real, then LiteLLM, then table).
 4. The runner books tokens and cost onto the run with `set_meters`.
+5. The header reflects the new totals on the next update.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -94,3 +94,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `llama-4-70b` - 0.6 / 0.9
 - `qwen3-72b` - 0.6 / 0.9
 - `deepseek-v4` - 0.6 / 1.7
+- Ollama / local models - 0 (self-hosted, no API charge)

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -115,3 +115,5 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 ## Tokens explained
 
 **Prompt (input) tokens** are everything sent to the model: system prompt, prior turns, tool definitions, and the current message.
+
+**Completion (output) tokens** are what the model generates, including tool-call arguments.

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -92,3 +92,4 @@ USD per 1M tokens as (input, output). Estimates for the fallback table; OpenRout
 - `glm-4.6` - 0.4 / 1.6
 - `glm-4.5-air` - 0.2 / 1.1
 - `llama-4-70b` - 0.6 / 0.9
+- `qwen3-72b` - 0.6 / 0.9

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -14,3 +14,4 @@ For each LLM call, cost is resolved in order:
 
 1. **OpenRouter real cost** - for the `openrouter` provider, the request sets `usage.include`, and the response's `usage.cost` is the charge.
 2. **LiteLLM price map** - `litellm.completion_cost` multiplies the returned tokens by LiteLLM's own prices for models it knows.
+3. **REDCELL price table** - a fallback in `engine/pricing.py` for models LiteLLM does not price (the catalog uses forward-looking model names LiteLLM has no entry for).

--- a/packages/core/redcell_core/engine/llm.py
+++ b/packages/core/redcell_core/engine/llm.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ..config import settings
 from ..schemas import LlmSettings
+from .pricing import estimate_cost
 
 # provider id -> LiteLLM model prefix. Providers LiteLLM does not route natively
 # fall back to an OpenAI-compatible base URL from settings.
@@ -67,6 +68,9 @@ class LlmClient:
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = tool_choice
+        # Ask OpenRouter to report the actual charge in usage.cost.
+        if self.cfg.provider == "openrouter":
+            kwargs.setdefault("extra_body", {})["usage"] = {"include": True}
         resp = await litellm.acompletion(model=self._model(), messages=messages, **kwargs)
         choice = resp["choices"][0]["message"]
         out: dict[str, Any] = {"role": "assistant", "content": choice.get("content") or ""}
@@ -76,21 +80,68 @@ class LlmClient:
                 {"id": tc["id"], "name": tc["function"]["name"], "arguments": tc["function"]["arguments"]}
                 for tc in tcs
             ]
-        out["usage_tokens"] = _usage_total(resp)
-        try:
-            out["cost"] = float(litellm.completion_cost(completion_response=resp) or 0.0)
-        except Exception:
-            out["cost"] = 0.0
+        total, prompt, completion = _usage(resp)
+        out["usage_tokens"] = total
+        out["cost"] = self._cost(resp, prompt, completion)
         return out
 
+    def _cost(self, resp: Any, prompt_tokens: int, completion_tokens: int) -> float:
+        # 1. OpenRouter reports the real charge in usage.cost when include is set.
+        if self.cfg.provider == "openrouter":
+            direct = _usage_cost(resp)
+            if direct:
+                return direct
+        # 2. LiteLLM's price map, accurate for models it knows.
+        try:
+            import litellm
 
-def _usage_total(resp: Any) -> int:
-    usage = resp.get("usage") if hasattr(resp, "get") else None
-    if usage is None:
-        return 0
-    if hasattr(usage, "total_tokens"):
-        return int(usage.total_tokens or 0)
+            metered = float(litellm.completion_cost(completion_response=resp) or 0.0)
+            if metered:
+                return metered
+        except Exception:
+            pass
+        # 3. Our fallback table for the catalog models.
+        return estimate_cost(self.cfg.model, prompt_tokens, completion_tokens, self.cfg.provider)
+
+
+def _usage_obj(resp: Any) -> Any:
+    if resp is None:
+        return None
+    if hasattr(resp, "get"):
+        return resp.get("usage")
+    return getattr(resp, "usage", None)
+
+
+def _field(obj: Any, name: str) -> Any:
+    if obj is None:
+        return None
+    if hasattr(obj, name):
+        return getattr(obj, name)
+    if hasattr(obj, "get"):
+        return obj.get(name)
+    return None
+
+
+def _int(v: Any) -> int:
     try:
-        return int(usage.get("total_tokens") or 0)
+        return int(v or 0)
     except Exception:
         return 0
+
+
+def _usage(resp: Any) -> tuple[int, int, int]:
+    u = _usage_obj(resp)
+    total = _int(_field(u, "total_tokens"))
+    prompt = _int(_field(u, "prompt_tokens"))
+    completion = _int(_field(u, "completion_tokens"))
+    if not total:
+        total = prompt + completion
+    return total, prompt, completion
+
+
+def _usage_cost(resp: Any) -> float:
+    u = _usage_obj(resp)
+    try:
+        return float(_field(u, "cost") or 0.0)
+    except Exception:
+        return 0.0

--- a/packages/core/redcell_core/engine/pricing.py
+++ b/packages/core/redcell_core/engine/pricing.py
@@ -1,0 +1,64 @@
+"""Fallback token pricing for models LiteLLM does not price.
+
+Prices are USD per 1M tokens as (input, output). LiteLLM is tried first in the
+client; this table fills the gap for the catalog models (and future variants
+via a family match). Local providers cost nothing.
+"""
+
+from __future__ import annotations
+
+PRICES: dict[str, tuple[float, float]] = {
+    "gpt-5.6": (5.0, 15.0),
+    "gpt-5.5": (3.0, 10.0),
+    "gpt-5.4": (2.5, 8.0),
+    "gpt-5.4-mini": (0.4, 1.6),
+    "o4-mini": (1.1, 4.4),
+    "claude-opus-5": (15.0, 75.0),
+    "claude-sonnet-5": (3.0, 15.0),
+    "claude-haiku-4-5": (0.8, 4.0),
+    "gemini-3.1-pro": (2.5, 10.0),
+    "gemini-3.6-flash": (0.3, 2.5),
+    "gemini-3.1-flash-lite": (0.1, 0.4),
+    "deepseek-v4-pro": (0.6, 1.7),
+    "deepseek-v4-flash": (0.3, 0.9),
+    "deepseek-r2": (0.7, 2.4),
+    "kimi-k3": (0.6, 2.5),
+    "kimi-k2.7-code": (0.5, 2.0),
+    "glm-5.3": (0.6, 2.2),
+    "glm-5.2": (0.5, 1.8),
+    "glm-4.6": (0.4, 1.6),
+    "glm-4.5-air": (0.2, 1.1),
+    "llama-4-70b": (0.6, 0.9),
+    "qwen3-72b": (0.6, 0.9),
+    "deepseek-v4": (0.6, 1.7),
+}
+
+_FREE_PROVIDERS = {"ollama"}
+
+
+def _norm(model: str) -> str:
+    return model.split("/")[-1].strip().lower()
+
+
+def price_for(model: str) -> tuple[float, float] | None:
+    n = _norm(model)
+    if n in PRICES:
+        return PRICES[n]
+    for key, val in PRICES.items():
+        if n.startswith(key) or key.startswith(n):
+            return val
+    fam = n.split("-")[0]
+    for key, val in PRICES.items():
+        if key.split("-")[0] == fam:
+            return val
+    return None
+
+
+def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int, provider: str | None = None) -> float:
+    if provider in _FREE_PROVIDERS:
+        return 0.0
+    p = price_for(model)
+    if p is None:
+        return 0.0
+    inp, outp = p
+    return round(prompt_tokens / 1_000_000 * inp + completion_tokens / 1_000_000 * outp, 6)

--- a/packages/core/tests/test_pricing.py
+++ b/packages/core/tests/test_pricing.py
@@ -1,0 +1,56 @@
+"""Cost resolution: OpenRouter real cost first, then LiteLLM, then the table."""
+
+import litellm
+from redcell_core.engine.llm import LlmClient, _usage, _usage_cost
+from redcell_core.engine.pricing import estimate_cost, price_for
+from redcell_core.schemas import LlmSettings
+
+
+def test_price_exact():
+    assert price_for("claude-opus-5") == (15.0, 75.0)
+
+
+def test_price_strips_vendor_prefix():
+    assert price_for("z-ai/glm-5.2") == (0.5, 1.8)
+
+
+def test_price_family_fallback_for_unknown_variant():
+    assert price_for("glm-5.9") is not None
+
+
+def test_estimate_cost_math():
+    assert estimate_cost("claude-opus-5", 1_000_000, 1_000_000) == 90.0
+
+
+def test_estimate_cost_is_zero_for_local_provider():
+    assert estimate_cost("glm-4", 1_000_000, 1_000_000, provider="ollama") == 0.0
+
+
+def test_estimate_cost_zero_for_unknown_model():
+    assert estimate_cost("totally-unknown-9000", 1000, 1000) == 0.0
+
+
+def test_usage_parses_dict():
+    assert _usage({"usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}) == (15, 10, 5)
+
+
+def test_usage_total_is_derived_when_missing():
+    total, _p, _c = _usage({"usage": {"prompt_tokens": 10, "completion_tokens": 5}})
+    assert total == 15
+
+
+def test_usage_cost_extracted():
+    assert _usage_cost({"usage": {"cost": 0.0123}}) == 0.0123
+
+
+def test_cost_prefers_openrouter_real_cost():
+    client = LlmClient(LlmSettings(provider="openrouter", model="z-ai/glm-5.2"))
+    resp = {"usage": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150, "cost": 0.0042}}
+    assert client._cost(resp, 100, 50) == 0.0042
+
+
+def test_cost_falls_back_to_table(monkeypatch):
+    monkeypatch.setattr(litellm, "completion_cost", lambda **_: 0.0)
+    client = LlmClient(LlmSettings(provider="anthropic", model="claude-opus-5"))
+    resp = {"usage": {"prompt_tokens": 1_000_000, "completion_tokens": 0, "total_tokens": 1_000_000}}
+    assert client._cost(resp, 1_000_000, 0) == 15.0


### PR DESCRIPTION
Closes #64.

Session spend always read `$0.00`. Providers return token usage, not dollars, so REDCELL computes cost from tokens - but the catalog model names (`glm-5.3`, `claude-opus-5`, `deepseek-v4-pro`, ...) are not in LiteLLM's price map, so `litellm.completion_cost` returned 0 and the run never accumulated any cost.

## Fix
- **OpenRouter real cost**: for the `openrouter` provider, request `usage.include` and read the actual `usage.cost` off the response.
- **Fallback price table** (`engine/pricing.py`): USD per 1M tokens `(input, output)` for the catalog models, with a family match for variants and zero cost for local providers.
- **Resolution order** in `LlmClient._cost`: OpenRouter real cost -> LiteLLM price map -> REDCELL table -> 0.
- Robust parsing of prompt/completion/total tokens from either a dict or an object usage block.

Downstream already worked: `runs.set_meters` accumulates `tokens` and `cost_usd` onto the run, and the header renders `run.costUsd` - it was just always 0.

## Tests
`test_pricing.py`: exact/prefix/family price lookup, cost math, local-provider zero, unknown-model zero, usage parsing, and the resolution order (OpenRouter cost preferred, table fallback). Verified locally.

## Docs
New `docs/COST.md` explains tokens vs dollars, the three-tier resolution, the price table and how to update it, OpenRouter specifics, accuracy caveats, and a per-model reference. Linked from the README.

Please merge with a **merge commit** to preserve the commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV