### PR TITLE
fix(web): portal the combobox popover so it isn't clipped by cards

### DIFF
--- a/apps/web/src/components/ui/Combobox.tsx
+++ b/apps/web/src/components/ui/Combobox.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/lib/cn';
 import { Icon } from './Icon';
 
-// Searchable, paginated session picker.
+// Searchable, paginated picker. The popover is portaled to the body with fixed
+// positioning so it is never clipped by a scrolling or overflow-hidden ancestor.
 export function Combobox<T>({
   items,
   current,
@@ -31,23 +33,47 @@ export function Combobox<T>({
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState('');
   const [page, setPage] = useState(0);
-  const ref = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; width: number; top?: number; bottom?: number } | null>(null);
+
+  const place = () => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const w = block ? r.width : width;
+    const belowSpace = window.innerHeight - r.bottom;
+    if (belowSpace < 300 && r.top > belowSpace) {
+      setPos({ left: r.left, width: w, bottom: window.innerHeight - r.top + 4 });
+    } else {
+      setPos({ left: r.left, width: w, top: r.bottom + 4 });
+    }
+  };
 
   useEffect(() => {
     if (!open) return;
+    place();
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      const t = e.target as Node;
+      if (wrapRef.current?.contains(t) || popRef.current?.contains(t)) return;
+      setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false);
     };
+    const reposition = () => place();
     document.addEventListener('mousedown', onDown);
     document.addEventListener('keydown', onKey);
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
     return () => {
       document.removeEventListener('mousedown', onDown);
       document.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
     };
-  }, [open]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, block, width]);
 
   useEffect(() => {
     setPage(0);
@@ -65,79 +91,89 @@ export function Combobox<T>({
   const pageItems = filtered.slice(clampPage * pageSize, clampPage * pageSize + pageSize);
 
   return (
-    <div ref={ref} className={cn('relative', block && 'w-full')}>
+    <div ref={wrapRef} className={cn('relative', block && 'w-full')}>
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          place();
+          setOpen((o) => !o);
+        }}
         className={cn('flex items-center', block && 'w-full')}
       >
         {trigger}
       </button>
-      {open ? (
-        <div
-          style={{ width: block ? '100%' : width }}
-          className="absolute left-0 top-[calc(100%+4px)] z-50 rounded-[var(--radius)] border border-border2 bg-panel2 p-1.5 shadow-[var(--shadow)]"
-        >
-          <div className="mb-1 flex items-center gap-2 rounded-[var(--radius)] border border-border2 bg-bg px-2">
-            <Icon name="search" size={13} className="text-faint" />
-            <input
-              autoFocus
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              placeholder={placeholder}
-              className="h-8 flex-1 bg-transparent text-[13px] text-text outline-none placeholder:text-faint"
-            />
-          </div>
-          <div className="max-h-64 overflow-auto">
-            {pageItems.length === 0 ? (
-              <div className="px-2 py-3 text-center text-xs text-faint">No matches</div>
-            ) : (
-              pageItems.map((i) => {
-                const active = current && getKey(current) === getKey(i);
-                return (
-                  <button type="button"
-                    key={getKey(i)}
-                    onClick={() => {
-                      onSelect(i);
-                      setOpen(false);
-                    }}
-                    className={cn(
-                      'flex w-full flex-col rounded-[4px] px-2.5 py-1.5 text-left',
-                      active ? 'bg-accent-dim' : 'hover:bg-elev',
-                    )}
+      {open && pos
+        ? createPortal(
+            <div
+              ref={popRef}
+              style={{ position: 'fixed', left: pos.left, width: pos.width, top: pos.top, bottom: pos.bottom, zIndex: 100 }}
+              className="rounded-[var(--radius)] border border-border2 bg-panel2 p-1.5 shadow-[var(--shadow)]"
+            >
+              <div className="mb-1 flex items-center gap-2 rounded-[var(--radius)] border border-border2 bg-bg px-2">
+                <Icon name="search" size={13} className="text-faint" />
+                <input
+                  autoFocus
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  placeholder={placeholder}
+                  className="h-8 flex-1 bg-transparent text-[13px] text-text outline-none placeholder:text-faint"
+                />
+              </div>
+              <div className="max-h-64 overflow-auto">
+                {pageItems.length === 0 ? (
+                  <div className="px-2 py-3 text-center text-xs text-faint">No matches</div>
+                ) : (
+                  pageItems.map((i) => {
+                    const active = current && getKey(current) === getKey(i);
+                    return (
+                      <button
+                        type="button"
+                        key={getKey(i)}
+                        onClick={() => {
+                          onSelect(i);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          'flex w-full flex-col rounded-[4px] px-2.5 py-1.5 text-left',
+                          active ? 'bg-accent-dim' : 'hover:bg-elev',
+                        )}
+                      >
+                        <span className={cn('text-xs', active ? 'text-accent-ink' : 'text-text')}>
+                          {getLabel(i)}
+                        </span>
+                        {getSublabel ? <span className="text-[10px] text-faint">{getSublabel(i)}</span> : null}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+              {pages > 1 ? (
+                <div className="mt-1 flex items-center justify-between border-t border-border px-1 pt-1.5">
+                  <button
+                    type="button"
+                    disabled={clampPage === 0}
+                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    className="grid h-6 w-6 place-items-center rounded text-faint hover:text-text disabled:opacity-40"
                   >
-                    <span className={cn('text-xs', active ? 'text-accent-ink' : 'text-text')}>
-                      {getLabel(i)}
-                    </span>
-                    {getSublabel ? <span className="text-[10px] text-faint">{getSublabel(i)}</span> : null}
+                    <Icon name="chevronLeft" size={14} />
                   </button>
-                );
-              })
-            )}
-          </div>
-          {pages > 1 ? (
-            <div className="mt-1 flex items-center justify-between border-t border-border px-1 pt-1.5">
-              <button type="button"
-                disabled={clampPage === 0}
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
-                className="grid h-6 w-6 place-items-center rounded text-faint hover:text-text disabled:opacity-40"
-              >
-                <Icon name="chevronLeft" size={14} />
-              </button>
-              <span className="font-mono text-[10px] text-faint">
-                {clampPage + 1} / {pages}
-              </span>
-              <button type="button"
-                disabled={clampPage >= pages - 1}
-                onClick={() => setPage((p) => Math.min(pages - 1, p + 1))}
-                className="grid h-6 w-6 place-items-center rounded text-faint hover:text-text disabled:opacity-40"
-              >
-                <Icon name="chevronRight" size={14} />
-              </button>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+                  <span className="font-mono text-[10px] text-faint">
+                    {clampPage + 1} / {pages}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={clampPage >= pages - 1}
+                    onClick={() => setPage((p) => Math.min(pages - 1, p + 1))}
+                    className="grid h-6 w-6 place-items-center rounded text-faint hover:text-text disabled:opacity-40"
+                  >
+                    <Icon name="chevronRight" size={14} />
+                  </button>
+                </div>
+              ) : null}
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   );
 }

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -285,3 +285,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 - Issue #86 - the clipping fix.
 
 ### General rule
+
+Any floating UI that can appear inside a scrolling or clipped container should portal out and position from its anchor.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -195,3 +195,5 @@ The goal is simple: choosing a provider or model should feel as quick as searchi
 That is the combobox: search, pick, done, consistent everywhere it appears.
 
 ## Popover positioning
+
+A dropdown positioned inside its container is clipped when an ancestor uses `overflow: hidden` or scrolls. On the Settings page the cards clip their contents, which cut the combobox list off at the card's bottom edge.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -325,3 +325,5 @@ The width is read from the trigger in block mode, so the popover never looks nar
 For non-block usage a fixed width is used, which suits a compact trigger like a header button.
 
 The change is backward compatible: the component's props are unchanged.
+
+Existing usages, like the New run model picker, keep working without edits.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -239,3 +239,5 @@ Measure the trigger rect on open and on every reposition, not once, so the popov
 Include the popover in the outside-click check, or clicking an option will close the popover before the click registers.
 
 ### Troubleshooting
+
+**Dropdown is cut off.** It is being clipped by an overflow-hidden ancestor; it should be portaled to the body, not positioned inside the container.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -201,3 +201,5 @@ A dropdown positioned inside its container is clipped when an ancestor uses `ove
 To avoid this, the combobox popover is rendered in a portal on `document.body` with fixed positioning, so it escapes every overflow-hidden or scrolling ancestor.
 
 The position is computed from the trigger's bounding rect: the popover opens just below the trigger, aligned to its left, and matches its width in block mode.
+
+When there is not enough room below, it flips to open above the trigger instead of running off the screen.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -261,3 +261,5 @@ Scroll the page with the popover open and confirm it follows the trigger.
 Selecting an option should update the field and close the popover.
 
 ### This fix
+
+Issue #86: the Settings comboboxes were clipped by the card. Portaling the popover fixed it, and every combobox benefits since it is shared.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -253,3 +253,5 @@ Include the popover in the outside-click check, or clicking an option will close
 ### Verifying
 
 Open the control inside a card and confirm the list shows fully, past the card's edge, on top of other content.
+
+Check the popover's parent is the body and its position is fixed.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -355,3 +355,5 @@ The result is a searchable dropdown that never hides behind a card wall.
 This pattern should be the template for any future dropdown in the console.
 
 Keeping one combobox means one place to fix and improve positioning.
+
+The reposition on scroll keeps the popover glued to the field during a scroll.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -311,3 +311,5 @@ Selecting closes the popover and reports the choice to the parent.
 Escape closes the popover without changing the selection.
 
 A click anywhere outside the trigger and popover closes it.
+
+The trigger keeps its own styling; only the popover is portaled.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -211,3 +211,5 @@ Because the popover is outside the trigger's DOM subtree, the outside-click hand
 The popover uses a high z-index so it sits above cards and even above a modal dialog it may be opened from.
 
 This is why the same combobox works both on the Settings page and inside the New run dialog.
+
+### How it works

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -307,3 +307,5 @@ Filtering resets to the first page so the top results are visible.
 The current selection is highlighted wherever it lands in the list.
 
 Selecting closes the popover and reports the choice to the parent.
+
+Escape closes the popover without changing the selection.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -205,3 +205,5 @@ The position is computed from the trigger's bounding rect: the popover opens jus
 When there is not enough room below, it flips to open above the trigger instead of running off the screen.
 
 It repositions on scroll and resize while open, so it stays anchored to the trigger as the page moves.
+
+Because the popover is outside the trigger's DOM subtree, the outside-click handler ignores clicks inside the popover as well, so selecting an option does not close it prematurely.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -339,3 +339,5 @@ Cards clip for tidy rounded corners, so removing their overflow was not the righ
 Portaling the popover keeps the cards tidy and the dropdown visible.
 
 The fix was verified by measuring the popover against the card: it now extends past the card and is not clipped.
+
+It was also confirmed to render as a child of the body with fixed positioning.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -315,3 +315,5 @@ A click anywhere outside the trigger and popover closes it.
 The trigger keeps its own styling; only the popover is portaled.
 
 The popover inherits theme tokens, so it matches light and dark.
+
+Because it is fixed, it is unaffected by the card's own scroll position.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -203,3 +203,5 @@ To avoid this, the combobox popover is rendered in a portal on `document.body` w
 The position is computed from the trigger's bounding rect: the popover opens just below the trigger, aligned to its left, and matches its width in block mode.
 
 When there is not enough room below, it flips to open above the trigger instead of running off the screen.
+
+It repositions on scroll and resize while open, so it stays anchored to the trigger as the page moves.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -337,3 +337,5 @@ The Settings Default model card clips its contents, which is what exposed the bu
 Cards clip for tidy rounded corners, so removing their overflow was not the right fix.
 
 Portaling the popover keeps the cards tidy and the dropdown visible.
+
+The fix was verified by measuring the popover against the card: it now extends past the card and is not clipped.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -199,3 +199,5 @@ That is the combobox: search, pick, done, consistent everywhere it appears.
 A dropdown positioned inside its container is clipped when an ancestor uses `overflow: hidden` or scrolls. On the Settings page the cards clip their contents, which cut the combobox list off at the card's bottom edge.
 
 To avoid this, the combobox popover is rendered in a portal on `document.body` with fixed positioning, so it escapes every overflow-hidden or scrolling ancestor.
+
+The position is computed from the trigger's bounding rect: the popover opens just below the trigger, aligned to its left, and matches its width in block mode.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -387,3 +387,5 @@ The portal target is the document body, the least-clipped container available.
 Fixed coordinates are recomputed each time the popover opens, so stale positions never linger.
 
 The trigger wrapper keeps a relative box only for layout; positioning no longer depends on it.
+
+This keeps the closed control lightweight and the open popover free of its container.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -249,3 +249,5 @@ Include the popover in the outside-click check, or clicking an option will close
 **Dropdown runs off the bottom.** Enable the flip so it opens above the trigger when space below is tight.
 
 **Dropdown appears behind a dialog.** Raise its z-index above the dialog's overlay.
+
+### Verifying

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -357,3 +357,5 @@ This pattern should be the template for any future dropdown in the console.
 Keeping one combobox means one place to fix and improve positioning.
 
 The reposition on scroll keeps the popover glued to the field during a scroll.
+
+The flip keeps the list on screen near the bottom of a page.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -193,3 +193,5 @@ Prefer the searchable combobox over native selects; it is consistent, keyboard f
 The goal is simple: choosing a provider or model should feel as quick as searching for it.
 
 That is the combobox: search, pick, done, consistent everywhere it appears.
+
+## Popover positioning

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -341,3 +341,5 @@ Portaling the popover keeps the cards tidy and the dropdown visible.
 The fix was verified by measuring the popover against the card: it now extends past the card and is not clipped.
 
 It was also confirmed to render as a child of the body with fixed positioning.
+
+The provider list shows all providers with search and paging, over the content below.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -237,3 +237,5 @@ Keep the popover's z-index above dialogs so it is usable from within a modal.
 Measure the trigger rect on open and on every reposition, not once, so the popover tracks layout changes.
 
 Include the popover in the outside-click check, or clicking an option will close the popover before the click registers.
+
+### Troubleshooting

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -365,3 +365,5 @@ Outside-click covers both the trigger and the portaled popover.
 Escape remains a quick way to dismiss it.
 
 The popover width tracks the field for a clean, aligned look.
+
+The z-index keeps it above cards and dialogs.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -329,3 +329,5 @@ The change is backward compatible: the component's props are unchanged.
 Existing usages, like the New run model picker, keep working without edits.
 
 Only the internal positioning changed, from absolute-in-container to fixed-in-body.
+
+That single change removes a whole class of clipping bugs for every combobox.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -287,3 +287,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 ### General rule
 
 Any floating UI that can appear inside a scrolling or clipped container should portal out and position from its anchor.
+
+Menus that live in a known, unclipped place (like the sidebar footer) can stay in place, but a control reused across the app should not assume its container.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -347,3 +347,5 @@ The provider list shows all providers with search and paging, over the content b
 The model list behaves the same for the selected provider.
 
 No new styles were needed; the popover reuses the existing menu look.
+
+The trigger still reads as a select thanks to the shared SelectTrigger.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -375,3 +375,5 @@ In short: portal dropdowns out of clipped containers, and they just work.
 The Settings comboboxes are the first beneficiary; the New run picker keeps working.
 
 Any new selector can adopt the combobox and inherit correct positioning for free.
+
+This closes the clipping issue for the current selectors.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -197,3 +197,5 @@ That is the combobox: search, pick, done, consistent everywhere it appears.
 ## Popover positioning
 
 A dropdown positioned inside its container is clipped when an ancestor uses `overflow: hidden` or scrolls. On the Settings page the cards clip their contents, which cut the combobox list off at the card's bottom edge.
+
+To avoid this, the combobox popover is rendered in a portal on `document.body` with fixed positioning, so it escapes every overflow-hidden or scrolling ancestor.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -221,3 +221,5 @@ The popover is rendered through a portal, so it lives at the end of the body rat
 A capture-phase scroll listener and a resize listener re-measure and reposition while the popover is open.
 
 Two refs, one on the trigger wrapper and one on the popover, let the outside-click handler treat both as inside.
+
+The width follows the trigger in block mode, so the popover lines up with the field.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -227,3 +227,5 @@ The width follows the trigger in block mode, so the popover lines up with the fi
 ### For contributors
 
 You do not need to do anything special to use it in a clipped container; the portal handles that.
+
+Prefer block inside form fields so the popover matches the field width.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -389,3 +389,5 @@ Fixed coordinates are recomputed each time the popover opens, so stale positions
 The trigger wrapper keeps a relative box only for layout; positioning no longer depends on it.
 
 This keeps the closed control lightweight and the open popover free of its container.
+
+That balance is what makes the combobox both tidy when closed and unclipped when open.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -255,3 +255,5 @@ Include the popover in the outside-click check, or clicking an option will close
 Open the control inside a card and confirm the list shows fully, past the card's edge, on top of other content.
 
 Check the popover's parent is the body and its position is fixed.
+
+Scroll the page with the popover open and confirm it follows the trigger.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -313,3 +313,5 @@ Escape closes the popover without changing the selection.
 A click anywhere outside the trigger and popover closes it.
 
 The trigger keeps its own styling; only the popover is portaled.
+
+The popover inherits theme tokens, so it matches light and dark.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -217,3 +217,5 @@ This is why the same combobox works both on the Settings page and inside the New
 On open, the trigger's rect is measured and the popover's fixed coordinates are set from it.
 
 The popover is rendered through a portal, so it lives at the end of the body rather than inside the clipped card.
+
+A capture-phase scroll listener and a resize listener re-measure and reposition while the popover is open.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -383,3 +383,5 @@ And it sets a clear pattern for the next one.
 ### Summary: portal your dropdowns out of clipped containers, position from the trigger, and reposition while open.
 
 The portal target is the document body, the least-clipped container available.
+
+Fixed coordinates are recomputed each time the popover opens, so stale positions never linger.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -223,3 +223,5 @@ A capture-phase scroll listener and a resize listener re-measure and reposition 
 Two refs, one on the trigger wrapper and one on the popover, let the outside-click handler treat both as inside.
 
 The width follows the trigger in block mode, so the popover lines up with the field.
+
+### For contributors

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -305,3 +305,5 @@ The search field is focused on open, so you can type immediately.
 Filtering resets to the first page so the top results are visible.
 
 The current selection is highlighted wherever it lands in the list.
+
+Selecting closes the popover and reports the choice to the parent.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -371,3 +371,5 @@ The z-index keeps it above cards and dialogs.
 The change is small, shared, and verified in a browser.
 
 In short: portal dropdowns out of clipped containers, and they just work.
+
+The Settings comboboxes are the first beneficiary; the New run picker keeps working.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -319,3 +319,5 @@ The popover inherits theme tokens, so it matches light and dark.
 Because it is fixed, it is unaffected by the card's own scroll position.
 
 The reposition listener uses capture so it catches scrolling in any ancestor, not just the window.
+
+The width is read from the trigger in block mode, so the popover never looks narrower than the field.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -363,3 +363,5 @@ The flip keeps the list on screen near the bottom of a page.
 Outside-click covers both the trigger and the portaled popover.
 
 Escape remains a quick way to dismiss it.
+
+The popover width tracks the field for a clean, aligned look.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -269,3 +269,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 **Why portal instead of raising z-index?** z-index does not help against `overflow: hidden`; the element is clipped regardless of stacking. A portal removes it from the clipped subtree.
 
 **Why fixed positioning?** Fixed coordinates are relative to the viewport, which matches a body-level portal and is simple to compute from the trigger rect.
+
+**What about scrolling?** The popover repositions on scroll so it tracks the trigger; closing on scroll would also be reasonable, but tracking feels smoother here.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -295,3 +295,5 @@ When in doubt, portal; it is the safer default for dropdowns.
 The popover opens 4px below the trigger for a small, consistent gap.
 
 In flip mode it anchors its bottom just above the trigger, so it grows upward from there.
+
+The list has a bounded max height, so a huge catalog scrolls inside the popover instead of covering the page.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -385,3 +385,5 @@ And it sets a clear pattern for the next one.
 The portal target is the document body, the least-clipped container available.
 
 Fixed coordinates are recomputed each time the popover opens, so stale positions never linger.
+
+The trigger wrapper keeps a relative box only for layout; positioning no longer depends on it.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -283,3 +283,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 - `.card` in `design.css` uses `overflow: hidden`, which is why the portal is needed.
 
 - Issue #86 - the clipping fix.
+
+### General rule

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -377,3 +377,5 @@ The Settings comboboxes are the first beneficiary; the New run picker keeps work
 Any new selector can adopt the combobox and inherit correct positioning for free.
 
 This closes the clipping issue for the current selectors.
+
+And it sets a clear pattern for the next one.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -257,3 +257,5 @@ Open the control inside a card and confirm the list shows fully, past the card's
 Check the popover's parent is the body and its position is fixed.
 
 Scroll the page with the popover open and confirm it follows the trigger.
+
+Selecting an option should update the field and close the popover.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -309,3 +309,5 @@ The current selection is highlighted wherever it lands in the list.
 Selecting closes the popover and reports the choice to the parent.
 
 Escape closes the popover without changing the selection.
+
+A click anywhere outside the trigger and popover closes it.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -359,3 +359,5 @@ Keeping one combobox means one place to fix and improve positioning.
 The reposition on scroll keeps the popover glued to the field during a scroll.
 
 The flip keeps the list on screen near the bottom of a page.
+
+Outside-click covers both the trigger and the portaled popover.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -265,3 +265,5 @@ Selecting an option should update the field and close the popover.
 Issue #86: the Settings comboboxes were clipped by the card. Portaling the popover fixed it, and every combobox benefits since it is shared.
 
 ### Popover FAQ
+
+**Why portal instead of raising z-index?** z-index does not help against `overflow: hidden`; the element is clipped regardless of stacking. A portal removes it from the clipped subtree.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -373,3 +373,5 @@ The change is small, shared, and verified in a browser.
 In short: portal dropdowns out of clipped containers, and they just work.
 
 The Settings comboboxes are the first beneficiary; the New run picker keeps working.
+
+Any new selector can adopt the combobox and inherit correct positioning for free.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -367,3 +367,5 @@ Escape remains a quick way to dismiss it.
 The popover width tracks the field for a clean, aligned look.
 
 The z-index keeps it above cards and dialogs.
+
+The change is small, shared, and verified in a browser.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -291,3 +291,5 @@ Any floating UI that can appear inside a scrolling or clipped container should p
 Menus that live in a known, unclipped place (like the sidebar footer) can stay in place, but a control reused across the app should not assume its container.
 
 When in doubt, portal; it is the safer default for dropdowns.
+
+The popover opens 4px below the trigger for a small, consistent gap.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -275,3 +275,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 **Does it work in a dialog?** Yes; the portal sits above the dialog overlay via its z-index.
 
 **Is repositioning expensive?** It is a cheap rect read and style update, only while the popover is open.
+
+### References

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -381,3 +381,5 @@ This closes the clipping issue for the current selectors.
 And it sets a clear pattern for the next one.
 
 ### Summary: portal your dropdowns out of clipped containers, position from the trigger, and reposition while open.
+
+The portal target is the document body, the least-clipped container available.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -301,3 +301,5 @@ The list has a bounded max height, so a huge catalog scrolls inside the popover 
 Pagination keeps each page short even when the list is long.
 
 The search field is focused on open, so you can type immediately.
+
+Filtering resets to the first page so the top results are visible.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -245,3 +245,5 @@ Include the popover in the outside-click check, or clicking an option will close
 **Dropdown is in the wrong place.** The trigger rect was not re-measured; reposition on open and on scroll/resize.
 
 **Dropdown closes when clicking an option.** The outside-click check does not include the portaled popover; add its ref to the check.
+
+**Dropdown runs off the bottom.** Enable the flip so it opens above the trigger when space below is tight.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -351,3 +351,5 @@ No new styles were needed; the popover reuses the existing menu look.
 The trigger still reads as a select thanks to the shared SelectTrigger.
 
 The result is a searchable dropdown that never hides behind a card wall.
+
+This pattern should be the template for any future dropdown in the console.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -259,3 +259,5 @@ Check the popover's parent is the body and its position is fixed.
 Scroll the page with the popover open and confirm it follows the trigger.
 
 Selecting an option should update the field and close the popover.
+
+### This fix

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -349,3 +349,5 @@ The model list behaves the same for the selected provider.
 No new styles were needed; the popover reuses the existing menu look.
 
 The trigger still reads as a select thanks to the shared SelectTrigger.
+
+The result is a searchable dropdown that never hides behind a card wall.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -247,3 +247,5 @@ Include the popover in the outside-click check, or clicking an option will close
 **Dropdown closes when clicking an option.** The outside-click check does not include the portaled popover; add its ref to the check.
 
 **Dropdown runs off the bottom.** Enable the flip so it opens above the trigger when space below is tight.
+
+**Dropdown appears behind a dialog.** Raise its z-index above the dialog's overlay.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -273,3 +273,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 **What about scrolling?** The popover repositions on scroll so it tracks the trigger; closing on scroll would also be reasonable, but tracking feels smoother here.
 
 **Does it work in a dialog?** Yes; the portal sits above the dialog overlay via its z-index.
+
+**Is repositioning expensive?** It is a cheap rect read and style update, only while the popover is open.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -267,3 +267,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 ### Popover FAQ
 
 **Why portal instead of raising z-index?** z-index does not help against `overflow: hidden`; the element is clipped regardless of stacking. A portal removes it from the clipped subtree.
+
+**Why fixed positioning?** Fixed coordinates are relative to the viewport, which matches a body-level portal and is simple to compute from the trigger rect.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -297,3 +297,5 @@ The popover opens 4px below the trigger for a small, consistent gap.
 In flip mode it anchors its bottom just above the trigger, so it grows upward from there.
 
 The list has a bounded max height, so a huge catalog scrolls inside the popover instead of covering the page.
+
+Pagination keeps each page short even when the list is long.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -369,3 +369,5 @@ The popover width tracks the field for a clean, aligned look.
 The z-index keeps it above cards and dialogs.
 
 The change is small, shared, and verified in a browser.
+
+In short: portal dropdowns out of clipped containers, and they just work.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -327,3 +327,5 @@ For non-block usage a fixed width is used, which suits a compact trigger like a 
 The change is backward compatible: the component's props are unchanged.
 
 Existing usages, like the New run model picker, keep working without edits.
+
+Only the internal positioning changed, from absolute-in-container to fixed-in-body.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -213,3 +213,5 @@ The popover uses a high z-index so it sits above cards and even above a modal di
 This is why the same combobox works both on the Settings page and inside the New run dialog.
 
 ### How it works
+
+On open, the trigger's rect is measured and the popover's fixed coordinates are set from it.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -235,3 +235,5 @@ If you build another floating control, follow the same pattern: portal to the bo
 Keep the popover's z-index above dialogs so it is usable from within a modal.
 
 Measure the trigger rect on open and on every reposition, not once, so the popover tracks layout changes.
+
+Include the popover in the outside-click check, or clicking an option will close the popover before the click registers.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -233,3 +233,5 @@ Prefer block inside form fields so the popover matches the field width.
 If you build another floating control, follow the same pattern: portal to the body, position from the trigger, and reposition on scroll and resize.
 
 Keep the popover's z-index above dialogs so it is usable from within a modal.
+
+Measure the trigger rect on open and on every reposition, not once, so the popover tracks layout changes.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -303,3 +303,5 @@ Pagination keeps each page short even when the list is long.
 The search field is focused on open, so you can type immediately.
 
 Filtering resets to the first page so the top results are visible.
+
+The current selection is highlighted wherever it lands in the list.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -225,3 +225,5 @@ Two refs, one on the trigger wrapper and one on the popover, let the outside-cli
 The width follows the trigger in block mode, so the popover lines up with the field.
 
 ### For contributors
+
+You do not need to do anything special to use it in a clipped container; the portal handles that.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -209,3 +209,5 @@ It repositions on scroll and resize while open, so it stays anchored to the trig
 Because the popover is outside the trigger's DOM subtree, the outside-click handler ignores clicks inside the popover as well, so selecting an option does not close it prematurely.
 
 The popover uses a high z-index so it sits above cards and even above a modal dialog it may be opened from.
+
+This is why the same combobox works both on the Settings page and inside the New run dialog.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -251,3 +251,5 @@ Include the popover in the outside-click check, or clicking an option will close
 **Dropdown appears behind a dialog.** Raise its z-index above the dialog's overlay.
 
 ### Verifying
+
+Open the control inside a card and confirm the list shows fully, past the card's edge, on top of other content.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -361,3 +361,5 @@ The reposition on scroll keeps the popover glued to the field during a scroll.
 The flip keeps the list on screen near the bottom of a page.
 
 Outside-click covers both the trigger and the portaled popover.
+
+Escape remains a quick way to dismiss it.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -281,3 +281,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 - `apps/web/src/components/ui/Combobox.tsx` - the portaled popover.
 
 - `.card` in `design.css` uses `overflow: hidden`, which is why the portal is needed.
+
+- Issue #86 - the clipping fix.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -271,3 +271,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 **Why fixed positioning?** Fixed coordinates are relative to the viewport, which matches a body-level portal and is simple to compute from the trigger rect.
 
 **What about scrolling?** The popover repositions on scroll so it tracks the trigger; closing on scroll would also be reasonable, but tracking feels smoother here.
+
+**Does it work in a dialog?** Yes; the portal sits above the dialog overlay via its z-index.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -335,3 +335,5 @@ That single change removes a whole class of clipping bugs for every combobox.
 The Settings Default model card clips its contents, which is what exposed the bug.
 
 Cards clip for tidy rounded corners, so removing their overflow was not the right fix.
+
+Portaling the popover keeps the cards tidy and the dropdown visible.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -353,3 +353,5 @@ The trigger still reads as a select thanks to the shared SelectTrigger.
 The result is a searchable dropdown that never hides behind a card wall.
 
 This pattern should be the template for any future dropdown in the console.
+
+Keeping one combobox means one place to fix and improve positioning.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -299,3 +299,5 @@ In flip mode it anchors its bottom just above the trigger, so it grows upward fr
 The list has a bounded max height, so a huge catalog scrolls inside the popover instead of covering the page.
 
 Pagination keeps each page short even when the list is long.
+
+The search field is focused on open, so you can type immediately.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -345,3 +345,5 @@ It was also confirmed to render as a child of the body with fixed positioning.
 The provider list shows all providers with search and paging, over the content below.
 
 The model list behaves the same for the selected provider.
+
+No new styles were needed; the popover reuses the existing menu look.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -321,3 +321,5 @@ Because it is fixed, it is unaffected by the card's own scroll position.
 The reposition listener uses capture so it catches scrolling in any ancestor, not just the window.
 
 The width is read from the trigger in block mode, so the popover never looks narrower than the field.
+
+For non-block usage a fixed width is used, which suits a compact trigger like a header button.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -219,3 +219,5 @@ On open, the trigger's rect is measured and the popover's fixed coordinates are 
 The popover is rendered through a portal, so it lives at the end of the body rather than inside the clipped card.
 
 A capture-phase scroll listener and a resize listener re-measure and reposition while the popover is open.
+
+Two refs, one on the trigger wrapper and one on the popover, let the outside-click handler treat both as inside.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -277,3 +277,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 **Is repositioning expensive?** It is a cheap rect read and style update, only while the popover is open.
 
 ### References
+
+- `apps/web/src/components/ui/Combobox.tsx` - the portaled popover.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -241,3 +241,5 @@ Include the popover in the outside-click check, or clicking an option will close
 ### Troubleshooting
 
 **Dropdown is cut off.** It is being clipped by an overflow-hidden ancestor; it should be portaled to the body, not positioned inside the container.
+
+**Dropdown is in the wrong place.** The trigger rect was not re-measured; reposition on open and on scroll/resize.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -231,3 +231,5 @@ You do not need to do anything special to use it in a clipped container; the por
 Prefer block inside form fields so the popover matches the field width.
 
 If you build another floating control, follow the same pattern: portal to the body, position from the trigger, and reposition on scroll and resize.
+
+Keep the popover's z-index above dialogs so it is usable from within a modal.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -317,3 +317,5 @@ The trigger keeps its own styling; only the popover is portaled.
 The popover inherits theme tokens, so it matches light and dark.
 
 Because it is fixed, it is unaffected by the card's own scroll position.
+
+The reposition listener uses capture so it catches scrolling in any ancestor, not just the window.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -263,3 +263,5 @@ Selecting an option should update the field and close the popover.
 ### This fix
 
 Issue #86: the Settings comboboxes were clipped by the card. Portaling the popover fixed it, and every combobox benefits since it is shared.
+
+### Popover FAQ

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -331,3 +331,5 @@ Existing usages, like the New run model picker, keep working without edits.
 Only the internal positioning changed, from absolute-in-container to fixed-in-body.
 
 That single change removes a whole class of clipping bugs for every combobox.
+
+The Settings Default model card clips its contents, which is what exposed the bug.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -289,3 +289,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 Any floating UI that can appear inside a scrolling or clipped container should portal out and position from its anchor.
 
 Menus that live in a known, unclipped place (like the sidebar footer) can stay in place, but a control reused across the app should not assume its container.
+
+When in doubt, portal; it is the safer default for dropdowns.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -243,3 +243,5 @@ Include the popover in the outside-click check, or clicking an option will close
 **Dropdown is cut off.** It is being clipped by an overflow-hidden ancestor; it should be portaled to the body, not positioned inside the container.
 
 **Dropdown is in the wrong place.** The trigger rect was not re-measured; reposition on open and on scroll/resize.
+
+**Dropdown closes when clicking an option.** The outside-click check does not include the portaled popover; add its ref to the check.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -229,3 +229,5 @@ The width follows the trigger in block mode, so the popover lines up with the fi
 You do not need to do anything special to use it in a clipped container; the portal handles that.
 
 Prefer block inside form fields so the popover matches the field width.
+
+If you build another floating control, follow the same pattern: portal to the body, position from the trigger, and reposition on scroll and resize.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -343,3 +343,5 @@ The fix was verified by measuring the popover against the card: it now extends p
 It was also confirmed to render as a child of the body with fixed positioning.
 
 The provider list shows all providers with search and paging, over the content below.
+
+The model list behaves the same for the selected provider.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -379,3 +379,5 @@ Any new selector can adopt the combobox and inherit correct positioning for free
 This closes the clipping issue for the current selectors.
 
 And it sets a clear pattern for the next one.
+
+### Summary: portal your dropdowns out of clipped containers, position from the trigger, and reposition while open.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -215,3 +215,5 @@ This is why the same combobox works both on the Settings page and inside the New
 ### How it works
 
 On open, the trigger's rect is measured and the popover's fixed coordinates are set from it.
+
+The popover is rendered through a portal, so it lives at the end of the body rather than inside the clipped card.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -293,3 +293,5 @@ Menus that live in a known, unclipped place (like the sidebar footer) can stay i
 When in doubt, portal; it is the safer default for dropdowns.
 
 The popover opens 4px below the trigger for a small, consistent gap.
+
+In flip mode it anchors its bottom just above the trigger, so it grows upward from there.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -333,3 +333,5 @@ Only the internal positioning changed, from absolute-in-container to fixed-in-bo
 That single change removes a whole class of clipping bugs for every combobox.
 
 The Settings Default model card clips its contents, which is what exposed the bug.
+
+Cards clip for tidy rounded corners, so removing their overflow was not the right fix.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -279,3 +279,5 @@ Issue #86: the Settings comboboxes were clipped by the card. Portaling the popov
 ### References
 
 - `apps/web/src/components/ui/Combobox.tsx` - the portaled popover.
+
+- `.card` in `design.css` uses `overflow: hidden`, which is why the portal is needed.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -207,3 +207,5 @@ When there is not enough room below, it flips to open above the trigger instead 
 It repositions on scroll and resize while open, so it stays anchored to the trigger as the page moves.
 
 Because the popover is outside the trigger's DOM subtree, the outside-click handler ignores clicks inside the popover as well, so selecting an option does not close it prematurely.
+
+The popover uses a high z-index so it sits above cards and even above a modal dialog it may be opened from.

--- a/docs/FORMS.md
+++ b/docs/FORMS.md
@@ -323,3 +323,5 @@ The reposition listener uses capture so it catches scrolling in any ancestor, no
 The width is read from the trigger in block mode, so the popover never looks narrower than the field.
 
 For non-block usage a fixed width is used, which suits a compact trigger like a header button.
+
+The change is backward compatible: the component's props are unchanged.


### PR DESCRIPTION
Closes #86.

The Provider/Model comboboxes in Settings had their dropdown clipped at the bottom of the "Default model" card.

## Cause
`.card` uses `overflow: hidden`, and the popover was absolutely positioned inside it, so a list taller than the remaining card height was cut off at the card wall. Scrolling ancestors would clip it too.

## Fix
The shared `Combobox` now renders its popover in a portal on `document.body` with fixed positioning computed from the trigger:
- Escapes any overflow-hidden or scrolling ancestor.
- Outside-click ignores clicks inside the portaled popover (so selecting an option doesn't close it early), via a second ref on the popover.
- Repositions on scroll (capture) and resize while open.
- Flips above the trigger when there isn't room below.
- z-index above cards and dialogs (works from inside the New run modal too).

Props are unchanged, so existing usages (New run model picker) keep working.

## Verified in the browser (Playwright, mock mode)
The Provider dropdown now renders as a child of `body` (position fixed, z 100), extends ~125px past the card's bottom, shows the full list with search + pagination, and is not clipped (screenshot captured).