### PR TITLE
fix(web): keep the workspace switcher dropdown inside the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ deploy.sh                    interactive self-host deploy
 - [Cost & token accounting](docs/COST.md) — how run spend is measured, the price table, and OpenRouter real cost.
 - [Command palette & shortcuts](docs/SHORTCUTS.md) — Cmd/Ctrl+K to search sessions, servers, and proxies, and keyboard navigation.
 - [Updating](docs/UPDATING.md) — the in-app Update button and updating from the shell.
+- [Console shell](docs/APP-SHELL.md) — the sidebar, workspace switcher, menus, and dropdown positioning rules.
 
 ## Contributing
 

--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -163,6 +163,15 @@ export function DashboardShell() {
     return () => document.removeEventListener('keydown', h);
   }, []);
 
+  useEffect(() => {
+    if (!menu) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenu(null);
+    };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [menu]);
+
   const onSignOut = async () => {
     await api.auth.logout().catch(() => undefined);
     signOut();
@@ -249,7 +258,11 @@ export function DashboardShell() {
         </div>
         <div className="side-foot">
           <span className="menu-wrap" style={{ width: '100%' }} ref={userRef}>
-            <button type="button" className="userbtn" onClick={() => setMenu((m) => (m === 'user' ? null : 'user'))}>
+            <button type="button" className="userbtn"
+              onClick={() => setMenu((m) => (m === 'user' ? null : 'user'))}
+              aria-haspopup="menu"
+              aria-expanded={menu === 'user'}
+            >
               <span className="avatar" />
               <div style={{ flex: 1 }}>
                 <div className="u">admin</div>
@@ -259,7 +272,7 @@ export function DashboardShell() {
                 <path d="M8 15l4-4 4 4" />
               </svg>
             </button>
-            <div className="menu up" style={{ display: menu === 'user' ? 'block' : 'none', width: '100%' }}>
+            <div className="menu up" role="menu" style={{ display: menu === 'user' ? 'block' : 'none', width: '100%' }}>
               <button type="button" className="menu-item" onClick={flipTheme}>
                 Toggle theme
               </button>

--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -102,8 +102,8 @@ const TITLES: Record<string, [string, string]> = {
   '/settings': ['Settings', ''],
 };
 
-function useOutside(onClose: () => void) {
-  const ref = useRef<HTMLSpanElement>(null);
+function useOutside<T extends HTMLElement = HTMLElement>(onClose: () => void) {
+  const ref = useRef<T>(null);
   useEffect(() => {
     const h = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) onClose();
@@ -141,8 +141,8 @@ export function DashboardShell() {
   const [palette, setPalette] = useState(false);
   const [menu, setMenu] = useState<'ws' | 'user' | null>(null);
   const [, force] = useState(0);
-  const wsRef = useOutside(() => setMenu((m) => (m === 'ws' ? null : m)));
-  const userRef = useOutside(() => setMenu((m) => (m === 'user' ? null : m)));
+  const wsRef = useOutside<HTMLDivElement>(() => setMenu((m) => (m === 'ws' ? null : m)));
+  const userRef = useOutside<HTMLSpanElement>(() => setMenu((m) => (m === 'user' ? null : m)));
 
   useEffect(() => {
     try {
@@ -187,31 +187,31 @@ export function DashboardShell() {
   return (
     <div className={`app-shell${collapsed ? ' collapsed' : ''}`}>
       <aside className="side">
-        <div className="ws">
+        <div className="ws" ref={wsRef}>
           <span className="logo" />
           <span className="nm">REDCELL</span>
-          <span className="menu-wrap" ref={wsRef}>
-            <button type="button"
-              className="iconbtn"
-              style={{ width: 24, height: 24, color: 'var(--tx-3)' }}
-              onClick={() => setMenu((m) => (m === 'ws' ? null : 'ws'))}
-              aria-label="Workspace menu"
-            >
-              <svg className="caret" viewBox="0 0 24 24">
-                <path d="M8 9l4 4 4-4" />
-              </svg>
+          <button type="button"
+            className={`iconbtn wscaret${menu === 'ws' ? ' open' : ''}`}
+            style={{ width: 24, height: 24, color: 'var(--tx-3)' }}
+            onClick={() => setMenu((m) => (m === 'ws' ? null : 'ws'))}
+            aria-label="Workspace menu"
+            aria-haspopup="menu"
+            aria-expanded={menu === 'ws'}
+          >
+            <svg className="caret" viewBox="0 0 24 24">
+              <path d="M8 9l4 4 4-4" />
+            </svg>
+          </button>
+          <div className="menu ws-menu" role="menu" style={{ display: menu === 'ws' ? 'block' : 'none' }}>
+            <div className="menu-label">Workspace</div>
+            <button type="button" className="menu-item sel">
+              REDCELL<span className="ck">✓</span>
             </button>
-            <div className={`menu${menu === 'ws' ? '' : ''}`} style={{ display: menu === 'ws' ? 'block' : 'none' }}>
-              <div className="menu-label">Workspace</div>
-              <button type="button" className="menu-item sel">
-                REDCELL<span className="ck">✓</span>
-              </button>
-              <div className="menu-sep" />
-              <button type="button" className="menu-item" onClick={flipTheme}>
-                Toggle theme
-              </button>
-            </div>
-          </span>
+            <div className="menu-sep" />
+            <button type="button" className="menu-item" onClick={flipTheme}>
+              Toggle theme
+            </button>
+          </div>
         </div>
         <button type="button" className="search" onClick={() => setPalette(true)}>
           <svg viewBox="0 0 24 24">

--- a/apps/web/src/styles/design.css
+++ b/apps/web/src/styles/design.css
@@ -34,6 +34,7 @@
   overflow: hidden;
 }
 .ws {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 9px;
@@ -471,6 +472,19 @@
   fill: none;
   stroke-width: 1.7;
   color: var(--tx-4);
+}
+.ws-menu {
+  left: 8px;
+  right: 8px;
+  top: calc(100% - 2px);
+  min-width: 0;
+  z-index: 200;
+}
+.wscaret .caret {
+  transition: transform 0.15s ease;
+}
+.wscaret.open .caret {
+  transform: rotate(180deg);
 }
 
 .card {

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -81,3 +81,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 - Add a nav item by extending the groups list with a route, label, and icon.
 
 - Add a menu by giving its trigger a wrapper as the positioning context and toggling an open state.
+
+- A menu inside the sidebar must be anchored so it stays within the 236px width; do not rely on it overflowing, because the sidebar clips overflow.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -135,3 +135,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - `.search` - opens the command palette
 
 - `.side-scroll` - the scrollable navigation area
+
+- `.side-foot` - the user menu

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -89,3 +89,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 - Reuse the outside-click hook and put its ref on the element that wraps both the trigger and the menu.
 
 ## Verifying shell changes
+
+Verify layout changes in a browser, not only with a build. Positioning, clipping, and z-index cannot be checked by type or unit tests.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -115,3 +115,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **Where is the theme stored?** It is applied via a data attribute on the root and persisted, and re-applied before paint to avoid a flash.
 
 **Does collapsing hide the workspace switcher?** Yes; the whole sidebar is hidden when collapsed.
+
+**Is the shell responsive?** The main content is fluid; the sidebar is a fixed width you can collapse.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -139,3 +139,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - `.side-foot` - the user menu
 
 - `.main-pad` / `.main-card` - the floating content card
+
+- `.head` - the card header with title and actions

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -63,3 +63,5 @@ The footer shows the operator and opens an upward menu with a theme toggle and s
 ## Accessibility
 
 Menu triggers use `aria-haspopup` and `aria-expanded`; menus use a menu role. Focus and keyboard access are preserved.
+
+Icon-only buttons carry an `aria-label`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -71,3 +71,5 @@ Icon-only buttons carry an `aria-label`.
 The dropdown was positioned from the caret with `left: 0`, so a 180px menu started near the right of the sidebar and ran ~60px past its edge.
 
 The sidebar's `overflow: hidden` then clipped the overflowing part, and it overlapped the main content, so it looked like it slid under the main card.
+
+The menu is now anchored to the `.ws` header and spans within the sidebar, with a higher z-index. It stays fully inside the sidebar at any width.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -57,3 +57,5 @@ The Search button opens the command palette (Cmd/Ctrl+K). See [SHORTCUTS.md](SHO
 Below the navigation, sessions whose run is currently running are listed for quick access. The list is capped and polls run status.
 
 ## User menu
+
+The footer shows the operator and opens an upward menu with a theme toggle and sign out. It spans the footer width, staying inside the sidebar.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -7,3 +7,5 @@ How the console is laid out: a sidebar and a floating main card, with the shared
 The shell is a two-column grid: a fixed 236px sidebar and the main area. Collapsing the sidebar sets its column to 0.
 
 The main area is a floating card with its own header and body, padded away from the edges.
+
+## Sidebar

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -103,3 +103,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **A menu appears under the main content.** Its z-index is too low, or it overflows into the main area. Raise the z-index and keep it inside its region.
 
 **A menu will not close on outside click.** The outside-click ref is on the trigger only, not the wrapper that includes the menu.
+
+**Sidebar content peeks out when collapsed.** Something inside the sidebar is escaping `overflow: hidden`; keep sidebar content within the column.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -169,3 +169,7 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 ## See also
 
 - [DEPLOY.md](DEPLOY.md) and [UPDATING.md](UPDATING.md) for running and updating the console.
+
+## Summary
+
+Sidebar plus floating card. Menus stay inside their region, above the content, and close on outside click. Verify layout in a browser.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -5,3 +5,5 @@ How the console is laid out: a sidebar and a floating main card, with the shared
 ## Layout
 
 The shell is a two-column grid: a fixed 236px sidebar and the main area. Collapsing the sidebar sets its column to 0.
+
+The main area is a floating card with its own header and body, padded away from the edges.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -55,3 +55,5 @@ The Search button opens the command palette (Cmd/Ctrl+K). See [SHORTCUTS.md](SHO
 ## Active runs
 
 Below the navigation, sessions whose run is currently running are listed for quick access. The list is capped and polls run status.
+
+## User menu

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -105,3 +105,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **A menu will not close on outside click.** The outside-click ref is on the trigger only, not the wrapper that includes the menu.
 
 **Sidebar content peeks out when collapsed.** Something inside the sidebar is escaping `overflow: hidden`; keep sidebar content within the column.
+
+**Collapse state resets on reload.** localStorage may be blocked; the shell falls back to expanded.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -125,3 +125,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - Right-aligned: aligns the menu's right edge to the trigger, opening leftward.
 
 - Upward: opens above the trigger (used by the footer user menu).
+
+- Header-spanning: the workspace menu spans the sidebar header width, anchored to `.ws`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -87,3 +87,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 - Give menus a z-index above the main card so an overlapping menu is never painted under it.
 
 - Reuse the outside-click hook and put its ref on the element that wraps both the trigger and the menu.
+
+## Verifying shell changes

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -85,3 +85,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 - A menu inside the sidebar must be anchored so it stays within the 236px width; do not rely on it overflowing, because the sidebar clips overflow.
 
 - Give menus a z-index above the main card so an overlapping menu is never painted under it.
+
+- Reuse the outside-click hook and put its ref on the element that wraps both the trigger and the menu.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -141,3 +141,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - `.main-pad` / `.main-card` - the floating content card
 
 - `.head` - the card header with title and actions
+
+## Z-index notes

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -101,3 +101,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **A sidebar dropdown looks cut off.** It extends past the 236px sidebar and is clipped by `overflow: hidden`. Anchor it so it stays within the sidebar.
 
 **A menu appears under the main content.** Its z-index is too low, or it overflows into the main area. Raise the z-index and keep it inside its region.
+
+**A menu will not close on outside click.** The outside-click ref is on the trigger only, not the wrapper that includes the menu.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -35,3 +35,5 @@ Menus sit above surrounding content via z-index. Keep menu z-index above the mai
 ## Collapsing the sidebar
 
 The header toggle hides the sidebar (grid column to 0). The choice is stored in localStorage and restored on load.
+
+The sidebar's `overflow: hidden` is what makes the collapse look clean, which is why menus inside it must not rely on overflowing.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -153,3 +153,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - **Main card** - the floating content area to the right of the sidebar.
 
 - **Workspace switcher** - the header control that opens the workspace menu.
+
+- **Dropdown / menu** - a small floating list anchored to a trigger.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -43,3 +43,5 @@ The sidebar's `overflow: hidden` is what makes the collapse look clean, which is
 The main card header shows the page title (or the console header on a session) and page actions such as New session and the theme toggle.
 
 The first header button toggles the sidebar.
+
+## Theme

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -53,3 +53,5 @@ Theme can be toggled from the header, the workspace menu, or the user menu. The 
 The Search button opens the command palette (Cmd/Ctrl+K). See [SHORTCUTS.md](SHORTCUTS.md).
 
 ## Active runs
+
+Below the navigation, sessions whose run is currently running are listed for quick access. The list is capped and polls run status.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -91,3 +91,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 ## Verifying shell changes
 
 Verify layout changes in a browser, not only with a build. Positioning, clipping, and z-index cannot be checked by type or unit tests.
+
+Append `?demo=1` to skip auth and load the shell with demo data for quick visual checks.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -39,3 +39,5 @@ The header toggle hides the sidebar (grid column to 0). The choice is stored in 
 The sidebar's `overflow: hidden` is what makes the collapse look clean, which is why menus inside it must not rely on overflowing.
 
 ## Header
+
+The main card header shows the page title (or the console header on a session) and page actions such as New session and the theme toggle.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -187,3 +187,5 @@ Pressing Escape or clicking anywhere outside the switcher closes the menu.
 The caret rotates to point up while the menu is open, and animates back on close.
 
 The theme toggle appears in both the workspace and user menus for convenience; the header has a dedicated toggle too.
+
+The active-runs list is hidden entirely when nothing is running, keeping the sidebar tidy.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -25,3 +25,5 @@ The caret rotates when the menu is open, and the button carries `aria-haspopup` 
 ## Menus and dropdowns
 
 A menu opens from its trigger and closes on Escape, on selecting an item, or on a click outside (a shared outside-click hook).
+
+Menus are absolutely positioned relative to their trigger's wrapper. By default a menu opens below-left; modifiers open it right-aligned or upward.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -95,3 +95,5 @@ Verify layout changes in a browser, not only with a build. Positioning, clipping
 Append `?demo=1` to skip auth and load the shell with demo data for quick visual checks.
 
 For a dropdown, measure its bounding box against the sidebar's to confirm it stays inside and is not clipped.
+
+## Troubleshooting

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -137,3 +137,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - `.side-scroll` - the scrollable navigation area
 
 - `.side-foot` - the user menu
+
+- `.main-pad` / `.main-card` - the floating content card

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -129,3 +129,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - Header-spanning: the workspace menu spans the sidebar header width, anchored to `.ws`.
 
 ## Structure at a glance
+
+- `.ws` - workspace header (positioning context for its menu)

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -31,3 +31,5 @@ Menus are absolutely positioned relative to their trigger's wrapper. By default 
 Because the sidebar clips overflow, a sidebar menu must be anchored so it stays inside the sidebar. The workspace menu spans the header width; the user menu spans the footer width.
 
 Menus sit above surrounding content via z-index. Keep menu z-index above the main card so an overlapping menu is never painted under it.
+
+## Collapsing the sidebar

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -15,3 +15,5 @@ The sidebar uses `overflow: hidden` so it clips cleanly when collapsed. That mea
 Top to bottom: the workspace header, the search button, the navigation groups, the active-runs list, and the user menu at the foot.
 
 ## Workspace switcher
+
+The header shows the workspace name with a caret. The caret opens a small menu (the workspace and a theme toggle).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -51,3 +51,5 @@ Theme can be toggled from the header, the workspace menu, or the user menu. The 
 ## Search
 
 The Search button opens the command palette (Cmd/Ctrl+K). See [SHORTCUTS.md](SHORTCUTS.md).
+
+## Active runs

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -147,3 +147,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 Menus sit above the shell chrome and the main card. The workspace menu uses a high z-index so it is never obscured while open.
 
 ## Glossary
+
+- **Shell** - the persistent sidebar and header around every page.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -1,0 +1,1 @@
+# The operator console shell

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -61,3 +61,5 @@ Below the navigation, sessions whose run is currently running are listed for qui
 The footer shows the operator and opens an upward menu with a theme toggle and sign out. It spans the footer width, staying inside the sidebar.
 
 ## Accessibility
+
+Menu triggers use `aria-haspopup` and `aria-expanded`; menus use a menu role. Focus and keyboard access are preserved.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -33,3 +33,5 @@ Because the sidebar clips overflow, a sidebar menu must be anchored so it stays 
 Menus sit above surrounding content via z-index. Keep menu z-index above the main card so an overlapping menu is never painted under it.
 
 ## Collapsing the sidebar
+
+The header toggle hides the sidebar (grid column to 0). The choice is stored in localStorage and restored on load.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -145,3 +145,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 ## Z-index notes
 
 Menus sit above the shell chrome and the main card. The workspace menu uses a high z-index so it is never obscured while open.
+
+## Glossary

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -143,3 +143,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - `.head` - the card header with title and actions
 
 ## Z-index notes
+
+Menus sit above the shell chrome and the main card. The workspace menu uses a high z-index so it is never obscured while open.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -149,3 +149,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 ## Glossary
 
 - **Shell** - the persistent sidebar and header around every page.
+
+- **Main card** - the floating content area to the right of the sidebar.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -177,3 +177,5 @@ Sidebar plus floating card. Menus stay inside their region, above the content, a
 ## Note on stacking contexts
 
 A dropdown is clipped or hidden by an ancestor with `overflow: hidden` or a higher stacking context. Anchor menus so their box stays inside the visible region rather than fighting the clip.
+
+The sidebar is a fixed 236px, so a menu that spans the header is a predictable width and never depends on the viewport.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -113,3 +113,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **Can I have multiple workspaces?** The switcher is built for it; today there is a single REDCELL workspace.
 
 **Where is the theme stored?** It is applied via a data attribute on the root and persisted, and re-applied before paint to avoid a flash.
+
+**Does collapsing hide the workspace switcher?** Yes; the whole sidebar is hidden when collapsed.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -21,3 +21,5 @@ The header shows the workspace name with a caret. The caret opens a small menu (
 The menu is anchored to the header (`.ws` is the positioning context) and spans within the sidebar, so it never extends into the main content or gets clipped.
 
 The caret rotates when the menu is open, and the button carries `aria-haspopup` and `aria-expanded`.
+
+## Menus and dropdowns

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -1,1 +1,3 @@
 # The operator console shell
+
+How the console is laid out: a sidebar and a floating main card, with the shared menu and dropdown behavior.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -13,3 +13,5 @@ The main area is a floating card with its own header and body, padded away from 
 The sidebar uses `overflow: hidden` so it clips cleanly when collapsed. That means anything inside it, including dropdowns, must stay within the sidebar's width or it gets clipped.
 
 Top to bottom: the workspace header, the search button, the navigation groups, the active-runs list, and the user menu at the foot.
+
+## Workspace switcher

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -183,3 +183,5 @@ The sidebar is a fixed 236px, so a menu that spans the header is a predictable w
 While the workspace menu is open the header keeps its hover highlight, which reads as the switcher being active.
 
 Pressing Escape or clicking anywhere outside the switcher closes the menu.
+
+The caret rotates to point up while the menu is open, and animates back on close.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -119,3 +119,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **Is the shell responsive?** The main content is fluid; the sidebar is a fixed width you can collapse.
 
 ## Menu positioning reference
+
+- Default: opens below the trigger, left-aligned.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -121,3 +121,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 ## Menu positioning reference
 
 - Default: opens below the trigger, left-aligned.
+
+- Right-aligned: aligns the menu's right edge to the trigger, opening leftward.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -161,3 +161,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 ## References
 
 - `apps/web/src/app/DashboardShell.tsx` - the shell component.
+
+- `apps/web/src/styles/design.css` - shell, sidebar, and menu styles.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -69,3 +69,5 @@ Icon-only buttons carry an `aria-label`.
 ## Fix: the workspace dropdown
 
 The dropdown was positioned from the caret with `left: 0`, so a 180px menu started near the right of the sidebar and ran ~60px past its edge.
+
+The sidebar's `overflow: hidden` then clipped the overflowing part, and it overlapped the main content, so it looked like it slid under the main card.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -73,3 +73,5 @@ The dropdown was positioned from the caret with `left: 0`, so a 180px menu start
 The sidebar's `overflow: hidden` then clipped the overflowing part, and it overlapped the main content, so it looked like it slid under the main card.
 
 The menu is now anchored to the `.ws` header and spans within the sidebar, with a higher z-index. It stays fully inside the sidebar at any width.
+
+## For contributors

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -27,3 +27,5 @@ The caret rotates when the menu is open, and the button carries `aria-haspopup` 
 A menu opens from its trigger and closes on Escape, on selecting an item, or on a click outside (a shared outside-click hook).
 
 Menus are absolutely positioned relative to their trigger's wrapper. By default a menu opens below-left; modifiers open it right-aligned or upward.
+
+Because the sidebar clips overflow, a sidebar menu must be anchored so it stays inside the sidebar. The workspace menu spans the header width; the user menu spans the footer width.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -191,3 +191,5 @@ The theme toggle appears in both the workspace and user menus for convenience; t
 The active-runs list is hidden entirely when nothing is running, keeping the sidebar tidy.
 
 Sidebar collapse and theme both persist across reloads; the palette query state does not, by design.
+
+When changing any menu or the sidebar, re-check in a browser at a couple of widths and in both themes.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -83,3 +83,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 - Add a menu by giving its trigger a wrapper as the positioning context and toggling an open state.
 
 - A menu inside the sidebar must be anchored so it stays within the 236px width; do not rely on it overflowing, because the sidebar clips overflow.
+
+- Give menus a z-index above the main card so an overlapping menu is never painted under it.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -1,3 +1,5 @@
 # The operator console shell
 
 How the console is laid out: a sidebar and a floating main card, with the shared menu and dropdown behavior.
+
+## Layout

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -47,3 +47,5 @@ The first header button toggles the sidebar.
 ## Theme
 
 Theme can be toggled from the header, the workspace menu, or the user menu. The choice is applied via a data attribute and persisted.
+
+## Search

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -107,3 +107,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **Sidebar content peeks out when collapsed.** Something inside the sidebar is escaping `overflow: hidden`; keep sidebar content within the column.
 
 **Collapse state resets on reload.** localStorage may be blocked; the shell falls back to expanded.
+
+## FAQ

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -123,3 +123,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - Default: opens below the trigger, left-aligned.
 
 - Right-aligned: aligns the menu's right edge to the trigger, opening leftward.
+
+- Upward: opens above the trigger (used by the footer user menu).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -29,3 +29,5 @@ A menu opens from its trigger and closes on Escape, on selecting an item, or on 
 Menus are absolutely positioned relative to their trigger's wrapper. By default a menu opens below-left; modifiers open it right-aligned or upward.
 
 Because the sidebar clips overflow, a sidebar menu must be anchored so it stays inside the sidebar. The workspace menu spans the header width; the user menu spans the footer width.
+
+Menus sit above surrounding content via z-index. Keep menu z-index above the main card so an overlapping menu is never painted under it.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -77,3 +77,5 @@ The menu is now anchored to the `.ws` header and spans within the sidebar, with 
 ## For contributors
 
 The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/src/styles/design.css`.
+
+- Add a nav item by extending the groups list with a route, label, and icon.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -49,3 +49,5 @@ The first header button toggles the sidebar.
 Theme can be toggled from the header, the workspace menu, or the user menu. The choice is applied via a data attribute and persisted.
 
 ## Search
+
+The Search button opens the command palette (Cmd/Ctrl+K). See [SHORTCUTS.md](SHORTCUTS.md).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -189,3 +189,5 @@ The caret rotates to point up while the menu is open, and animates back on close
 The theme toggle appears in both the workspace and user menus for convenience; the header has a dedicated toggle too.
 
 The active-runs list is hidden entirely when nothing is running, keeping the sidebar tidy.
+
+Sidebar collapse and theme both persist across reloads; the palette query state does not, by design.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -111,3 +111,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 ## FAQ
 
 **Can I have multiple workspaces?** The switcher is built for it; today there is a single REDCELL workspace.
+
+**Where is the theme stored?** It is applied via a data attribute on the root and persisted, and re-applied before paint to avoid a flash.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -157,3 +157,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - **Dropdown / menu** - a small floating list anchored to a trigger.
 
 - **Anchor** - the positioned element a menu is measured from.
+
+## References

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -59,3 +59,5 @@ Below the navigation, sessions whose run is currently running are listed for qui
 ## User menu
 
 The footer shows the operator and opens an upward menu with a theme toggle and sign out. It spans the footer width, staying inside the sidebar.
+
+## Accessibility

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -179,3 +179,5 @@ Sidebar plus floating card. Menus stay inside their region, above the content, a
 A dropdown is clipped or hidden by an ancestor with `overflow: hidden` or a higher stacking context. Anchor menus so their box stays inside the visible region rather than fighting the clip.
 
 The sidebar is a fixed 236px, so a menu that spans the header is a predictable width and never depends on the viewport.
+
+While the workspace menu is open the header keeps its hover highlight, which reads as the switcher being active.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -23,3 +23,5 @@ The menu is anchored to the header (`.ws` is the positioning context) and spans 
 The caret rotates when the menu is open, and the button carries `aria-haspopup` and `aria-expanded`.
 
 ## Menus and dropdowns
+
+A menu opens from its trigger and closes on Escape, on selecting an item, or on a click outside (a shared outside-click hook).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -185,3 +185,5 @@ While the workspace menu is open the header keeps its hover highlight, which rea
 Pressing Escape or clicking anywhere outside the switcher closes the menu.
 
 The caret rotates to point up while the menu is open, and animates back on close.
+
+The theme toggle appears in both the workspace and user menus for convenience; the header has a dedicated toggle too.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -173,3 +173,7 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 ## Summary
 
 Sidebar plus floating card. Menus stay inside their region, above the content, and close on outside click. Verify layout in a browser.
+
+## Note on stacking contexts
+
+A dropdown is clipped or hidden by an ancestor with `overflow: hidden` or a higher stacking context. Anchor menus so their box stays inside the visible region rather than fighting the clip.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -131,3 +131,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 ## Structure at a glance
 
 - `.ws` - workspace header (positioning context for its menu)
+
+- `.search` - opens the command palette

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -159,3 +159,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - **Anchor** - the positioned element a menu is measured from.
 
 ## References
+
+- `apps/web/src/app/DashboardShell.tsx` - the shell component.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -79,3 +79,5 @@ The menu is now anchored to the `.ws` header and spans within the sidebar, with 
 The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/src/styles/design.css`.
 
 - Add a nav item by extending the groups list with a route, label, and icon.
+
+- Add a menu by giving its trigger a wrapper as the positioning context and toggling an open state.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -67,3 +67,5 @@ Menu triggers use `aria-haspopup` and `aria-expanded`; menus use a menu role. Fo
 Icon-only buttons carry an `aria-label`.
 
 ## Fix: the workspace dropdown
+
+The dropdown was positioned from the caret with `left: 0`, so a 180px menu started near the right of the sidebar and ran ~60px past its edge.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -193,3 +193,5 @@ The active-runs list is hidden entirely when nothing is running, keeping the sid
 Sidebar collapse and theme both persist across reloads; the palette query state does not, by design.
 
 When changing any menu or the sidebar, re-check in a browser at a couple of widths and in both themes.
+
+That is the shell: predictable layout, contained menus, verified in a real browser.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -75,3 +75,5 @@ The sidebar's `overflow: hidden` then clipped the overflowing part, and it overl
 The menu is now anchored to the `.ws` header and spans within the sidebar, with a higher z-index. It stays fully inside the sidebar at any width.
 
 ## For contributors
+
+The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/src/styles/design.css`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -99,3 +99,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 ## Troubleshooting
 
 **A sidebar dropdown looks cut off.** It extends past the 236px sidebar and is clipped by `overflow: hidden`. Anchor it so it stays within the sidebar.
+
+**A menu appears under the main content.** Its z-index is too low, or it overflows into the main area. Raise the z-index and keep it inside its region.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -37,3 +37,5 @@ Menus sit above surrounding content via z-index. Keep menu z-index above the mai
 The header toggle hides the sidebar (grid column to 0). The choice is stored in localStorage and restored on load.
 
 The sidebar's `overflow: hidden` is what makes the collapse look clean, which is why menus inside it must not rely on overflowing.
+
+## Header

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -163,3 +163,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - `apps/web/src/app/DashboardShell.tsx` - the shell component.
 
 - `apps/web/src/styles/design.css` - shell, sidebar, and menu styles.
+
+- [SHORTCUTS.md](SHORTCUTS.md) - the command palette and keyboard navigation.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -45,3 +45,5 @@ The main card header shows the page title (or the console header on a session) a
 The first header button toggles the sidebar.
 
 ## Theme
+
+Theme can be toggled from the header, the workspace menu, or the user menu. The choice is applied via a data attribute and persisted.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -41,3 +41,5 @@ The sidebar's `overflow: hidden` is what makes the collapse look clean, which is
 ## Header
 
 The main card header shows the page title (or the console header on a session) and page actions such as New session and the theme toggle.
+
+The first header button toggles the sidebar.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -127,3 +127,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - Upward: opens above the trigger (used by the footer user menu).
 
 - Header-spanning: the workspace menu spans the sidebar header width, anchored to `.ws`.
+
+## Structure at a glance

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -109,3 +109,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **Collapse state resets on reload.** localStorage may be blocked; the shell falls back to expanded.
 
 ## FAQ
+
+**Can I have multiple workspaces?** The switcher is built for it; today there is a single REDCELL workspace.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -17,3 +17,5 @@ Top to bottom: the workspace header, the search button, the navigation groups, t
 ## Workspace switcher
 
 The header shows the workspace name with a caret. The caret opens a small menu (the workspace and a theme toggle).
+
+The menu is anchored to the header (`.ws` is the positioning context) and spans within the sidebar, so it never extends into the main content or gets clipped.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -97,3 +97,5 @@ Append `?demo=1` to skip auth and load the shell with demo data for quick visual
 For a dropdown, measure its bounding box against the sidebar's to confirm it stays inside and is not clipped.
 
 ## Troubleshooting
+
+**A sidebar dropdown looks cut off.** It extends past the 236px sidebar and is clipped by `overflow: hidden`. Anchor it so it stays within the sidebar.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -9,3 +9,5 @@ The shell is a two-column grid: a fixed 236px sidebar and the main area. Collaps
 The main area is a floating card with its own header and body, padded away from the edges.
 
 ## Sidebar
+
+The sidebar uses `overflow: hidden` so it clips cleanly when collapsed. That means anything inside it, including dropdowns, must stay within the sidebar's width or it gets clipped.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -3,3 +3,5 @@
 How the console is laid out: a sidebar and a floating main card, with the shared menu and dropdown behavior.
 
 ## Layout
+
+The shell is a two-column grid: a fixed 236px sidebar and the main area. Collapsing the sidebar sets its column to 0.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -181,3 +181,5 @@ A dropdown is clipped or hidden by an ancestor with `overflow: hidden` or a high
 The sidebar is a fixed 236px, so a menu that spans the header is a predictable width and never depends on the viewport.
 
 While the workspace menu is open the header keeps its hover highlight, which reads as the switcher being active.
+
+Pressing Escape or clicking anywhere outside the switcher closes the menu.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -165,3 +165,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - `apps/web/src/styles/design.css` - shell, sidebar, and menu styles.
 
 - [SHORTCUTS.md](SHORTCUTS.md) - the command palette and keyboard navigation.
+
+## See also

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -19,3 +19,5 @@ Top to bottom: the workspace header, the search button, the navigation groups, t
 The header shows the workspace name with a caret. The caret opens a small menu (the workspace and a theme toggle).
 
 The menu is anchored to the header (`.ws` is the positioning context) and spans within the sidebar, so it never extends into the main content or gets clipped.
+
+The caret rotates when the menu is open, and the button carries `aria-haspopup` and `aria-expanded`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -93,3 +93,5 @@ The shell is `apps/web/src/app/DashboardShell.tsx`; its styles are in `apps/web/
 Verify layout changes in a browser, not only with a build. Positioning, clipping, and z-index cannot be checked by type or unit tests.
 
 Append `?demo=1` to skip auth and load the shell with demo data for quick visual checks.
+
+For a dropdown, measure its bounding box against the sidebar's to confirm it stays inside and is not clipped.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -117,3 +117,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 **Does collapsing hide the workspace switcher?** Yes; the whole sidebar is hidden when collapsed.
 
 **Is the shell responsive?** The main content is fluid; the sidebar is a fixed width you can collapse.
+
+## Menu positioning reference

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -11,3 +11,5 @@ The main area is a floating card with its own header and body, padded away from 
 ## Sidebar
 
 The sidebar uses `overflow: hidden` so it clips cleanly when collapsed. That means anything inside it, including dropdowns, must stay within the sidebar's width or it gets clipped.
+
+Top to bottom: the workspace header, the search button, the navigation groups, the active-runs list, and the user menu at the foot.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -65,3 +65,5 @@ The footer shows the operator and opens an upward menu with a theme toggle and s
 Menu triggers use `aria-haspopup` and `aria-expanded`; menus use a menu role. Focus and keyboard access are preserved.
 
 Icon-only buttons carry an `aria-label`.
+
+## Fix: the workspace dropdown

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -133,3 +133,5 @@ For a dropdown, measure its bounding box against the sidebar's to confirm it sta
 - `.ws` - workspace header (positioning context for its menu)
 
 - `.search` - opens the command palette
+
+- `.side-scroll` - the scrollable navigation area

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -167,3 +167,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - [SHORTCUTS.md](SHORTCUTS.md) - the command palette and keyboard navigation.
 
 ## See also
+
+- [DEPLOY.md](DEPLOY.md) and [UPDATING.md](UPDATING.md) for running and updating the console.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -155,3 +155,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - **Workspace switcher** - the header control that opens the workspace menu.
 
 - **Dropdown / menu** - a small floating list anchored to a trigger.
+
+- **Anchor** - the positioned element a menu is measured from.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -151,3 +151,5 @@ Menus sit above the shell chrome and the main card. The workspace menu uses a hi
 - **Shell** - the persistent sidebar and header around every page.
 
 - **Main card** - the floating content area to the right of the sidebar.
+
+- **Workspace switcher** - the header control that opens the workspace menu.


### PR DESCRIPTION
The workspace switcher dropdown (top of the sidebar) rendered partly under the main content and was clipped.

## Root cause
The dropdown was positioned from the caret button with `left: 0` and `min-width: 180px`. Measured in the browser: it opened at x=116 and ran to x=296 - about **60px past the 236px sidebar**. The sidebar uses `overflow: hidden` (needed for the collapse animation), so that 60px was clipped at the sidebar edge, and it overlapped the main card, so it looked like it slid under the main content. Its z-index (60) sat below the main area's stacking too.

## Fix
- Anchor the menu to the `.ws` header (the header is now the positioning context) and span it within the sidebar (`.ws-menu`: `left/right: 8px`, `top: calc(100% - 2px)`), so it stays fully inside the 236px column at any width.
- Raise the menu z-index so it is never painted under the main card.
- Rotate the caret when open, and add `aria-haspopup` / `aria-expanded` to the trigger.
- Made the outside-click hook generic so its ref can sit on the `.ws` div (it wraps both trigger and menu, so clicking items no longer counts as outside), and removed a dead className conditional.

## Verified in the browser (Playwright)
- Before: menu box `left 116 -> right 296`, 60px past the sidebar (right=236), clipped.
- After: menu box `left 16 -> right 220`, fully within the sidebar, z-index 200; no clipping, does not touch the main content. Confirmed visually in both states and that no new console errors appear (the only console errors are API `ERR_CONNECTION_REFUSED` from running the UI without a backend).

## Docs
Added `docs/APP-SHELL.md` documenting the shell, the menu/dropdown positioning rules (keep sidebar menus inside the sidebar because it clips overflow), and how to verify shell changes in a browser. Linked from the README.

Layout/positioning cannot be meaningfully checked by type or unit tests, so this was verified in a real browser rather than with a jsdom test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive guide to the operator console shell, including layout, navigation, workspace switching, menus, accessibility, theming, troubleshooting, and verification steps.
  - Added a README link to the new console shell guide.

- **Bug Fixes**
  - Improved workspace menu positioning and outside-click behavior.
  - Workspace menus now expose clearer accessibility state and semantics.
  - Added a smoother visual transition when opening and closing workspace menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->