### PR TITLE
feat: in-app Update button when a new version is available

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ CADDYFILE=Caddyfile
 # Login cookie flag. Must be false over plain HTTP on an IP, true over HTTPS
 # (including behind a proxy that serves HTTPS to the browser).
 REDCELL_COOKIE_SECURE=false
+# Host path of this checkout, so the in-app updater can run docker compose here.
+# deploy.sh sets this for you; leave blank to disable the in-app Update button.
+REDCELL_COMPOSE_DIR=
+# Image used for the one-shot updater container (needs the docker compose plugin).
+REDCELL_UPDATER_IMAGE=docker:cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           push: true
+          build-args: |
+            VERSION=${{ steps.v.outputs.version }}
           tags: |
             ${{ steps.v.outputs.image }}:${{ steps.v.outputs.version }}
             ${{ steps.v.outputs.image }}:latest

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ deploy.sh                    interactive self-host deploy
 - [Pre-authentication surface](docs/PRE-AUTH-SURFACE.md) — what an unauthenticated client can observe, and how to keep that minimal.
 - [Cost & token accounting](docs/COST.md) — how run spend is measured, the price table, and OpenRouter real cost.
 - [Command palette & shortcuts](docs/SHORTCUTS.md) — Cmd/Ctrl+K to search sessions, servers, and proxies, and keyboard navigation.
+- [Updating](docs/UPDATING.md) — the in-app Update button and updating from the shell.
 
 ## Contributing
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -10,7 +10,7 @@ from redcell_core.bus import bus
 from redcell_core.config import settings
 from redcell_core.logs import configure as configure_logging
 
-from .routers import ai, auth, files, infra, reports, resources, ws
+from .routers import ai, auth, files, infra, reports, resources, system, ws
 from .routers import settings as settings_router
 
 
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
 
     prefix = settings.api_prefix
     for r in (auth.router, resources.router, settings_router.router, infra.router,
-              files.router, reports.router, ai.router, ws.router):
+              files.router, reports.router, ai.router, system.router, ws.router):
         app.include_router(r, prefix=prefix)
 
     @app.get("/health")

--- a/apps/api/app/routers/system.py
+++ b/apps/api/app/routers/system.py
@@ -1,0 +1,103 @@
+"""Runtime version and in-app self-update."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+from fastapi import APIRouter, Depends, HTTPException
+from redcell_core.schemas import Camel
+from redcell_core.security import User, current_user
+
+router = APIRouter(tags=["system"], dependencies=[Depends(current_user)])
+
+_GITHUB_LATEST = "https://api.github.com/repos/martian56/redcell/releases/latest"
+_cache: dict[str, object] = {"at": 0.0, "latest": None}
+_CACHE_TTL = 600.0
+
+
+class VersionInfo(Camel):
+    current: str
+    latest: str | None = None
+    update_available: bool = False
+
+
+class UpdateStarted(Camel):
+    started: bool
+    detail: str
+
+
+def current_version() -> str:
+    return os.environ.get("REDCELL_VERSION") or "dev"
+
+
+def _norm(v: str | None) -> tuple[int, ...]:
+    if not v:
+        return ()
+    parts: list[int] = []
+    for p in v.strip().lstrip("vV").split("."):
+        digits = "".join(ch for ch in p if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def update_available(current: str, latest: str | None) -> bool:
+    if not latest or current == "dev":
+        return False
+    return _norm(latest) > _norm(current)
+
+
+async def _latest_version() -> str | None:
+    now = time.time()
+    if _cache["latest"] is not None and now - float(_cache["at"]) < _CACHE_TTL:
+        return _cache["latest"]  # type: ignore[return-value]
+    tag: str | None = None
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=6.0) as client:
+            r = await client.get(_GITHUB_LATEST, headers={"accept": "application/vnd.github+json"})
+            r.raise_for_status()
+            tag = r.json().get("tag_name")
+    except Exception:
+        tag = None
+    if tag:
+        _cache["latest"] = tag
+        _cache["at"] = now
+    return _cache["latest"]  # type: ignore[return-value]
+
+
+@router.get("/system/version", response_model=VersionInfo)
+async def version() -> VersionInfo:
+    current = current_version()
+    latest = await _latest_version()
+    return VersionInfo(current=current, latest=latest, update_available=update_available(current, latest))
+
+
+@router.post("/system/update", response_model=UpdateStarted)
+async def start_update(user: User = Depends(current_user)) -> UpdateStarted:
+    if user.role != "admin":
+        raise HTTPException(403, "admin only")
+    repo_dir = os.environ.get("REDCELL_COMPOSE_DIR")
+    if not repo_dir:
+        raise HTTPException(400, "in-app update is not available on this deployment (REDCELL_COMPOSE_DIR is not set)")
+    image = os.environ.get("REDCELL_UPDATER_IMAGE") or "docker:cli"
+    cmd = [
+        "docker", "run", "-d", "--rm",
+        "-v", "/var/run/docker.sock:/var/run/docker.sock",
+        "-v", f"{repo_dir}:/repo",
+        "-w", "/repo",
+        image,
+        "sh", "-c", "docker compose pull && docker compose up -d",
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+        )
+        out, _ = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError((out or b"").decode(errors="replace")[-300:])
+    except Exception as exc:
+        raise HTTPException(500, f"could not start the updater: {exc}") from None
+    return UpdateStarted(started=True, detail="Update started. The stack will pull new images and restart shortly.")

--- a/apps/api/tests/test_system.py
+++ b/apps/api/tests/test_system.py
@@ -1,0 +1,27 @@
+"""Version comparison for the self-update endpoint."""
+
+from app.routers.system import _norm, current_version, update_available
+
+
+def test_norm_parses_versions():
+    assert _norm("v1.2.3") == (1, 2, 3)
+    assert _norm("0.3.2") == (0, 3, 2)
+
+
+def test_update_available_when_newer():
+    assert update_available("0.3.2", "v0.3.3") is True
+    assert update_available("0.9.0", "v0.10.0") is True
+
+
+def test_no_update_when_equal_or_older():
+    assert update_available("0.3.2", "v0.3.2") is False
+    assert update_available("0.3.3", "v0.3.2") is False
+
+
+def test_no_update_when_dev_or_unknown():
+    assert update_available("dev", "v1.0.0") is False
+    assert update_available("0.3.2", None) is False
+
+
+def test_current_version_is_a_string():
+    assert isinstance(current_version(), str)

--- a/apps/web/src/app/UpdateBanner.test.tsx
+++ b/apps/web/src/app/UpdateBanner.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mutateAsync = vi.fn(async () => ({ started: true, detail: 'Update started.' }));
+vi.mock('@/features/hooks', () => ({
+  useVersion: () => ({ data: { current: '0.3.2', latest: '0.3.3', updateAvailable: true } }),
+  useSelfUpdate: () => ({ mutateAsync, isPending: false }),
+}));
+
+import { UpdateBanner } from './UpdateBanner';
+
+describe('UpdateBanner', () => {
+  it('shows current and latest, and triggers the update', async () => {
+    render(<UpdateBanner />);
+    expect(screen.getByText('0.3.2')).toBeTruthy();
+    expect(screen.getByText('0.3.3')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /update now/i }));
+    expect(mutateAsync).toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText(/update started/i)).toBeTruthy());
+  });
+});

--- a/apps/web/src/app/UpdateBanner.tsx
+++ b/apps/web/src/app/UpdateBanner.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useSelfUpdate, useVersion } from '@/features/hooks';
+
+export function UpdateBanner() {
+  const { data: v } = useVersion();
+  const update = useSelfUpdate();
+  const [msg, setMsg] = useState<string | null>(null);
+  if (!v) return null;
+  const onUpdate = async () => {
+    setMsg(null);
+    try {
+      const r = await update.mutateAsync();
+      setMsg(r.detail);
+    } catch {
+      setMsg('In-app update is not available on this deployment.');
+    }
+  };
+  return (
+    <div className="updbar">
+      <div className="updbar-v">
+        <span className="meta">Version</span>
+        <span className="mono">{v.current}</span>
+      </div>
+      {v.updateAvailable ? (
+        <div className="updbar-act">
+          <span>
+            Update available: <b className="mono">{v.latest}</b>
+          </span>
+          <button type="button" className="btn pri sm" disabled={update.isPending} onClick={onUpdate}>
+            {update.isPending ? 'Starting…' : 'Update now'}
+          </button>
+        </div>
+      ) : (
+        <span className="meta">Up to date</span>
+      )}
+      {msg ? <span className="meta updbar-msg">{msg}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/pages/SettingsPage.tsx
+++ b/apps/web/src/app/pages/SettingsPage.tsx
@@ -5,12 +5,51 @@ import {
   useProviders,
   useRemoveProviderKey,
   useSaveSettings,
+  useSelfUpdate,
   useSetProviderKey,
   useSettings,
+  useVersion,
 } from '@/features/hooks';
 import { Spinner } from '@/components/ui/primitives';
 import { Dialog } from '@/components/ui/Dialog';
 import { toast } from '@/components/ui/toast';
+
+function UpdateBanner() {
+  const { data: v } = useVersion();
+  const update = useSelfUpdate();
+  const [msg, setMsg] = useState<string | null>(null);
+  if (!v) return null;
+  const onUpdate = async () => {
+    setMsg(null);
+    try {
+      const r = await update.mutateAsync();
+      setMsg(r.detail);
+    } catch {
+      setMsg('In-app update is not available on this deployment.');
+    }
+  };
+  return (
+    <div className="updbar">
+      <div className="updbar-v">
+        <span className="meta">Version</span>
+        <span className="mono">{v.current}</span>
+      </div>
+      {v.updateAvailable ? (
+        <div className="updbar-act">
+          <span>
+            Update available: <b className="mono">{v.latest}</b>
+          </span>
+          <button type="button" className="btn pri sm" disabled={update.isPending} onClick={onUpdate}>
+            {update.isPending ? 'Starting…' : 'Update now'}
+          </button>
+        </div>
+      ) : (
+        <span className="meta">Up to date</span>
+      )}
+      {msg ? <span className="meta updbar-msg">{msg}</span> : null}
+    </div>
+  );
+}
 
 type Tab = 'providers' | 'execution' | 'scope' | 'branding';
 
@@ -83,6 +122,7 @@ export function SettingsPage() {
 
   return (
     <div className="wrap">
+      <UpdateBanner />
       <div className="settings">
         <div className="subnav">
           {TABS.map((t) => (

--- a/apps/web/src/app/pages/SettingsPage.tsx
+++ b/apps/web/src/app/pages/SettingsPage.tsx
@@ -5,51 +5,13 @@ import {
   useProviders,
   useRemoveProviderKey,
   useSaveSettings,
-  useSelfUpdate,
   useSetProviderKey,
   useSettings,
-  useVersion,
 } from '@/features/hooks';
 import { Spinner } from '@/components/ui/primitives';
 import { Dialog } from '@/components/ui/Dialog';
 import { toast } from '@/components/ui/toast';
-
-function UpdateBanner() {
-  const { data: v } = useVersion();
-  const update = useSelfUpdate();
-  const [msg, setMsg] = useState<string | null>(null);
-  if (!v) return null;
-  const onUpdate = async () => {
-    setMsg(null);
-    try {
-      const r = await update.mutateAsync();
-      setMsg(r.detail);
-    } catch {
-      setMsg('In-app update is not available on this deployment.');
-    }
-  };
-  return (
-    <div className="updbar">
-      <div className="updbar-v">
-        <span className="meta">Version</span>
-        <span className="mono">{v.current}</span>
-      </div>
-      {v.updateAvailable ? (
-        <div className="updbar-act">
-          <span>
-            Update available: <b className="mono">{v.latest}</b>
-          </span>
-          <button type="button" className="btn pri sm" disabled={update.isPending} onClick={onUpdate}>
-            {update.isPending ? 'Starting…' : 'Update now'}
-          </button>
-        </div>
-      ) : (
-        <span className="meta">Up to date</span>
-      )}
-      {msg ? <span className="meta updbar-msg">{msg}</span> : null}
-    </div>
-  );
-}
+import { UpdateBanner } from '../UpdateBanner';
 
 type Tab = 'providers' | 'execution' | 'scope' | 'branding';
 

--- a/apps/web/src/features/hooks.ts
+++ b/apps/web/src/features/hooks.ts
@@ -444,3 +444,18 @@ export function useRunEvents(runId: string | null, max = 60) {
   }, [api, runId, max]);
   return events;
 }
+
+export function useVersion() {
+  const api = useApi();
+  return useQuery({
+    queryKey: ['system', 'version'],
+    queryFn: () => api.system.version(),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+}
+
+export function useSelfUpdate() {
+  const api = useApi();
+  return useMutation({ mutationFn: () => api.system.update() });
+}

--- a/apps/web/src/styles/design.css
+++ b/apps/web/src/styles/design.css
@@ -1600,3 +1600,32 @@ svg.chart {
   text-overflow: ellipsis;
   min-width: 0;
 }
+
+.updbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding: 11px 14px;
+  margin-bottom: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  background: var(--bg);
+  font-size: 12.5px;
+  color: var(--tx-2);
+}
+.updbar-v {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.updbar-act {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+.updbar-msg {
+  flex-basis: 100%;
+  color: var(--tx-3);
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -111,6 +111,8 @@ case "$mode" in
     ;;
 esac
 
+set_env REDCELL_COMPOSE_DIR "$(pwd)"
+
 say ""
 say "Pulling images..."
 docker compose pull

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ x-app-env: &app-env
   REDCELL_ADMIN_PASSWORD_FILE: /run/redcell/admin_password
   REDCELL_COOKIE_SECURE: ${REDCELL_COOKIE_SECURE:-true}
   REDCELL_CORS_ORIGINS: ${REDCELL_CORS_ORIGINS:-http://localhost:5183}
+  REDCELL_COMPOSE_DIR: ${REDCELL_COMPOSE_DIR:-}
+  REDCELL_UPDATER_IMAGE: ${REDCELL_UPDATER_IMAGE:-docker:cli}
 
 services:
   postgres:

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -19,6 +19,8 @@ COPY apps/api ./apps/api
 RUN uv sync --frozen --group live
 
 ENV PATH="/app/.venv/bin:$PATH"
+ARG VERSION=dev
+ENV REDCELL_VERSION=$VERSION
 WORKDIR /app/apps/api
 EXPOSE 8080
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -19,5 +19,7 @@ COPY apps/worker ./apps/worker
 RUN uv sync --frozen --group live
 
 ENV PATH="/app/.venv/bin:$PATH"
+ARG VERSION=dev
+ENV REDCELL_VERSION=$VERSION
 WORKDIR /app/apps/worker
 CMD ["arq", "worker.settings.WorkerSettings"]

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -137,6 +137,8 @@ docker compose up -d
 
 Because the deploy mode lives entirely in `.env`, a `git pull` never conflicts with local changes. Your mode is preserved across updates.
 
+You can also update from the console: see [UPDATING.md](UPDATING.md) for the in-app Update button.
+
 ## Changing how it is reached
 
 Re-run `./deploy.sh` and pick a different option, or edit `SITE_ADDRESS`, `CADDYFILE`, `REDCELL_COOKIE_SECURE`, and `REDCELL_CORS_ORIGINS` in `.env` and run `docker compose up -d`.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -140,3 +140,5 @@ Your data in the named volumes is preserved across the update.
 ## Best practices
 
 - Update in a quiet window, not during a live run.
+
+- Take a database dump first for anything important.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -162,3 +162,4 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 ## See also
 
 - [DEPLOY.md](DEPLOY.md) - deploying and the update commands in context.
+- [COST.md](COST.md) - unrelated, but another operator reference.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -191,3 +191,7 @@ The latest-release lookup is cached for a few minutes, so a brand-new release ca
 ## Manual trigger
 
 You can trigger the same update from the shell with the compose commands above; the button is a convenience, not the only path.
+
+## Where the version comes from
+
+The banner's current version is whatever `REDCELL_VERSION` the running image was built with; a locally built image without the build-arg reports `dev`.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -92,3 +92,5 @@ curl -s https://your-domain/api/v1/system/version
 **Permission denied on the socket.** The api container must have access to `/var/run/docker.sock`. The compose file mounts it by default.
 
 **Stuck updating.** The pull may be slow on a large image. Give it time, then check `docker compose ps` and logs.
+
+## API

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -138,3 +138,5 @@ Your data in the named volumes is preserved across the update.
 **Can it auto-update on a schedule?** Not yet; updates are on demand from the button.
 
 ## Best practices
+
+- Update in a quiet window, not during a live run.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -183,3 +183,7 @@ REDCELL has one operator account, which is the admin, so the admin gate means th
 ## Watching the updater
 
 The updater runs as its own container; `docker ps` shows it briefly, and its logs show the pull and recreate.
+
+## Latest is cached
+
+The latest-release lookup is cached for a few minutes, so a brand-new release can take a moment to appear in the banner.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -110,3 +110,5 @@ Both require a valid session; update additionally requires the admin role.
 - `REDCELL_VERSION` - baked into the image at build; the running version.
 
 ## End to end
+
+1. The banner polls the version endpoint and compares against the latest release.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -49,3 +49,5 @@ The docker socket is root-equivalent on the host. The update endpoint is a real 
 Only an admin can trigger an update, and only when `REDCELL_COMPOSE_DIR` is set. If you do not want in-app updates, leave it unset.
 
 Updates pull `:latest` from the project's registry. Trust that registry, or pin to a specific version tag you have reviewed.
+
+## Updating from the shell

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -98,3 +98,5 @@ curl -s https://your-domain/api/v1/system/version
 - `GET /api/v1/system/version` returns `{ current, latest, updateAvailable }`.
 
 - `POST /api/v1/system/update` (admin) starts the update and returns `{ started, detail }`.
+
+Both require a valid session; update additionally requires the admin role.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -62,3 +62,5 @@ docker compose up -d
 This is the same set of steps the button runs, plus a `git pull` to refresh the compose file and scripts.
 
 ## Rolling back
+
+Pin the image tags to a previous version (for example `:0.3.2`) in an override, or check out the matching commit and `docker compose up -d`.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,3 +1,5 @@
 # Updating REDCELL
 
 Two ways to update a self-hosted REDCELL: the in-app Update button, or pulling and restarting from the shell.
+
+## In-app update

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -35,3 +35,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 ## Requirements for the button
 
 - `REDCELL_COMPOSE_DIR` must point at the host checkout so the updater can find the compose file. `deploy.sh` sets it; leave it blank to disable the button.
+
+- The api container needs the docker socket (it already mounts it to run tools).

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -39,3 +39,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 - The api container needs the docker socket (it already mounts it to run tools).
 
 - The updater image (`REDCELL_UPDATER_IMAGE`, default `docker:cli`) needs the docker compose plugin.
+
+- Compose tracks `:latest`, so a pull fetches the new build.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -13,3 +13,5 @@ The banner shows the running version and, when available, the latest release to 
 The running version is baked into the api and worker images at build time as `REDCELL_VERSION`, set from the release tag.
 
 The latest version comes from the GitHub Releases API for the repository, cached briefly to avoid rate limits.
+
+An update is offered when the latest release compares greater than the running version. A `dev` build never shows an update.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -45,3 +45,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 ## Security
 
 The docker socket is root-equivalent on the host. The update endpoint is a real privilege boundary.
+
+Only an admin can trigger an update, and only when `REDCELL_COMPOSE_DIR` is set. If you do not want in-app updates, leave it unset.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -130,3 +130,5 @@ Your data in the named volumes is preserved across the update.
 **Should I back up first?** Backing up the database and volumes before an update is good practice. See DEPLOY.md.
 
 **Does it need internet?** Yes, to check the latest release and to pull new images.
+
+**How do I disable it?** Leave `REDCELL_COMPOSE_DIR` unset. The endpoint then refuses and the button does nothing useful.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -114,3 +114,4 @@ Both require a valid session; update additionally requires the admin role.
 1. The banner polls the version endpoint and compares against the latest release.
 2. An admin clicks Update.
 3. The api launches a detached updater container with the socket and the checkout mounted.
+4. The updater pulls new images and runs `up -d`, which re-applies migrations.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -58,3 +58,5 @@ git pull
 docker compose pull
 docker compose up -d
 ```
+
+This is the same set of steps the button runs, plus a `git pull` to refresh the compose file and scripts.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -102,3 +102,5 @@ curl -s https://your-domain/api/v1/system/version
 Both require a valid session; update additionally requires the admin role.
 
 ## Configuration
+
+- `REDCELL_COMPOSE_DIR` - host path of the checkout; enables the button.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,0 +1,1 @@
+# Updating REDCELL

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -148,3 +148,5 @@ Your data in the named volumes is preserved across the update.
 - Pin a version if you need change control rather than always tracking latest.
 
 ## Notes
+
+Running the update when already current is harmless: the pull finds nothing new and `up -d` is a no-op.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -7,3 +7,5 @@ Two ways to update a self-hosted REDCELL: the in-app Update button, or pulling a
 Settings shows a version banner. When a newer release exists, an admin sees an Update button.
 
 The banner shows the running version and, when available, the latest release to update to.
+
+## How the version is known

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -157,3 +157,4 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 
 - `apps/api/app/routers/system.py` - the version and update endpoints.
 - `apps/web/src/app/UpdateBanner.tsx` - the Settings banner.
+- Issue #66 - the request this implements.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -118,3 +118,5 @@ Both require a valid session; update additionally requires the admin role.
 5. The app restarts; the banner shows the new version.
 
 ## What updates
+
+The api, worker, and web images update to the new release. Postgres, Redis, and MinIO stay on their pinned versions.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -80,3 +80,5 @@ curl -s https://your-domain/api/v1/system/version
 ## Troubleshooting
 
 **No Update button.** Either you are already up to date, the build is `dev`, or `REDCELL_COMPOSE_DIR` is unset. Set it and redeploy to enable the button.
+
+**"In-app update is not available on this deployment."** `REDCELL_COMPOSE_DIR` is not set. `deploy.sh` sets it; add it to `.env` and `docker compose up -d`.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -43,3 +43,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 - Compose tracks `:latest`, so a pull fetches the new build.
 
 ## Security
+
+The docker socket is root-equivalent on the host. The update endpoint is a real privilege boundary.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -126,3 +126,5 @@ Your data in the named volumes is preserved across the update.
 ## FAQ
 
 **Is the update safe to run during work?** It restarts the stack, so avoid it mid-engagement. Data is preserved, but active connections drop briefly.
+
+**Should I back up first?** Backing up the database and volumes before an update is good practice. See DEPLOY.md.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -134,3 +134,5 @@ Your data in the named volumes is preserved across the update.
 **How do I disable it?** Leave `REDCELL_COMPOSE_DIR` unset. The endpoint then refuses and the button does nothing useful.
 
 **Why not Watchtower?** Watchtower recreates containers but does not re-run the compose one-shots, so migrations would be skipped. Running compose keeps migrations in the loop.
+
+**Can it auto-update on a schedule?** Not yet; updates are on demand from the button.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -160,3 +160,5 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 - Issue #66 - the request this implements.
 
 ## See also
+
+- [DEPLOY.md](DEPLOY.md) - deploying and the update commands in context.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -21,3 +21,5 @@ An update is offered when the latest release compares greater than the running v
 It calls an admin-only endpoint that launches a one-shot updater container on the host.
 
 The updater runs `docker compose pull` then `docker compose up -d` against this deployment's compose file.
+
+`up -d` re-runs the one-shot `migrate` service, so database migrations in the new version are applied automatically.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -19,3 +19,5 @@ An update is offered when the latest release compares greater than the running v
 ## What the button does
 
 It calls an admin-only endpoint that launches a one-shot updater container on the host.
+
+The updater runs `docker compose pull` then `docker compose up -d` against this deployment's compose file.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -163,3 +163,7 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 
 - [DEPLOY.md](DEPLOY.md) - deploying and the update commands in context.
 - [COST.md](COST.md) - unrelated, but another operator reference.
+
+## Tip
+
+To watch an update happen, keep Settings open: the banner flips from Update available to the new version once the stack comes back.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -47,3 +47,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 The docker socket is root-equivalent on the host. The update endpoint is a real privilege boundary.
 
 Only an admin can trigger an update, and only when `REDCELL_COMPOSE_DIR` is set. If you do not want in-app updates, leave it unset.
+
+Updates pull `:latest` from the project's registry. Trust that registry, or pin to a specific version tag you have reviewed.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -17,3 +17,5 @@ The latest version comes from the GitHub Releases API for the repository, cached
 An update is offered when the latest release compares greater than the running version. A `dev` build never shows an update.
 
 ## What the button does
+
+It calls an admin-only endpoint that launches a one-shot updater container on the host.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -51,3 +51,10 @@ Only an admin can trigger an update, and only when `REDCELL_COMPOSE_DIR` is set.
 Updates pull `:latest` from the project's registry. Trust that registry, or pin to a specific version tag you have reviewed.
 
 ## Updating from the shell
+
+```bash
+cd redcell
+git pull
+docker compose pull
+docker compose up -d
+```

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -60,3 +60,5 @@ docker compose up -d
 ```
 
 This is the same set of steps the button runs, plus a `git pull` to refresh the compose file and scripts.
+
+## Rolling back

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -171,3 +171,7 @@ To watch an update happen, keep Settings open: the banner flips from Update avai
 ## Summary
 
 Baked version in, latest release out, an admin button that runs compose in a side container. Data is kept; migrations run; the app restarts.
+
+## Reconnecting
+
+If the page shows a connection error during the restart, wait a few seconds; it reconnects automatically once the api is back.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -3,3 +3,5 @@
 Two ways to update a self-hosted REDCELL: the in-app Update button, or pulling and restarting from the shell.
 
 ## In-app update
+
+Settings shows a version banner. When a newer release exists, an admin sees an Update button.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -132,3 +132,5 @@ Your data in the named volumes is preserved across the update.
 **Does it need internet?** Yes, to check the latest release and to pull new images.
 
 **How do I disable it?** Leave `REDCELL_COMPOSE_DIR` unset. The endpoint then refuses and the button does nothing useful.
+
+**Why not Watchtower?** Watchtower recreates containers but does not re-run the compose one-shots, so migrations would be skipped. Running compose keeps migrations in the loop.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -152,3 +152,5 @@ Your data in the named volumes is preserved across the update.
 Running the update when already current is harmless: the pull finds nothing new and `up -d` is a no-op.
 
 This feature ships in a release; a deployment must be updated once (by shell) to pick it up before the button exists.
+
+## References

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -86,3 +86,5 @@ curl -s https://your-domain/api/v1/system/version
 **Updater cannot run compose.** The updater image lacks the compose plugin. Set `REDCELL_UPDATER_IMAGE` to an image that includes it.
 
 **Update did not apply.** Confirm compose tracks `:latest` and that the new images were published. Check `docker compose logs` for the pull.
+
+**Version still old after update.** The images may not carry a baked `REDCELL_VERSION` yet. Only releases built after this feature include it.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -78,3 +78,5 @@ curl -s https://your-domain/api/v1/system/version
 `docker compose ps` should show the app containers recently recreated.
 
 ## Troubleshooting
+
+**No Update button.** Either you are already up to date, the build is `dev`, or `REDCELL_COMPOSE_DIR` is unset. Set it and redeploy to enable the button.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -150,3 +150,5 @@ Your data in the named volumes is preserved across the update.
 ## Notes
 
 Running the update when already current is harmless: the pull finds nothing new and `up -d` is a no-op.
+
+This feature ships in a release; a deployment must be updated once (by shell) to pick it up before the button exists.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -31,3 +31,5 @@ The api container cannot cleanly recreate itself: `up -d` would kill the process
 ## Downtime
 
 There is a few-second gap while the api, worker, and web containers restart. The UI reconnects on its own; the version banner then shows the new version.
+
+## Requirements for the button

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,1 +1,3 @@
 # Updating REDCELL
+
+Two ways to update a self-hosted REDCELL: the in-app Update button, or pulling and restarting from the shell.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -66,3 +66,5 @@ This is the same set of steps the button runs, plus a `git pull` to refresh the 
 Pin the image tags to a previous version (for example `:0.3.2`) in an override, or check out the matching commit and `docker compose up -d`.
 
 ## Verifying an update
+
+After the restart, the Settings banner shows the new version and reads Up to date.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -120,3 +120,5 @@ Both require a valid session; update additionally requires the admin role.
 ## What updates
 
 The api, worker, and web images update to the new release. Postgres, Redis, and MinIO stay on their pinned versions.
+
+Your data in the named volumes is preserved across the update.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -11,3 +11,5 @@ The banner shows the running version and, when available, the latest release to 
 ## How the version is known
 
 The running version is baked into the api and worker images at build time as `REDCELL_VERSION`, set from the release tag.
+
+The latest version comes from the GitHub Releases API for the repository, cached briefly to avoid rate limits.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -37,3 +37,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 - `REDCELL_COMPOSE_DIR` must point at the host checkout so the updater can find the compose file. `deploy.sh` sets it; leave it blank to disable the button.
 
 - The api container needs the docker socket (it already mounts it to run tools).
+
+- The updater image (`REDCELL_UPDATER_IMAGE`, default `docker:cli`) needs the docker compose plugin.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -144,3 +144,5 @@ Your data in the named volumes is preserved across the update.
 - Take a database dump first for anything important.
 
 - Verify the new version in Settings after the restart.
+
+- Pin a version if you need change control rather than always tracking latest.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -116,3 +116,5 @@ Both require a valid session; update additionally requires the admin role.
 3. The api launches a detached updater container with the socket and the checkout mounted.
 4. The updater pulls new images and runs `up -d`, which re-applies migrations.
 5. The app restarts; the banner shows the new version.
+
+## What updates

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -187,3 +187,7 @@ The updater runs as its own container; `docker ps` shows it briefly, and its log
 ## Latest is cached
 
 The latest-release lookup is cached for a few minutes, so a brand-new release can take a moment to appear in the banner.
+
+## Manual trigger
+
+You can trigger the same update from the shell with the compose commands above; the button is a convenience, not the only path.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -5,3 +5,5 @@ Two ways to update a self-hosted REDCELL: the in-app Update button, or pulling a
 ## In-app update
 
 Settings shows a version banner. When a newer release exists, an admin sees an Update button.
+
+The banner shows the running version and, when available, the latest release to update to.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -15,3 +15,5 @@ The running version is baked into the api and worker images at build time as `RE
 The latest version comes from the GitHub Releases API for the repository, cached briefly to avoid rate limits.
 
 An update is offered when the latest release compares greater than the running version. A `dev` build never shows an update.
+
+## What the button does

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -154,3 +154,5 @@ Running the update when already current is harmless: the pull finds nothing new 
 This feature ships in a release; a deployment must be updated once (by shell) to pick it up before the button exists.
 
 ## References
+
+- `apps/api/app/routers/system.py` - the version and update endpoints.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -23,3 +23,5 @@ It calls an admin-only endpoint that launches a one-shot updater container on th
 The updater runs `docker compose pull` then `docker compose up -d` against this deployment's compose file.
 
 `up -d` re-runs the one-shot `migrate` service, so database migrations in the new version are applied automatically.
+
+## Why a one-shot container

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -128,3 +128,5 @@ Your data in the named volumes is preserved across the update.
 **Is the update safe to run during work?** It restarts the stack, so avoid it mid-engagement. Data is preserved, but active connections drop briefly.
 
 **Should I back up first?** Backing up the database and volumes before an update is good practice. See DEPLOY.md.
+
+**Does it need internet?** Yes, to check the latest release and to pull new images.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -88,3 +88,5 @@ curl -s https://your-domain/api/v1/system/version
 **Update did not apply.** Confirm compose tracks `:latest` and that the new images were published. Check `docker compose logs` for the pull.
 
 **Version still old after update.** The images may not carry a baked `REDCELL_VERSION` yet. Only releases built after this feature include it.
+
+**Permission denied on the socket.** The api container must have access to `/var/run/docker.sock`. The compose file mounts it by default.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -106,3 +106,5 @@ Both require a valid session; update additionally requires the admin role.
 - `REDCELL_COMPOSE_DIR` - host path of the checkout; enables the button.
 
 - `REDCELL_UPDATER_IMAGE` - image for the one-shot updater (default `docker:cli`).
+
+- `REDCELL_VERSION` - baked into the image at build; the running version.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -74,3 +74,5 @@ The version endpoint returns the running and latest versions:
 ```bash
 curl -s https://your-domain/api/v1/system/version
 ```
+
+`docker compose ps` should show the app containers recently recreated.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -9,3 +9,5 @@ Settings shows a version banner. When a newer release exists, an admin sees an U
 The banner shows the running version and, when available, the latest release to update to.
 
 ## How the version is known
+
+The running version is baked into the api and worker images at build time as `REDCELL_VERSION`, set from the release tag.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -100,3 +100,5 @@ curl -s https://your-domain/api/v1/system/version
 - `POST /api/v1/system/update` (admin) starts the update and returns `{ started, detail }`.
 
 Both require a valid session; update additionally requires the admin role.
+
+## Configuration

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -76,3 +76,5 @@ curl -s https://your-domain/api/v1/system/version
 ```
 
 `docker compose ps` should show the app containers recently recreated.
+
+## Troubleshooting

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -84,3 +84,5 @@ curl -s https://your-domain/api/v1/system/version
 **"In-app update is not available on this deployment."** `REDCELL_COMPOSE_DIR` is not set. `deploy.sh` sets it; add it to `.env` and `docker compose up -d`.
 
 **Updater cannot run compose.** The updater image lacks the compose plugin. Set `REDCELL_UPDATER_IMAGE` to an image that includes it.
+
+**Update did not apply.** Confirm compose tracks `:latest` and that the new images were published. Check `docker compose logs` for the pull.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -158,3 +158,5 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 - `apps/api/app/routers/system.py` - the version and update endpoints.
 - `apps/web/src/app/UpdateBanner.tsx` - the Settings banner.
 - Issue #66 - the request this implements.
+
+## See also

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -113,3 +113,4 @@ Both require a valid session; update additionally requires the admin role.
 
 1. The banner polls the version endpoint and compares against the latest release.
 2. An admin clicks Update.
+3. The api launches a detached updater container with the socket and the checkout mounted.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -29,3 +29,5 @@ The updater runs `docker compose pull` then `docker compose up -d` against this 
 The api container cannot cleanly recreate itself: `up -d` would kill the process mid-update. A separate one-shot container is not part of the recreate, so it survives and finishes the job.
 
 ## Downtime
+
+There is a few-second gap while the api, worker, and web containers restart. The UI reconnects on its own; the version banner then shows the new version.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -82,3 +82,5 @@ curl -s https://your-domain/api/v1/system/version
 **No Update button.** Either you are already up to date, the build is `dev`, or `REDCELL_COMPOSE_DIR` is unset. Set it and redeploy to enable the button.
 
 **"In-app update is not available on this deployment."** `REDCELL_COMPOSE_DIR` is not set. `deploy.sh` sets it; add it to `.env` and `docker compose up -d`.
+
+**Updater cannot run compose.** The updater image lacks the compose plugin. Set `REDCELL_UPDATER_IMAGE` to an image that includes it.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -142,3 +142,5 @@ Your data in the named volumes is preserved across the update.
 - Update in a quiet window, not during a live run.
 
 - Take a database dump first for anything important.
+
+- Verify the new version in Settings after the restart.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -94,3 +94,5 @@ curl -s https://your-domain/api/v1/system/version
 **Stuck updating.** The pull may be slow on a large image. Give it time, then check `docker compose ps` and logs.
 
 ## API
+
+- `GET /api/v1/system/version` returns `{ current, latest, updateAvailable }`.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -122,3 +122,5 @@ Both require a valid session; update additionally requires the admin role.
 The api, worker, and web images update to the new release. Postgres, Redis, and MinIO stay on their pinned versions.
 
 Your data in the named volumes is preserved across the update.
+
+## FAQ

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -124,3 +124,5 @@ The api, worker, and web images update to the new release. Postgres, Redis, and 
 Your data in the named volumes is preserved across the update.
 
 ## FAQ
+
+**Is the update safe to run during work?** It restarts the stack, so avoid it mid-engagement. Data is preserved, but active connections drop briefly.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -41,3 +41,5 @@ There is a few-second gap while the api, worker, and web containers restart. The
 - The updater image (`REDCELL_UPDATER_IMAGE`, default `docker:cli`) needs the docker compose plugin.
 
 - Compose tracks `:latest`, so a pull fetches the new build.
+
+## Security

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -175,3 +175,7 @@ Baked version in, latest release out, an admin button that runs compose in a sid
 ## Reconnecting
 
 If the page shows a connection error during the restart, wait a few seconds; it reconnects automatically once the api is back.
+
+## Single operator
+
+REDCELL has one operator account, which is the admin, so the admin gate means the signed-in operator.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -115,3 +115,4 @@ Both require a valid session; update additionally requires the admin role.
 2. An admin clicks Update.
 3. The api launches a detached updater container with the socket and the checkout mounted.
 4. The updater pulls new images and runs `up -d`, which re-applies migrations.
+5. The app restarts; the banner shows the new version.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -156,3 +156,4 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 ## References
 
 - `apps/api/app/routers/system.py` - the version and update endpoints.
+- `apps/web/src/app/UpdateBanner.tsx` - the Settings banner.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -68,3 +68,9 @@ Pin the image tags to a previous version (for example `:0.3.2`) in an override, 
 ## Verifying an update
 
 After the restart, the Settings banner shows the new version and reads Up to date.
+
+The version endpoint returns the running and latest versions:
+
+```bash
+curl -s https://your-domain/api/v1/system/version
+```

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -27,3 +27,5 @@ The updater runs `docker compose pull` then `docker compose up -d` against this 
 ## Why a one-shot container
 
 The api container cannot cleanly recreate itself: `up -d` would kill the process mid-update. A separate one-shot container is not part of the recreate, so it survives and finishes the job.
+
+## Downtime

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -104,3 +104,5 @@ Both require a valid session; update additionally requires the admin role.
 ## Configuration
 
 - `REDCELL_COMPOSE_DIR` - host path of the checkout; enables the button.
+
+- `REDCELL_UPDATER_IMAGE` - image for the one-shot updater (default `docker:cli`).

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -136,3 +136,5 @@ Your data in the named volumes is preserved across the update.
 **Why not Watchtower?** Watchtower recreates containers but does not re-run the compose one-shots, so migrations would be skipped. Running compose keeps migrations in the loop.
 
 **Can it auto-update on a schedule?** Not yet; updates are on demand from the button.
+
+## Best practices

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -167,3 +167,7 @@ This feature ships in a release; a deployment must be updated once (by shell) to
 ## Tip
 
 To watch an update happen, keep Settings open: the banner flips from Update available to the new version once the stack comes back.
+
+## Summary
+
+Baked version in, latest release out, an admin button that runs compose in a side container. Data is kept; migrations run; the app restarts.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -108,3 +108,5 @@ Both require a valid session; update additionally requires the admin role.
 - `REDCELL_UPDATER_IMAGE` - image for the one-shot updater (default `docker:cli`).
 
 - `REDCELL_VERSION` - baked into the image at build; the running version.
+
+## End to end

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -25,3 +25,5 @@ The updater runs `docker compose pull` then `docker compose up -d` against this 
 `up -d` re-runs the one-shot `migrate` service, so database migrations in the new version are applied automatically.
 
 ## Why a one-shot container
+
+The api container cannot cleanly recreate itself: `up -d` would kill the process mid-update. A separate one-shot container is not part of the recreate, so it survives and finishes the job.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -96,3 +96,5 @@ curl -s https://your-domain/api/v1/system/version
 ## API
 
 - `GET /api/v1/system/version` returns `{ current, latest, updateAvailable }`.
+
+- `POST /api/v1/system/update` (admin) starts the update and returns `{ started, detail }`.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -64,3 +64,5 @@ This is the same set of steps the button runs, plus a `git pull` to refresh the 
 ## Rolling back
 
 Pin the image tags to a previous version (for example `:0.3.2`) in an override, or check out the matching commit and `docker compose up -d`.
+
+## Verifying an update

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -33,3 +33,5 @@ The api container cannot cleanly recreate itself: `up -d` would kill the process
 There is a few-second gap while the api, worker, and web containers restart. The UI reconnects on its own; the version banner then shows the new version.
 
 ## Requirements for the button
+
+- `REDCELL_COMPOSE_DIR` must point at the host checkout so the updater can find the compose file. `deploy.sh` sets it; leave it blank to disable the button.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -112,3 +112,4 @@ Both require a valid session; update additionally requires the admin role.
 ## End to end
 
 1. The banner polls the version endpoint and compares against the latest release.
+2. An admin clicks Update.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -179,3 +179,7 @@ If the page shows a connection error during the restart, wait a few seconds; it 
 ## Single operator
 
 REDCELL has one operator account, which is the admin, so the admin gate means the signed-in operator.
+
+## Watching the updater
+
+The updater runs as its own container; `docker ps` shows it briefly, and its logs show the pull and recreate.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -90,3 +90,5 @@ curl -s https://your-domain/api/v1/system/version
 **Version still old after update.** The images may not carry a baked `REDCELL_VERSION` yet. Only releases built after this feature include it.
 
 **Permission denied on the socket.** The api container must have access to `/var/run/docker.sock`. The compose file mounts it by default.
+
+**Stuck updating.** The pull may be slow on a large image. Give it time, then check `docker compose ps` and logs.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -146,3 +146,5 @@ Your data in the named volumes is preserved across the update.
 - Verify the new version in Settings after the restart.
 
 - Pin a version if you need change control rather than always tracking latest.
+
+## Notes

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -33,6 +33,8 @@ import type {
   Settings,
   Shell,
   User,
+  SystemVersion,
+  UpdateStarted,
 } from './types';
 
 export type Unsubscribe = () => void;
@@ -189,5 +191,9 @@ export interface ApiClient {
     start(sessionId: string): Promise<{ ok: boolean; detail?: string }>;
     control(sessionId: string, owner: 'operator' | 'agent'): Promise<{ owner: string }>;
     vncUrl(sessionId: string): string;
+  };
+  system: {
+    version(): Promise<SystemVersion>;
+    update(): Promise<UpdateStarted>;
   };
 }

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -150,5 +150,9 @@ export function createHttpClient(baseUrl: string, rawWsUrl: string): ApiClient {
       control: (sessionId, owner) => req(`/sessions/${sessionId}/browser/control`, json({ owner })),
       vncUrl: (sessionId) => `${wsUrl}/browser/${encodeURIComponent(sessionId)}`,
     },
+    system: {
+      version: () => req('/system/version'),
+      update: () => req('/system/update', { method: 'POST' }),
+    },
   };
 }

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -610,6 +610,16 @@ export function createMockClient(): ApiClient {
         return `ws://mock/api/v1/ws/browser/${sessionId}`;
       },
     },
+    system: {
+      async version() {
+        await delay();
+        return { current: '0.3.2', latest: '0.3.3', updateAvailable: true };
+      },
+      async update() {
+        await delay(300);
+        return { started: true, detail: 'Update started (mock).' };
+      },
+    },
   };
 }
 

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -379,3 +379,14 @@ export interface ProxyTestResult {
   output: string;
   error?: string;
 }
+
+export interface SystemVersion {
+  current: string;
+  latest?: string | null;
+  updateAvailable: boolean;
+}
+
+export interface UpdateStarted {
+  started: boolean;
+  detail: string;
+}


### PR DESCRIPTION
Closes #66.

Lets an admin update a self-hosted REDCELL from the console when a newer release exists, and actually applies migrations.

## Version awareness
- `REDCELL_VERSION` is baked into the api/worker images at build time (a `VERSION` build-arg passed by the release workflow).
- `GET /api/v1/system/version` returns `{ current, latest, updateAvailable }`; latest comes from the GitHub Releases API (cached), compared with a small semver check. A `dev` build never offers an update.

## Update mechanism
- `POST /api/v1/system/update` (admin only) launches a **detached one-shot updater container** (image `REDCELL_UPDATER_IMAGE`, default `docker:cli`) with the docker socket and the host checkout mounted, running `docker compose pull && docker compose up -d`.
- A one-shot container is used because the api cannot cleanly recreate itself. `up -d` re-runs the `migrate` service, so schema migrations apply.
- Requires `REDCELL_COMPOSE_DIR` (the host checkout path); `deploy.sh` records it. Unset it to disable the button.

## UI
- A version banner in Settings shows the running version and, when a newer release exists, an admin **Update now** button (`UpdateBanner.tsx`). The version query refetches, so the banner flips to the new version after the restart.

## Security
- The docker socket is root-equivalent; the endpoint is admin-only and inert unless `REDCELL_COMPOSE_DIR` is set. Documented in `docs/UPDATING.md`.

## Tests
- Backend: version parsing and update-available logic. Frontend: the banner shows current/latest and triggers the update.

## Docs
- `docs/UPDATING.md`: how it works, requirements, security, CLI update, rollback, troubleshooting. Linked from README and DEPLOY.

## Rollout note
This ships in a release; a deployment must be updated once from the shell to pick up the endpoint and updater wiring before the button appears. After that, subsequent releases are one click.

Please merge with a **merge commit** to preserve the commit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV