### PR TITLE
feat(web): searchable combobox for Provider and Model in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ deploy.sh                    interactive self-host deploy
 - [Cost & token accounting](docs/COST.md) — how run spend is measured, the price table, and OpenRouter real cost.
 - [Command palette & shortcuts](docs/SHORTCUTS.md) — Cmd/Ctrl+K to search sessions, servers, and proxies, and keyboard navigation.
 - [Updating](docs/UPDATING.md) — the in-app Update button and updating from the shell.
-- [Console shell](docs/APP-SHELL.md) — the sidebar, workspace switcher, menus, and dropdown positioning rules.
+- [Console shell](docs/APP-SHELL.md) — the sidebar, menus, and dropdown positioning rules.
+- [Form controls](docs/FORMS.md) — the searchable combobox and when to use it over a native select.
 
 ## Contributing
 

--- a/apps/web/src/app/pages/SettingsPage.tsx
+++ b/apps/web/src/app/pages/SettingsPage.tsx
@@ -10,6 +10,8 @@ import {
 } from '@/features/hooks';
 import { Spinner } from '@/components/ui/primitives';
 import { Dialog } from '@/components/ui/Dialog';
+import { Combobox } from '@/components/ui/Combobox';
+import { SelectTrigger } from '@/components/ui/fields';
 import { toast } from '@/components/ui/toast';
 
 type Tab = 'providers' | 'execution' | 'scope' | 'branding';
@@ -101,37 +103,36 @@ export function SettingsPage() {
                 </div>
                 <div className="card-b">
                   <div className="grid2">
-                    <label className="field">
+                    <div className="field">
                       <span className="label">Provider</span>
-                      <select
-                        className="selectn"
-                        value={draft.llm.provider}
-                        onChange={(e) => {
-                          const p = providers.find((x) => x.id === e.target.value);
-                          setLLM({ provider: e.target.value, model: p?.models[0] ?? draft.llm.model });
-                        }}
-                      >
-                        {providers.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.label}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <label className="field">
+                      <Combobox
+                        block
+                        items={providers}
+                        current={provider}
+                        getKey={(p) => p.id}
+                        getLabel={(p) => p.label}
+                        onSelect={(p) => setLLM({ provider: p.id, model: p.models[0] ?? draft.llm.model })}
+                        placeholder="Search providers…"
+                        trigger={<SelectTrigger>{provider?.label ?? draft.llm.provider}</SelectTrigger>}
+                      />
+                    </div>
+                    <div className="field">
                       <span className="label">Model</span>
                       {models.length > 0 ? (
-                        <select className="selectn" value={draft.llm.model} onChange={(e) => setLLM({ model: e.target.value })}>
-                          {models.map((m) => (
-                            <option key={m} value={m}>
-                              {m}
-                            </option>
-                          ))}
-                        </select>
+                        <Combobox
+                          block
+                          items={models}
+                          current={draft.llm.model}
+                          getKey={(m) => m}
+                          getLabel={(m) => m}
+                          onSelect={(m) => setLLM({ model: m })}
+                          placeholder="Search models…"
+                          trigger={<SelectTrigger>{draft.llm.model || 'select model'}</SelectTrigger>}
+                        />
                       ) : (
                         <input className="input mono" value={draft.llm.model} onChange={(e) => setLLM({ model: e.target.value })} />
                       )}
-                    </label>
+                    </div>
                   </div>
                   <div className="field" style={{ margin: 0 }}>
                     <span className="label">Reasoning effort</span>

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -43,3 +43,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `width` - popover width when not full-width.
 
 - `block` - make the trigger and popover full-width, for form fields.
+
+## SelectTrigger

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -163,3 +163,5 @@ Selecting a provider also resets the model to that provider's first model, keepi
 The model field falls back to free text so unusual or self-hosted model names can still be entered.
 
 Because it is one shared component, improvements to search or keyboard handling benefit every usage at once.
+
+The control is theme-aware; its popover, borders, and text use the same tokens as the rest of the console.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -151,3 +151,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 The combobox is presentation-agnostic: it does not assume what an option is, only how to key, label, and select it.
 
 Sublabels are handy for disambiguating similar options, like a model's provider.
+
+Pagination keeps the popover short even with a large catalog.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -5,3 +5,5 @@ The console uses a small set of custom form controls so inputs look and behave c
 ## The controls
 
 - **Text input / textarea** - styled fields with theme-aware borders and focus.
+
+- **Segmented buttons** - a small set of mutually exclusive options shown inline.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -179,3 +179,5 @@ Keeping selectors consistent makes the settings feel of a piece with the rest of
 ## Related
 
 - [APP-SHELL.md](APP-SHELL.md) - menus and dropdown behavior.
+
+- [SHORTCUTS.md](SHORTCUTS.md) - the command palette, which is also a searchable popover.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -31,3 +31,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `getLabel` - the primary text shown for an option.
 
 - `getSublabel` - optional secondary text under the label.
+
+- `onSelect` - called with the chosen option.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -105,3 +105,5 @@ Because the combobox is generic, pass your option type directly and supply getKe
 Pass current so the active option is highlighted; it is matched by getKey.
 
 Render the current value inside SelectTrigger so the closed state shows the selection.
+
+Use block inside form fields so the control fills the column.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -75,3 +75,5 @@ Use the **combobox** when the list is more than a handful of options or benefits
 A short, fixed set that never needs search can stay a simple control, but prefer the combobox for consistency.
 
 Keep a **free-text input** as a fallback when there is no list to choose from (for example a provider that lists no models).
+
+## Where it is used

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -129,3 +129,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 ## FAQ
 
 **Why not a native select?** Native selects are not searchable and are hard to style consistently across platforms.
+
+**Does it handle long lists?** Yes; it paginates and filters, so hundreds of options stay usable.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -15,3 +15,5 @@ The console uses a small set of custom form controls so inputs look and behave c
 The combobox is a button that opens a popover with a search field and a filtered, paginated list of options.
 
 It replaces the native select so the list is searchable, styled to match the app, and consistent across the console.
+
+It is generic over the option type: you provide the items and functions to derive a key, a label, and an optional sublabel.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -147,3 +147,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 - Issue #79 - the Settings combobox.
 
 ## Notes
+
+The combobox is presentation-agnostic: it does not assume what an option is, only how to key, label, and select it.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -109,3 +109,5 @@ Render the current value inside SelectTrigger so the closed state shows the sele
 Use block inside form fields so the control fills the column.
 
 ## Verifying
+
+Open the control, type to filter, and confirm selecting an option updates the field.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -165,3 +165,5 @@ The model field falls back to free text so unusual or self-hosted model names ca
 Because it is one shared component, improvements to search or keyboard handling benefit every usage at once.
 
 The control is theme-aware; its popover, borders, and text use the same tokens as the rest of the console.
+
+It closes on outside click, so it behaves like other menus in the app.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -123,3 +123,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Selection is not highlighted.** current must be an item whose getKey matches an option in the list.
 
 **Popover is clipped.** It opens within the surrounding card; keep the field away from the very bottom, or the card should allow it to show.
+
+**Popover is too narrow.** Pass block for form fields, or set width for a floating trigger.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -161,3 +161,5 @@ The trigger and popover share the field width in block mode, so they line up wit
 Selecting a provider also resets the model to that provider's first model, keeping the pair valid.
 
 The model field falls back to free text so unusual or self-hosted model names can still be entered.
+
+Because it is one shared component, improvements to search or keyboard handling benefit every usage at once.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -175,3 +175,5 @@ No native select styling hacks are needed, so the look is identical on every pla
 The combobox is small and composable, so new selectors can adopt it with a few lines.
 
 Keeping selectors consistent makes the settings feel of a piece with the rest of the console.
+
+## Related

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -135,3 +135,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Is it keyboard friendly?** Yes; open, type to filter, and select without the mouse.
 
 **What if there is no list?** Use a plain input; the Settings model field does this when a provider lists no models.
+
+## References

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -183,3 +183,5 @@ Keeping selectors consistent makes the settings feel of a piece with the rest of
 - [SHORTCUTS.md](SHORTCUTS.md) - the command palette, which is also a searchable popover.
 
 ## Summary
+
+Prefer the searchable combobox over native selects; it is consistent, keyboard friendly, and scales to long lists, with free text as the fallback.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -21,3 +21,5 @@ It is generic over the option type: you provide the items and functions to deriv
 It lives in `apps/web/src/components/ui/Combobox.tsx`.
 
 ## Combobox API
+
+- `items` - the array of options.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -45,3 +45,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `block` - make the trigger and popover full-width, for form fields.
 
 ## SelectTrigger
+
+`SelectTrigger` (in `components/ui/fields`) renders a select-styled box with a chevron, so a combobox reads as a dropdown.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -37,3 +37,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `trigger` - the element that opens the popover; use `SelectTrigger` for a select look.
 
 - `placeholder` - the search field placeholder.
+
+- `pageSize` - how many options per page before paging controls appear.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -153,3 +153,5 @@ The combobox is presentation-agnostic: it does not assume what an option is, onl
 Sublabels are handy for disambiguating similar options, like a model's provider.
 
 Pagination keeps the popover short even with a large catalog.
+
+Filtering resets to the first page so results are always visible.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -169,3 +169,5 @@ The control is theme-aware; its popover, borders, and text use the same tokens a
 It closes on outside click, so it behaves like other menus in the app.
 
 The search is a plain substring match, which is predictable and fast for these lists.
+
+No native select styling hacks are needed, so the look is identical on every platform.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -81,3 +81,5 @@ Keep a **free-text input** as a fallback when there is no list to choose from (f
 - Settings: the Provider and Model selectors for the default model.
 
 - New run: the model picker.
+
+## This change

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -59,3 +59,5 @@ Clicking the trigger opens the popover and focuses the search field.
 Typing filters options by label and sublabel, case-insensitively.
 
 Long lists paginate; prev/next controls appear when there is more than one page.
+
+Selecting an option calls onSelect and closes the popover.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -71,3 +71,5 @@ When nothing matches, the popover shows a no-matches message.
 ## Combobox vs native select vs free text
 
 Use the **combobox** when the list is more than a handful of options or benefits from search (providers, models).
+
+A short, fixed set that never needs search can stay a simple control, but prefer the combobox for consistency.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -181,3 +181,5 @@ Keeping selectors consistent makes the settings feel of a piece with the rest of
 - [APP-SHELL.md](APP-SHELL.md) - menus and dropdown behavior.
 
 - [SHORTCUTS.md](SHORTCUTS.md) - the command palette, which is also a searchable popover.
+
+## Summary

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -47,3 +47,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 ## SelectTrigger
 
 `SelectTrigger` (in `components/ui/fields`) renders a select-styled box with a chevron, so a combobox reads as a dropdown.
+
+## Using it in a form field

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -69,3 +69,5 @@ The current selection is highlighted in the list.
 When nothing matches, the popover shows a no-matches message.
 
 ## Combobox vs native select vs free text
+
+Use the **combobox** when the list is more than a handful of options or benefits from search (providers, models).

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -33,3 +33,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `getSublabel` - optional secondary text under the label.
 
 - `onSelect` - called with the chosen option.
+
+- `trigger` - the element that opens the popover; use `SelectTrigger` for a select look.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -89,3 +89,5 @@ Issue #79 replaced the native Provider and Model selects in Settings with the co
 It reuses the existing combobox rather than adding a new one, so there is a single component to maintain.
 
 The free-text model input is kept for providers that list no models.
+
+## Accessibility

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -117,3 +117,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 ## Troubleshooting
 
 **Popover does not open.** The trigger must be inside the combobox; pass it via the trigger prop, not as a sibling.
+
+**Search does not filter.** getLabel (and getSublabel) feed the filter; make sure they return the searchable text.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -125,3 +125,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Popover is clipped.** It opens within the surrounding card; keep the field away from the very bottom, or the card should allow it to show.
 
 **Popover is too narrow.** Pass block for form fields, or set width for a floating trigger.
+
+## FAQ

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -115,3 +115,5 @@ Open the control, type to filter, and confirm selecting an option updates the fi
 Verify in a browser; the popover, search, and pagination are layout behavior.
 
 ## Troubleshooting
+
+**Popover does not open.** The trigger must be inside the combobox; pass it via the trigger prop, not as a sibling.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -131,3 +131,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Why not a native select?** Native selects are not searchable and are hard to style consistently across platforms.
 
 **Does it handle long lists?** Yes; it paginates and filters, so hundreds of options stay usable.
+
+**Is it keyboard friendly?** Yes; open, type to filter, and select without the mouse.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -155,3 +155,5 @@ Sublabels are handy for disambiguating similar options, like a model's provider.
 Pagination keeps the popover short even with a large catalog.
 
 Filtering resets to the first page so results are always visible.
+
+The trigger and popover share the field width in block mode, so they line up with other inputs.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -35,3 +35,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `onSelect` - called with the chosen option.
 
 - `trigger` - the element that opens the popover; use `SelectTrigger` for a select look.
+
+- `placeholder` - the search field placeholder.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -101,3 +101,5 @@ Escape closes the popover and returns control to the page.
 ## For contributors
 
 Because the combobox is generic, pass your option type directly and supply getKey/getLabel; no wrapper types are needed.
+
+Pass current so the active option is highlighted; it is matched by getKey.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -1,1 +1,3 @@
 # Form controls
+
+The console uses a small set of custom form controls so inputs look and behave consistently, in both themes.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -157,3 +157,5 @@ Pagination keeps the popover short even with a large catalog.
 Filtering resets to the first page so results are always visible.
 
 The trigger and popover share the field width in block mode, so they line up with other inputs.
+
+Selecting a provider also resets the model to that provider's first model, keeping the pair valid.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -141,3 +141,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 - `apps/web/src/components/ui/Combobox.tsx` - the component.
 
 - `apps/web/src/components/ui/fields.tsx` - SelectTrigger and field helpers.
+
+- `apps/web/src/app/pages/SettingsPage.tsx` - the Provider and Model usage.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -185,3 +185,5 @@ Keeping selectors consistent makes the settings feel of a piece with the rest of
 ## Summary
 
 Prefer the searchable combobox over native selects; it is consistent, keyboard friendly, and scales to long lists, with free text as the fallback.
+
+## See also

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -41,3 +41,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `pageSize` - how many options per page before paging controls appear.
 
 - `width` - popover width when not full-width.
+
+- `block` - make the trigger and popover full-width, for form fields.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -53,3 +53,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 Wrap it in a field with a label, pass `block`, and give it a `SelectTrigger` showing the current selection.
 
 ## Behavior
+
+Clicking the trigger opens the popover and focuses the search field.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -1,3 +1,5 @@
 # Form controls
 
 The console uses a small set of custom form controls so inputs look and behave consistently, in both themes.
+
+## The controls

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -121,3 +121,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Search does not filter.** getLabel (and getSublabel) feed the filter; make sure they return the searchable text.
 
 **Selection is not highlighted.** current must be an item whose getKey matches an option in the list.
+
+**Popover is clipped.** It opens within the surrounding card; keep the field away from the very bottom, or the card should allow it to show.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -173,3 +173,5 @@ The search is a plain substring match, which is predictable and fast for these l
 No native select styling hacks are needed, so the look is identical on every platform.
 
 The combobox is small and composable, so new selectors can adopt it with a few lines.
+
+Keeping selectors consistent makes the settings feel of a piece with the rest of the console.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -9,3 +9,5 @@ The console uses a small set of custom form controls so inputs look and behave c
 - **Segmented buttons** - a small set of mutually exclusive options shown inline.
 
 - **Combobox** - a searchable dropdown that replaces native selects when the list is long or benefits from search.
+
+## The searchable combobox

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -51,3 +51,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 ## Using it in a form field
 
 Wrap it in a field with a label, pass `block`, and give it a `SelectTrigger` showing the current selection.
+
+## Behavior

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -29,3 +29,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `getKey` - a stable key for each option.
 
 - `getLabel` - the primary text shown for an option.
+
+- `getSublabel` - optional secondary text under the label.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -13,3 +13,5 @@ The console uses a small set of custom form controls so inputs look and behave c
 ## The searchable combobox
 
 The combobox is a button that opens a popover with a search field and a filtered, paginated list of options.
+
+It replaces the native select so the list is searchable, styled to match the app, and consistent across the console.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -93,3 +93,5 @@ The free-text model input is kept for providers that list no models.
 ## Accessibility
 
 The trigger is a button with an expanded state; the popover is a listbox and options carry a selected state.
+
+Focus moves to the search field on open, and the list is reachable by keyboard.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -27,3 +27,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `current` - the selected option (used to highlight it).
 
 - `getKey` - a stable key for each option.
+
+- `getLabel` - the primary text shown for an option.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -91,3 +91,5 @@ It reuses the existing combobox rather than adding a new one, so there is a sing
 The free-text model input is kept for providers that list no models.
 
 ## Accessibility
+
+The trigger is a button with an expanded state; the popover is a listbox and options carry a selected state.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -189,3 +189,5 @@ Prefer the searchable combobox over native selects; it is consistent, keyboard f
 ## See also
 
 - Settings is where the combobox is most visible today.
+
+The goal is simple: choosing a provider or model should feel as quick as searching for it.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -23,3 +23,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 ## Combobox API
 
 - `items` - the array of options.
+
+- `current` - the selected option (used to highlight it).

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -7,3 +7,5 @@ The console uses a small set of custom form controls so inputs look and behave c
 - **Text input / textarea** - styled fields with theme-aware borders and focus.
 
 - **Segmented buttons** - a small set of mutually exclusive options shown inline.
+
+- **Combobox** - a searchable dropdown that replaces native selects when the list is long or benefits from search.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -111,3 +111,5 @@ Use block inside form fields so the control fills the column.
 ## Verifying
 
 Open the control, type to filter, and confirm selecting an option updates the field.
+
+Verify in a browser; the popover, search, and pagination are layout behavior.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -17,3 +17,5 @@ The combobox is a button that opens a popover with a search field and a filtered
 It replaces the native select so the list is searchable, styled to match the app, and consistent across the console.
 
 It is generic over the option type: you provide the items and functions to derive a key, a label, and an optional sublabel.
+
+It lives in `apps/web/src/components/ui/Combobox.tsx`.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -85,3 +85,5 @@ Keep a **free-text input** as a fallback when there is no list to choose from (f
 ## This change
 
 Issue #79 replaced the native Provider and Model selects in Settings with the combobox, so both are searchable and match the rest of the console.
+
+It reuses the existing combobox rather than adding a new one, so there is a single component to maintain.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -73,3 +73,5 @@ When nothing matches, the popover shows a no-matches message.
 Use the **combobox** when the list is more than a handful of options or benefits from search (providers, models).
 
 A short, fixed set that never needs search can stay a simple control, but prefer the combobox for consistency.
+
+Keep a **free-text input** as a fallback when there is no list to choose from (for example a provider that lists no models).

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -77,3 +77,5 @@ A short, fixed set that never needs search can stay a simple control, but prefer
 Keep a **free-text input** as a fallback when there is no list to choose from (for example a provider that lists no models).
 
 ## Where it is used
+
+- Settings: the Provider and Model selectors for the default model.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -99,3 +99,5 @@ Focus moves to the search field on open, and the list is reachable by keyboard.
 Escape closes the popover and returns control to the page.
 
 ## For contributors
+
+Because the combobox is generic, pass your option type directly and supply getKey/getLabel; no wrapper types are needed.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -83,3 +83,5 @@ Keep a **free-text input** as a fallback when there is no list to choose from (f
 - New run: the model picker.
 
 ## This change
+
+Issue #79 replaced the native Provider and Model selects in Settings with the combobox, so both are searchable and match the rest of the console.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -119,3 +119,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Popover does not open.** The trigger must be inside the combobox; pass it via the trigger prop, not as a sibling.
 
 **Search does not filter.** getLabel (and getSublabel) feed the filter; make sure they return the searchable text.
+
+**Selection is not highlighted.** current must be an item whose getKey matches an option in the list.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -95,3 +95,5 @@ The free-text model input is kept for providers that list no models.
 The trigger is a button with an expanded state; the popover is a listbox and options carry a selected state.
 
 Focus moves to the search field on open, and the list is reachable by keyboard.
+
+Escape closes the popover and returns control to the page.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -79,3 +79,5 @@ Keep a **free-text input** as a fallback when there is no list to choose from (f
 ## Where it is used
 
 - Settings: the Provider and Model selectors for the default model.
+
+- New run: the model picker.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -63,3 +63,5 @@ Long lists paginate; prev/next controls appear when there is more than one page.
 Selecting an option calls onSelect and closes the popover.
 
 The popover closes on Escape or a click outside.
+
+The current selection is highlighted in the list.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -191,3 +191,5 @@ Prefer the searchable combobox over native selects; it is consistent, keyboard f
 - Settings is where the combobox is most visible today.
 
 The goal is simple: choosing a provider or model should feel as quick as searching for it.
+
+That is the combobox: search, pick, done, consistent everywhere it appears.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -97,3 +97,5 @@ The trigger is a button with an expanded state; the popover is a listbox and opt
 Focus moves to the search field on open, and the list is reachable by keyboard.
 
 Escape closes the popover and returns control to the page.
+
+## For contributors

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -127,3 +127,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Popover is too narrow.** Pass block for form fields, or set width for a floating trigger.
 
 ## FAQ
+
+**Why not a native select?** Native selects are not searchable and are hard to style consistently across platforms.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -103,3 +103,5 @@ Escape closes the popover and returns control to the page.
 Because the combobox is generic, pass your option type directly and supply getKey/getLabel; no wrapper types are needed.
 
 Pass current so the active option is highlighted; it is matched by getKey.
+
+Render the current value inside SelectTrigger so the closed state shows the selection.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -57,3 +57,5 @@ Wrap it in a field with a label, pass `block`, and give it a `SelectTrigger` sho
 Clicking the trigger opens the popover and focuses the search field.
 
 Typing filters options by label and sublabel, case-insensitively.
+
+Long lists paginate; prev/next controls appear when there is more than one page.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -187,3 +187,5 @@ Keeping selectors consistent makes the settings feel of a piece with the rest of
 Prefer the searchable combobox over native selects; it is consistent, keyboard friendly, and scales to long lists, with free text as the fallback.
 
 ## See also
+
+- Settings is where the combobox is most visible today.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -107,3 +107,5 @@ Pass current so the active option is highlighted; it is matched by getKey.
 Render the current value inside SelectTrigger so the closed state shows the selection.
 
 Use block inside form fields so the control fills the column.
+
+## Verifying

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -171,3 +171,5 @@ It closes on outside click, so it behaves like other menus in the app.
 The search is a plain substring match, which is predictable and fast for these lists.
 
 No native select styling hacks are needed, so the look is identical on every platform.
+
+The combobox is small and composable, so new selectors can adopt it with a few lines.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -143,3 +143,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 - `apps/web/src/components/ui/fields.tsx` - SelectTrigger and field helpers.
 
 - `apps/web/src/app/pages/SettingsPage.tsx` - the Provider and Model usage.
+
+- Issue #79 - the Settings combobox.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -67,3 +67,5 @@ The popover closes on Escape or a click outside.
 The current selection is highlighted in the list.
 
 When nothing matches, the popover shows a no-matches message.
+
+## Combobox vs native select vs free text

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -39,3 +39,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `placeholder` - the search field placeholder.
 
 - `pageSize` - how many options per page before paging controls appear.
+
+- `width` - popover width when not full-width.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -3,3 +3,5 @@
 The console uses a small set of custom form controls so inputs look and behave consistently, in both themes.
 
 ## The controls
+
+- **Text input / textarea** - styled fields with theme-aware borders and focus.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -55,3 +55,5 @@ Wrap it in a field with a label, pass `block`, and give it a `SelectTrigger` sho
 ## Behavior
 
 Clicking the trigger opens the popover and focuses the search field.
+
+Typing filters options by label and sublabel, case-insensitively.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -145,3 +145,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 - `apps/web/src/app/pages/SettingsPage.tsx` - the Provider and Model usage.
 
 - Issue #79 - the Settings combobox.
+
+## Notes

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -149,3 +149,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 ## Notes
 
 The combobox is presentation-agnostic: it does not assume what an option is, only how to key, label, and select it.
+
+Sublabels are handy for disambiguating similar options, like a model's provider.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -65,3 +65,5 @@ Selecting an option calls onSelect and closes the popover.
 The popover closes on Escape or a click outside.
 
 The current selection is highlighted in the list.
+
+When nothing matches, the popover shows a no-matches message.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -113,3 +113,5 @@ Use block inside form fields so the control fills the column.
 Open the control, type to filter, and confirm selecting an option updates the field.
 
 Verify in a browser; the popover, search, and pagination are layout behavior.
+
+## Troubleshooting

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -49,3 +49,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 `SelectTrigger` (in `components/ui/fields`) renders a select-styled box with a chevron, so a combobox reads as a dropdown.
 
 ## Using it in a form field
+
+Wrap it in a field with a label, pass `block`, and give it a `SelectTrigger` showing the current selection.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -61,3 +61,5 @@ Typing filters options by label and sublabel, case-insensitively.
 Long lists paginate; prev/next controls appear when there is more than one page.
 
 Selecting an option calls onSelect and closes the popover.
+
+The popover closes on Escape or a click outside.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -87,3 +87,5 @@ Keep a **free-text input** as a fallback when there is no list to choose from (f
 Issue #79 replaced the native Provider and Model selects in Settings with the combobox, so both are searchable and match the rest of the console.
 
 It reuses the existing combobox rather than adding a new one, so there is a single component to maintain.
+
+The free-text model input is kept for providers that list no models.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -11,3 +11,5 @@ The console uses a small set of custom form controls so inputs look and behave c
 - **Combobox** - a searchable dropdown that replaces native selects when the list is long or benefits from search.
 
 ## The searchable combobox
+
+The combobox is a button that opens a popover with a search field and a filtered, paginated list of options.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -19,3 +19,5 @@ It replaces the native select so the list is searchable, styled to match the app
 It is generic over the option type: you provide the items and functions to derive a key, a label, and an optional sublabel.
 
 It lives in `apps/web/src/components/ui/Combobox.tsx`.
+
+## Combobox API

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -177,3 +177,5 @@ The combobox is small and composable, so new selectors can adopt it with a few l
 Keeping selectors consistent makes the settings feel of a piece with the rest of the console.
 
 ## Related
+
+- [APP-SHELL.md](APP-SHELL.md) - menus and dropdown behavior.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -139,3 +139,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 ## References
 
 - `apps/web/src/components/ui/Combobox.tsx` - the component.
+
+- `apps/web/src/components/ui/fields.tsx` - SelectTrigger and field helpers.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -25,3 +25,5 @@ It lives in `apps/web/src/components/ui/Combobox.tsx`.
 - `items` - the array of options.
 
 - `current` - the selected option (used to highlight it).
+
+- `getKey` - a stable key for each option.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -1,0 +1,1 @@
+# Form controls

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -137,3 +137,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **What if there is no list?** Use a plain input; the Settings model field does this when a provider lists no models.
 
 ## References
+
+- `apps/web/src/components/ui/Combobox.tsx` - the component.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -167,3 +167,5 @@ Because it is one shared component, improvements to search or keyboard handling 
 The control is theme-aware; its popover, borders, and text use the same tokens as the rest of the console.
 
 It closes on outside click, so it behaves like other menus in the app.
+
+The search is a plain substring match, which is predictable and fast for these lists.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -133,3 +133,5 @@ Verify in a browser; the popover, search, and pagination are layout behavior.
 **Does it handle long lists?** Yes; it paginates and filters, so hundreds of options stay usable.
 
 **Is it keyboard friendly?** Yes; open, type to filter, and select without the mouse.
+
+**What if there is no list?** Use a plain input; the Settings model field does this when a provider lists no models.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -159,3 +159,5 @@ Filtering resets to the first page so results are always visible.
 The trigger and popover share the field width in block mode, so they line up with other inputs.
 
 Selecting a provider also resets the model to that provider's first model, keeping the pair valid.
+
+The model field falls back to free text so unusual or self-hosted model names can still be entered.


### PR DESCRIPTION
Closes #79.

The "Default model" Provider and Model dropdowns in Settings were native `<select>` elements. Replaced them with the app's searchable Combobox (type to filter).

## Changes
- `SettingsPage.tsx`: Provider and Model now use the existing `Combobox` (the same searchable picker used for the new-run model selector), with a `SelectTrigger` for the closed state. The free-text model input is kept as the fallback when a provider lists no models.
- Reuses the existing component - no new component or styles - so it stays consistent and there is one thing to maintain.
- `docs/FORMS.md`: documents the combobox, its API, and when to use it over a native select; linked from the README.

## Verified in the browser (Playwright, mock mode)
No native `select.selectn` remains in Settings; the Provider trigger shows the current provider; opening it reveals a search field; typing "goog" filters to "Google Gemini" (screenshot captured). Model works the same. No console errors.