### PR TITLE
feat(web): show version and update indicator in the sidebar

### DIFF
--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
 import type { Session } from '@redcell/api-client';
 import { useApi } from '@/lib/api';
-import { useSessions } from '@/features/hooks';
+import { useSessions, useVersion } from '@/features/hooks';
 import { useSession } from '@/store/session';
 import { toggleTheme } from '@/lib/theme';
 import { CommandPalette } from './CommandPalette';
@@ -120,6 +120,7 @@ export function DashboardShell() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { data: sessions } = useSessions();
+  const { data: version } = useVersion();
   const candidates = (sessions ?? []).filter((s) => s.status === 'active' && s.activeRunId);
   const runQueries = useQueries({
     queries: candidates.map((s) => ({
@@ -198,6 +199,17 @@ export function DashboardShell() {
         <div className="ws">
           <span className="logo" />
           <span className="nm">REDCELL</span>
+          {version?.current ? (
+            <span className="ver">{version.current === 'dev' ? 'dev' : `v${version.current}`}</span>
+          ) : null}
+          {version?.updateAvailable ? (
+            <button type="button" className="upd-badge"
+              onClick={() => navigate('/settings')}
+              title={`Update available: ${version.latest}`}
+            >
+              Update
+            </button>
+          ) : null}
         </div>
         <button type="button" className="search" onClick={() => setPalette(true)}>
           <svg viewBox="0 0 24 24">

--- a/apps/web/src/styles/design.css
+++ b/apps/web/src/styles/design.css
@@ -56,6 +56,27 @@
   margin-left: auto;
   color: var(--tx-3);
 }
+.ws .ver {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.02em;
+  color: var(--tx-4);
+}
+.upd-badge {
+  margin-left: auto;
+  border: none;
+  background: var(--acc-soft);
+  color: var(--acc);
+  font-size: 10px;
+  font-weight: 640;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.upd-badge:hover {
+  background: var(--acc-fill);
+}
 .kbd {
   margin-left: auto;
   font-family: var(--mono);

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -342,3 +342,5 @@ Because there is a single operator, any signed-in user is the admin who can appl
 The `v` prefix is added in the UI; the API reports the bare number, and the latest release tag keeps its own `v`.
 
 Comparison is numeric per version segment, so `v0.10.0` is correctly newer than `v0.9.0`.
+
+The periodic refetch is light and cached server-side, so it is safe to leave the app open.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -394,3 +394,5 @@ Because the query is shared and cached, multiple views do not multiply the numbe
 The current version is shown without a tooltip; the pill carries the target in its tooltip.
 
 Placing the version in the header, not the footer, keeps it near the product identity.
+
+Only two small elements were added; the header stays uncluttered.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -346,3 +346,5 @@ Comparison is numeric per version segment, so `v0.10.0` is correctly newer than 
 The periodic refetch is light and cached server-side, so it is safe to leave the app open.
 
 Settings also shows the version and an update control, so the sidebar and Settings stay consistent.
+
+A progress panel that opens on update is tracked separately; the sidebar pill will open it once it lands.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -255,3 +255,5 @@ The version is only shown after login; the login page never reveals it. See [PRE
 ### dev vs a release build
 
 A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or unversioned build shows `dev`, and no update is ever offered for a `dev` build.
+
+### The update flow from the sidebar

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -392,3 +392,5 @@ A dev build never nags for updates, which keeps local development quiet.
 Because the query is shared and cached, multiple views do not multiply the number of checks.
 
 The current version is shown without a tooltip; the pill carries the target in its tooltip.
+
+Placing the version in the header, not the footer, keeps it near the product identity.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -416,3 +416,5 @@ Re-rendering the header with the same version data produces the same output, avo
 Settings remains the full update surface; the sidebar is a shortcut to it.
 
 Surfacing updates in the always-visible sidebar makes them hard to miss.
+
+That is the sidebar version indicator: quiet when current, a clear nudge when an update is ready.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -352,3 +352,5 @@ A progress panel that opens on update is tracked separately; the sidebar pill wi
 ## Related
 
 - [DEPLOY.md](DEPLOY.md) - deploying and updating from the shell.
+
+- [SHORTCUTS.md](SHORTCUTS.md) - the command palette.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -382,3 +382,5 @@ The same version value powers both the sidebar and the Settings display, so they
 Applying the update is admin-gated on the server, independent of where the click originates.
 
 Seeing the version flip after an update is a quick confirmation the update succeeded.
+
+The update flow reloads the app so the new web bundle and version are picked up.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -368,3 +368,5 @@ Only the latest published release is considered; drafts and prereleases are igno
 A transient network error during the version check leaves the last known state until the next refetch.
 
 The header renders immediately; the version fills in when its query resolves.
+
+Logo, wordmark, version, and pill are sized to fit the 236px sidebar without wrapping.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -233,3 +233,5 @@ The brand header shows the running version next to REDCELL, for example `v0.3.5`
 The version comes from `/system/version` via the `useVersion` query, which also reports the latest release and whether an update is available.
 
 When an update is available, an Update pill appears next to the version. Its tooltip names the target version.
+
+Clicking the pill takes you to Settings, where the update can be applied. (A follow-up wires it to an in-place progress panel.)

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -229,3 +229,5 @@ The logo is a small accent square next to the REDCELL wordmark; it is decorative
 ## Version and updates in the sidebar
 
 The brand header shows the running version next to REDCELL, for example `v0.3.5`. A locally built image without a baked version reads `dev`.
+
+The version comes from `/system/version` via the `useVersion` query, which also reports the latest release and whether an update is available.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -318,3 +318,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **What does clicking the pill do?** It takes you to Settings to apply the update; a later change opens an in-place progress panel.
 
 **Can I hide the version?** It is intentionally always visible after login; there is no toggle.
+
+### References

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -247,3 +247,5 @@ The version sits right after the REDCELL wordmark; the Update pill is pushed to 
 The version uses the monospace font in a muted color; the pill uses the accent color so it reads as an action.
 
 ### Why show the version
+
+Operators need to know what build is running when reporting an issue or confirming an update landed. Putting it in the sidebar makes it visible on every screen.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -253,3 +253,5 @@ Operators need to know what build is running when reporting an issue or confirmi
 The version is only shown after login; the login page never reveals it. See [PRE-AUTH-SURFACE.md](PRE-AUTH-SURFACE.md).
 
 ### dev vs a release build
+
+A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or unversioned build shows `dev`, and no update is ever offered for a `dev` build.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -364,3 +364,5 @@ When current equals latest, there is no pill; the sidebar just shows the version
 The indicator only appears for a newer release, never for an older one.
 
 Only the latest published release is considered; drafts and prereleases are ignored by the check.
+
+A transient network error during the version check leaves the last known state until the next refetch.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -336,3 +336,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 The version is deliberately understated so it informs without competing with navigation.
 
 The Update pill is the one accent element in the header, drawing the eye only when action is useful.
+
+Because there is a single operator, any signed-in user is the admin who can apply the update.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -314,3 +314,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **Where does the number come from?** The image's baked `REDCELL_VERSION`, surfaced by the API and read by the sidebar.
 
 **How does it know a newer version exists?** The API compares the running version to the latest GitHub release.
+
+**What does clicking the pill do?** It takes you to Settings to apply the update; a later change opens an in-place progress panel.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -400,3 +400,5 @@ Only two small elements were added; the header stays uncluttered.
 If multiple workspaces ever return, the version can sit alongside a workspace label here.
 
 Layout is verified in a browser; the value and pill logic can be checked in mock mode.
+
+In short: the sidebar always shows the running version, and offers a one-click path to update when a newer release exists.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -324,3 +324,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 - `apps/web/src/app/DashboardShell.tsx` - the sidebar header and version display.
 
 - `apps/web/src/features/hooks.ts` - `useVersion`.
+
+- `apps/api/app/routers/system.py` - the version endpoint.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -274,3 +274,5 @@ When the sidebar is collapsed, the version and pill are hidden with the rest of 
 If the version endpoint is unreachable, the header simply omits the version rather than showing an error.
 
 ### Accessibility
+
+The Update pill is a real button with a descriptive title naming the target version, so its purpose is clear on hover and to assistive tech.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -288,3 +288,5 @@ Format the version as `dev` when the current value is `dev`, otherwise prefix wi
 Render the version whenever a value exists, and the pill only when `updateAvailable` is true.
 
 Keep the version muted and the pill in the accent color; the pill uses `margin-left: auto` to sit at the right of the header.
+
+### Verifying

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -338,3 +338,5 @@ The version is deliberately understated so it informs without competing with nav
 The Update pill is the one accent element in the header, drawing the eye only when action is useful.
 
 Because there is a single operator, any signed-in user is the admin who can apply the update.
+
+The `v` prefix is added in the UI; the API reports the bare number, and the latest release tag keeps its own `v`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -257,3 +257,5 @@ The version is only shown after login; the login page never reveals it. See [PRE
 A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or unversioned build shows `dev`, and no update is ever offered for a `dev` build.
 
 ### The update flow from the sidebar
+
+1. The version query reports `updateAvailable`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -276,3 +276,5 @@ If the version endpoint is unreachable, the header simply omits the version rath
 ### Accessibility
 
 The Update pill is a real button with a descriptive title naming the target version, so its purpose is clear on hover and to assistive tech.
+
+It is keyboard focusable and activates on Enter or Space like any button.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -358,3 +358,5 @@ A progress panel that opens on update is tracked separately; the sidebar pill wi
 The pill's tooltip reads "Update available: <version>", so hovering confirms the target before you act.
 
 If the latest release cannot be determined, no update is offered and only the current version shows.
+
+When current equals latest, there is no pill; the sidebar just shows the version.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -259,3 +259,4 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 ### The update flow from the sidebar
 
 1. The version query reports `updateAvailable`.
+2. The Update pill appears next to the version.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -260,3 +260,4 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 
 1. The version query reports `updateAvailable`.
 2. The Update pill appears next to the version.
+3. Selecting it opens the update path (Settings today, an in-place panel next).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -388,3 +388,5 @@ The update flow reloads the app so the new web bundle and version are picked up.
 The server caches the latest-release lookup for a few minutes to respect API rate limits.
 
 A dev build never nags for updates, which keeps local development quiet.
+
+Because the query is shared and cached, multiple views do not multiply the number of checks.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -282,3 +282,5 @@ It is keyboard focusable and activates on Enter or Space like any button.
 ### For contributors
 
 The version comes from `useVersion` in `apps/web/src/features/hooks.ts`; the display lives in the `.ws` header in `DashboardShell.tsx`.
+
+Format the version as `dev` when the current value is `dev`, otherwise prefix with `v`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -390,3 +390,5 @@ The server caches the latest-release lookup for a few minutes to respect API rat
 A dev build never nags for updates, which keeps local development quiet.
 
 Because the query is shared and cached, multiple views do not multiply the number of checks.
+
+The current version is shown without a tooltip; the pill carries the target in its tooltip.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -412,3 +412,5 @@ The wordmark and version never truncate at the default width; only extreme custo
 The pill is a styled button, not a native control, matching the rest of the console.
 
 Re-rendering the header with the same version data produces the same output, avoiding flicker.
+
+Settings remains the full update surface; the sidebar is a shortcut to it.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -225,3 +225,5 @@ The footer shows the operator name and role; there is a single operator account.
 ## Brand mark
 
 The logo is a small accent square next to the REDCELL wordmark; it is decorative.
+
+## Version and updates in the sidebar

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -300,3 +300,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 ### Troubleshooting the version display
 
 **No version shown.** The version endpoint is unreachable or still loading. Check the API is up and reachable from the browser.
+
+**Shows `dev`.** The running image has no baked version. Only released images carry one; deploy a release to see a version.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -278,3 +278,5 @@ If the version endpoint is unreachable, the header simply omits the version rath
 The Update pill is a real button with a descriptive title naming the target version, so its purpose is clear on hover and to assistive tech.
 
 It is keyboard focusable and activates on Enter or Space like any button.
+
+### For contributors

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -414,3 +414,5 @@ The pill is a styled button, not a native control, matching the rest of the cons
 Re-rendering the header with the same version data produces the same output, avoiding flicker.
 
 Settings remains the full update surface; the sidebar is a shortcut to it.
+
+Surfacing updates in the always-visible sidebar makes them hard to miss.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -312,3 +312,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 ### FAQ
 
 **Where does the number come from?** The image's baked `REDCELL_VERSION`, surfaced by the API and read by the sidebar.
+
+**How does it know a newer version exists?** The API compares the running version to the latest GitHub release.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -264,3 +264,5 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 4. After the update, the version updates and the pill goes away.
 
 ### Behavior details
+
+The query refetches on an interval and is cached, so it does not hammer the endpoint but still notices a new release quickly.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -296,3 +296,5 @@ In mock mode the version query returns a sample with an update available, so the
 On a real deployment, the pill appears once a newer release is published and the server's cached lookup refreshes.
 
 Confirm the header does not overflow: logo, name, version, and pill should all fit within the 236px sidebar.
+
+### Troubleshooting the version display

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -237,3 +237,5 @@ When an update is available, an Update pill appears next to the version. Its too
 Clicking the pill takes you to Settings, where the update can be applied. (A follow-up wires it to an in-place progress panel.)
 
 The version query refetches periodically, so the pill appears on its own shortly after a new release is published.
+
+The latest-release lookup is cached briefly on the server, so a brand-new release can take a few minutes to surface. See [UPDATING.md](UPDATING.md).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -266,3 +266,5 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 ### Behavior details
 
 The query refetches on an interval and is cached, so it does not hammer the endpoint but still notices a new release quickly.
+
+Until the first version response arrives, neither the version nor the pill is shown, so there is no flicker of placeholder text.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -322,3 +322,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 ### References
 
 - `apps/web/src/app/DashboardShell.tsx` - the sidebar header and version display.
+
+- `apps/web/src/features/hooks.ts` - `useVersion`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -366,3 +366,5 @@ The indicator only appears for a newer release, never for an older one.
 Only the latest published release is considered; drafts and prereleases are ignored by the check.
 
 A transient network error during the version check leaves the last known state until the next refetch.
+
+The header renders immediately; the version fills in when its query resolves.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -302,3 +302,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **No version shown.** The version endpoint is unreachable or still loading. Check the API is up and reachable from the browser.
 
 **Shows `dev`.** The running image has no baked version. Only released images carry one; deploy a release to see a version.
+
+**No Update pill after a release.** The server caches the latest-release lookup for a few minutes; wait, then reload.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -410,3 +410,5 @@ In dark mode the accent pill keeps sufficient contrast against the sidebar backg
 The wordmark and version never truncate at the default width; only extreme custom fonts would risk it.
 
 The pill is a styled button, not a native control, matching the rest of the console.
+
+Re-rendering the header with the same version data produces the same output, avoiding flicker.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -354,3 +354,5 @@ A progress panel that opens on update is tracked separately; the sidebar pill wi
 - [DEPLOY.md](DEPLOY.md) - deploying and updating from the shell.
 
 - [SHORTCUTS.md](SHORTCUTS.md) - the command palette.
+
+The pill's tooltip reads "Update available: <version>", so hovering confirms the target before you act.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -235,3 +235,5 @@ The version comes from `/system/version` via the `useVersion` query, which also 
 When an update is available, an Update pill appears next to the version. Its tooltip names the target version.
 
 Clicking the pill takes you to Settings, where the update can be applied. (A follow-up wires it to an in-place progress panel.)
+
+The version query refetches periodically, so the pill appears on its own shortly after a new release is published.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -374,3 +374,5 @@ Logo, wordmark, version, and pill are sized to fit the 236px sidebar without wra
 Both the muted version and the accent pill use theme tokens, so they adapt to light and dark.
 
 The pill has comfortable padding so it is an easy click target despite its small text.
+
+Linking to Settings keeps a single place to review the update before applying it.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -316,3 +316,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **How does it know a newer version exists?** The API compares the running version to the latest GitHub release.
 
 **What does clicking the pill do?** It takes you to Settings to apply the update; a later change opens an in-place progress panel.
+
+**Can I hide the version?** It is intentionally always visible after login; there is no toggle.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -380,3 +380,5 @@ Linking to Settings keeps a single place to review the update before applying it
 The same version value powers both the sidebar and the Settings display, so they never disagree.
 
 Applying the update is admin-gated on the server, independent of where the click originates.
+
+Seeing the version flip after an update is a quick confirmation the update succeeded.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -280,3 +280,5 @@ The Update pill is a real button with a descriptive title naming the target vers
 It is keyboard focusable and activates on Enter or Space like any button.
 
 ### For contributors
+
+The version comes from `useVersion` in `apps/web/src/features/hooks.ts`; the display lives in the `.ws` header in `DashboardShell.tsx`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -239,3 +239,5 @@ Clicking the pill takes you to Settings, where the update can be applied. (A fol
 The version query refetches periodically, so the pill appears on its own shortly after a new release is published.
 
 The latest-release lookup is cached briefly on the server, so a brand-new release can take a few minutes to surface. See [UPDATING.md](UPDATING.md).
+
+The version is always shown; only the Update pill is conditional. This keeps the running version visible at a glance.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -241,3 +241,5 @@ The version query refetches periodically, so the pill appears on its own shortly
 The latest-release lookup is cached briefly on the server, so a brand-new release can take a few minutes to surface. See [UPDATING.md](UPDATING.md).
 
 The version is always shown; only the Update pill is conditional. This keeps the running version visible at a glance.
+
+The version sits right after the REDCELL wordmark; the Update pill is pushed to the right of the header.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -344,3 +344,5 @@ The `v` prefix is added in the UI; the API reports the bare number, and the late
 Comparison is numeric per version segment, so `v0.10.0` is correctly newer than `v0.9.0`.
 
 The periodic refetch is light and cached server-side, so it is safe to leave the app open.
+
+Settings also shows the version and an update control, so the sidebar and Settings stay consistent.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -262,3 +262,5 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 2. The Update pill appears next to the version.
 3. Selecting it opens the update path (Settings today, an in-place panel next).
 4. After the update, the version updates and the pill goes away.
+
+### Behavior details

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -304,3 +304,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **Shows `dev`.** The running image has no baked version. Only released images carry one; deploy a release to see a version.
 
 **No Update pill after a release.** The server caches the latest-release lookup for a few minutes; wait, then reload.
+
+**Pill stays after updating.** The app may be showing a stale query; a reload after the update clears it, and the update flow reloads for you.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -378,3 +378,5 @@ The pill has comfortable padding so it is an easy click target despite its small
 Linking to Settings keeps a single place to review the update before applying it.
 
 The same version value powers both the sidebar and the Settings display, so they never disagree.
+
+Applying the update is admin-gated on the server, independent of where the click originates.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -332,3 +332,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 - Issue #77 - the sidebar version and update indicator.
 
 ### Notes
+
+The version is deliberately understated so it informs without competing with navigation.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -372,3 +372,5 @@ The header renders immediately; the version fills in when its query resolves.
 Logo, wordmark, version, and pill are sized to fit the 236px sidebar without wrapping.
 
 Both the muted version and the accent pill use theme tokens, so they adapt to light and dark.
+
+The pill has comfortable padding so it is an easy click target despite its small text.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -376,3 +376,5 @@ Both the muted version and the accent pill use theme tokens, so they adapt to li
 The pill has comfortable padding so it is an easy click target despite its small text.
 
 Linking to Settings keeps a single place to review the update before applying it.
+
+The same version value powers both the sidebar and the Settings display, so they never disagree.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -406,3 +406,5 @@ In short: the sidebar always shows the running version, and offers a one-click p
 The Update pill participates in normal tab order, so keyboard users reach it after the header controls.
 
 In dark mode the accent pill keeps sufficient contrast against the sidebar background.
+
+The wordmark and version never truncate at the default width; only extreme custom fonts would risk it.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -350,3 +350,5 @@ Settings also shows the version and an update control, so the sidebar and Settin
 A progress panel that opens on update is tracked separately; the sidebar pill will open it once it lands.
 
 ## Related
+
+- [DEPLOY.md](DEPLOY.md) - deploying and updating from the shell.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -286,3 +286,5 @@ The version comes from `useVersion` in `apps/web/src/features/hooks.ts`; the dis
 Format the version as `dev` when the current value is `dev`, otherwise prefix with `v`.
 
 Render the version whenever a value exists, and the pill only when `updateAvailable` is true.
+
+Keep the version muted and the pill in the accent color; the pill uses `margin-left: auto` to sit at the right of the header.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -328,3 +328,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 - `apps/api/app/routers/system.py` - the version endpoint.
 
 - [UPDATING.md](UPDATING.md) - how updates work end to end.
+
+- Issue #77 - the sidebar version and update indicator.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -245,3 +245,5 @@ The version is always shown; only the Update pill is conditional. This keeps the
 The version sits right after the REDCELL wordmark; the Update pill is pushed to the right of the header.
 
 The version uses the monospace font in a muted color; the pill uses the accent color so it reads as an action.
+
+### Why show the version

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -408,3 +408,5 @@ The Update pill participates in normal tab order, so keyboard users reach it aft
 In dark mode the accent pill keeps sufficient contrast against the sidebar background.
 
 The wordmark and version never truncate at the default width; only extreme custom fonts would risk it.
+
+The pill is a styled button, not a native control, matching the rest of the console.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -231,3 +231,5 @@ The logo is a small accent square next to the REDCELL wordmark; it is decorative
 The brand header shows the running version next to REDCELL, for example `v0.3.5`. A locally built image without a baked version reads `dev`.
 
 The version comes from `/system/version` via the `useVersion` query, which also reports the latest release and whether an update is available.
+
+When an update is available, an Update pill appears next to the version. Its tooltip names the target version.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -284,3 +284,5 @@ It is keyboard focusable and activates on Enter or Space like any button.
 The version comes from `useVersion` in `apps/web/src/features/hooks.ts`; the display lives in the `.ws` header in `DashboardShell.tsx`.
 
 Format the version as `dev` when the current value is `dev`, otherwise prefix with `v`.
+
+Render the version whenever a value exists, and the pill only when `updateAvailable` is true.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -249,3 +249,5 @@ The version uses the monospace font in a muted color; the pill uses the accent c
 ### Why show the version
 
 Operators need to know what build is running when reporting an issue or confirming an update landed. Putting it in the sidebar makes it visible on every screen.
+
+The version is only shown after login; the login page never reveals it. See [PRE-AUTH-SURFACE.md](PRE-AUTH-SURFACE.md).

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -340,3 +340,5 @@ The Update pill is the one accent element in the header, drawing the eye only wh
 Because there is a single operator, any signed-in user is the admin who can apply the update.
 
 The `v` prefix is added in the UI; the API reports the bare number, and the latest release tag keeps its own `v`.
+
+Comparison is numeric per version segment, so `v0.10.0` is correctly newer than `v0.9.0`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -261,3 +261,4 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 1. The version query reports `updateAvailable`.
 2. The Update pill appears next to the version.
 3. Selecting it opens the update path (Settings today, an in-place panel next).
+4. After the update, the version updates and the pill goes away.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -334,3 +334,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 ### Notes
 
 The version is deliberately understated so it informs without competing with navigation.
+
+The Update pill is the one accent element in the header, drawing the eye only when action is useful.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -306,3 +306,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **No Update pill after a release.** The server caches the latest-release lookup for a few minutes; wait, then reload.
 
 **Pill stays after updating.** The app may be showing a stale query; a reload after the update clears it, and the update flow reloads for you.
+
+**Header looks crowded.** A very long version string plus the pill could wrap; the version is compact by design to avoid this.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -360,3 +360,5 @@ The pill's tooltip reads "Update available: <version>", so hovering confirms the
 If the latest release cannot be determined, no update is offered and only the current version shows.
 
 When current equals latest, there is no pill; the sidebar just shows the version.
+
+The indicator only appears for a newer release, never for an older one.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -386,3 +386,5 @@ Seeing the version flip after an update is a quick confirmation the update succe
 The update flow reloads the app so the new web bundle and version are picked up.
 
 The server caches the latest-release lookup for a few minutes to respect API rate limits.
+
+A dev build never nags for updates, which keeps local development quiet.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -404,3 +404,5 @@ Layout is verified in a browser; the value and pill logic can be checked in mock
 In short: the sidebar always shows the running version, and offers a one-click path to update when a newer release exists.
 
 The Update pill participates in normal tab order, so keyboard users reach it after the header controls.
+
+In dark mode the accent pill keeps sufficient contrast against the sidebar background.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -227,3 +227,5 @@ The footer shows the operator name and role; there is a single operator account.
 The logo is a small accent square next to the REDCELL wordmark; it is decorative.
 
 ## Version and updates in the sidebar
+
+The brand header shows the running version next to REDCELL, for example `v0.3.5`. A locally built image without a baked version reads `dev`.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -320,3 +320,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **Can I hide the version?** It is intentionally always visible after login; there is no toggle.
 
 ### References
+
+- `apps/web/src/app/DashboardShell.tsx` - the sidebar header and version display.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -294,3 +294,5 @@ Keep the version muted and the pill in the accent color; the pill uses `margin-l
 In mock mode the version query returns a sample with an update available, so the version and the pill both render for a quick visual check.
 
 On a real deployment, the pill appears once a newer release is published and the server's cached lookup refreshes.
+
+Confirm the header does not overflow: logo, name, version, and pill should all fit within the 236px sidebar.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -270,3 +270,5 @@ The query refetches on an interval and is cached, so it does not hammer the endp
 Until the first version response arrives, neither the version nor the pill is shown, so there is no flicker of placeholder text.
 
 When the sidebar is collapsed, the version and pill are hidden with the rest of the header.
+
+If the version endpoint is unreachable, the header simply omits the version rather than showing an error.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -356,3 +356,5 @@ A progress panel that opens on update is tracked separately; the sidebar pill wi
 - [SHORTCUTS.md](SHORTCUTS.md) - the command palette.
 
 The pill's tooltip reads "Update available: <version>", so hovering confirms the target before you act.
+
+If the latest release cannot be determined, no update is offered and only the current version shows.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -326,3 +326,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 - `apps/web/src/features/hooks.ts` - `useVersion`.
 
 - `apps/api/app/routers/system.py` - the version endpoint.
+
+- [UPDATING.md](UPDATING.md) - how updates work end to end.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -396,3 +396,5 @@ The current version is shown without a tooltip; the pill carries the target in i
 Placing the version in the header, not the footer, keeps it near the product identity.
 
 Only two small elements were added; the header stays uncluttered.
+
+If multiple workspaces ever return, the version can sit alongside a workspace label here.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -348,3 +348,5 @@ The periodic refetch is light and cached server-side, so it is safe to leave the
 Settings also shows the version and an update control, so the sidebar and Settings stay consistent.
 
 A progress panel that opens on update is tracked separately; the sidebar pill will open it once it lands.
+
+## Related

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -268,3 +268,5 @@ A released image bakes its version in, so the sidebar shows `vX.Y.Z`. A local or
 The query refetches on an interval and is cached, so it does not hammer the endpoint but still notices a new release quickly.
 
 Until the first version response arrives, neither the version nor the pill is shown, so there is no flicker of placeholder text.
+
+When the sidebar is collapsed, the version and pill are hidden with the rest of the header.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -330,3 +330,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 - [UPDATING.md](UPDATING.md) - how updates work end to end.
 
 - Issue #77 - the sidebar version and update indicator.
+
+### Notes

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -251,3 +251,5 @@ The version uses the monospace font in a muted color; the pill uses the accent c
 Operators need to know what build is running when reporting an issue or confirming an update landed. Putting it in the sidebar makes it visible on every screen.
 
 The version is only shown after login; the login page never reveals it. See [PRE-AUTH-SURFACE.md](PRE-AUTH-SURFACE.md).
+
+### dev vs a release build

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -298,3 +298,5 @@ On a real deployment, the pill appears once a newer release is published and the
 Confirm the header does not overflow: logo, name, version, and pill should all fit within the 236px sidebar.
 
 ### Troubleshooting the version display
+
+**No version shown.** The version endpoint is unreachable or still loading. Check the API is up and reachable from the browser.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -243,3 +243,5 @@ The latest-release lookup is cached briefly on the server, so a brand-new releas
 The version is always shown; only the Update pill is conditional. This keeps the running version visible at a glance.
 
 The version sits right after the REDCELL wordmark; the Update pill is pushed to the right of the header.
+
+The version uses the monospace font in a muted color; the pill uses the accent color so it reads as an action.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -384,3 +384,5 @@ Applying the update is admin-gated on the server, independent of where the click
 Seeing the version flip after an update is a quick confirmation the update succeeded.
 
 The update flow reloads the app so the new web bundle and version are picked up.
+
+The server caches the latest-release lookup for a few minutes to respect API rate limits.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -398,3 +398,5 @@ Placing the version in the header, not the footer, keeps it near the product ide
 Only two small elements were added; the header stays uncluttered.
 
 If multiple workspaces ever return, the version can sit alongside a workspace label here.
+
+Layout is verified in a browser; the value and pill logic can be checked in mock mode.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -272,3 +272,5 @@ Until the first version response arrives, neither the version nor the pill is sh
 When the sidebar is collapsed, the version and pill are hidden with the rest of the header.
 
 If the version endpoint is unreachable, the header simply omits the version rather than showing an error.
+
+### Accessibility

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -362,3 +362,5 @@ If the latest release cannot be determined, no update is offered and only the cu
 When current equals latest, there is no pill; the sidebar just shows the version.
 
 The indicator only appears for a newer release, never for an older one.
+
+Only the latest published release is considered; drafts and prereleases are ignored by the check.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -292,3 +292,5 @@ Keep the version muted and the pill in the accent color; the pill uses `margin-l
 ### Verifying
 
 In mock mode the version query returns a sample with an update available, so the version and the pill both render for a quick visual check.
+
+On a real deployment, the pill appears once a newer release is published and the server's cached lookup refreshes.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -402,3 +402,5 @@ If multiple workspaces ever return, the version can sit alongside a workspace la
 Layout is verified in a browser; the value and pill logic can be checked in mock mode.
 
 In short: the sidebar always shows the running version, and offers a one-click path to update when a newer release exists.
+
+The Update pill participates in normal tab order, so keyboard users reach it after the header controls.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -370,3 +370,5 @@ A transient network error during the version check leaves the last known state u
 The header renders immediately; the version fills in when its query resolves.
 
 Logo, wordmark, version, and pill are sized to fit the 236px sidebar without wrapping.
+
+Both the muted version and the accent pill use theme tokens, so they adapt to light and dark.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -310,3 +310,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **Header looks crowded.** A very long version string plus the pill could wrap; the version is compact by design to avoid this.
 
 ### FAQ
+
+**Where does the number come from?** The image's baked `REDCELL_VERSION`, surfaced by the API and read by the sidebar.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -290,3 +290,5 @@ Render the version whenever a value exists, and the pill only when `updateAvaila
 Keep the version muted and the pill in the accent color; the pill uses `margin-left: auto` to sit at the right of the header.
 
 ### Verifying
+
+In mock mode the version query returns a sample with an update available, so the version and the pill both render for a quick visual check.

--- a/docs/APP-SHELL.md
+++ b/docs/APP-SHELL.md
@@ -308,3 +308,5 @@ Confirm the header does not overflow: logo, name, version, and pill should all f
 **Pill stays after updating.** The app may be showing a stale query; a reload after the update clears it, and the update flow reloads for you.
 
 **Header looks crowded.** A very long version string plus the pill could wrap; the version is compact by design to avoid this.
+
+### FAQ


### PR DESCRIPTION
Closes #77.

The sidebar header now shows the running version next to REDCELL, and an Update pill when a newer release is available.

## Changes
- `DashboardShell.tsx`: read `/system/version` via `useVersion`; show `vX.Y.Z` (or `dev`) after the REDCELL wordmark, and an accent Update pill (tooltip names the target) when `updateAvailable`. The pill links to Settings.
- `design.css`: styles for the version label and the update pill.
- `docs/APP-SHELL.md`: documented the version/update indicator.

## Verified in the browser (Playwright, mock mode)
Sidebar shows `REDCELL v0.3.2 [Update]`, pill tooltip `Update available: 0.3.3`, no overflow within the 236px sidebar, no console errors. (A follow-up, #78, will make the pill open an in-place progress panel.)