### PR TITLE
fix(api): scope the in-app updater to the app services

### DIFF
--- a/apps/api/app/routers/system.py
+++ b/apps/api/app/routers/system.py
@@ -89,7 +89,8 @@ async def start_update(user: User = Depends(current_user)) -> UpdateStarted:
         "-v", f"{repo_dir}:/repo",
         "-w", "/repo",
         image,
-        "sh", "-c", "docker compose pull && docker compose up -d",
+        "sh", "-c",
+        "docker compose pull api worker web && docker compose up -d migrate api worker web",
     ]
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -20,7 +20,7 @@ An update is offered when the latest release compares greater than the running v
 
 It calls an admin-only endpoint that launches a one-shot updater container on the host.
 
-The updater runs `docker compose pull` then `docker compose up -d` against this deployment's compose file.
+The updater pulls and recreates only the app services (`api`, `worker`, `web`) and re-runs `migrate`, leaving the reverse proxy and datastores running. That keeps the proxy up (no full-stack restart) and avoids a port-bind race on the proxy container.
 
 `up -d` re-runs the one-shot `migrate` service, so database migrations in the new version are applied automatically.
 


### PR DESCRIPTION
Follow-up to #66, found while making the feature live.

The updater ran `docker compose pull && docker compose up -d` (full stack). When the reverse proxy's base image tag (`caddy:2-alpine`) had a newer digest, the pull moved it and `up -d` recreated the proxy - the only service that publishes host ports 80/443 - which hit a port-bind race and got stuck in `Created`, taking the site down (Cloudflare 521).

## Fix
Scope the updater to the app services:

```
docker compose pull api worker web && docker compose up -d migrate api worker web
```

- Only `api`, `worker`, `web` are pulled and recreated; `migrate` re-runs so schema changes apply.
- The reverse proxy and datastores (postgres, redis, minio) are left running, so there is no proxy downtime and no port-bind race. Backend calls may 502 for a second or two while api/web restart, but the proxy stays up.

An in-app update is meant to update the application, not the infrastructure; infra version changes go through a normal `git pull` + `docker compose up -d`.

Verified on the live server: after this, an update recreates only the app containers and the proxy stays up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdDcqU9FSafSK7vnxVPLtV