### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.3.2"
+version = "0.3.3"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.3.2"
+version = "0.3.3"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/web": {
       "name": "@redcell/web",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@novnc/novnc": "1.7.0",
         "@redcell/api-client": "workspace:*",

--- a/uv.lock
+++ b/uv.lock
@@ -2117,7 +2117,7 @@ wheels = [
 
 [[package]]
 name = "redcell-api"
-version = "0.3.2"
+version = "0.3.3"
 source = { virtual = "apps/api" }
 dependencies = [
     { name = "fastapi" },
@@ -2197,7 +2197,7 @@ live = [
 
 [[package]]
 name = "redcell-worker"
-version = "0.3.2"
+version = "0.3.3"
 source = { virtual = "apps/worker" }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Ships the in-app update feature (#66) and starts baking `REDCELL_VERSION` into the api/worker images. Bumps `redcell-api`, `redcell-worker`, and `@redcell/web` to `0.3.3` and syncs lockfiles.

Tagging `v0.3.3` after merge builds the images with `VERSION=0.3.3` and publishes the release.

## Since v0.3.2
- Login page no longer discloses version or bind text (#63)
- Session cost is computed for real (#64)
- Command palette searches sessions/servers/proxies (#65)
- In-app Update button with version awareness (#66)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV