### PR TITLE
chore(release): v0.3.8

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.3.7"
+version = "0.3.8"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.3.7",
+  "version": "0.3.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.3.7"
+version = "0.3.8"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/web": {
       "name": "@redcell/web",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@novnc/novnc": "1.7.0",
         "@redcell/api-client": "workspace:*",

--- a/uv.lock
+++ b/uv.lock
@@ -2117,7 +2117,7 @@ wheels = [
 
 [[package]]
 name = "redcell-api"
-version = "0.3.7"
+version = "0.3.8"
 source = { virtual = "apps/api" }
 dependencies = [
     { name = "fastapi" },
@@ -2197,7 +2197,7 @@ live = [
 
 [[package]]
 name = "redcell-worker"
-version = "0.3.7"
+version = "0.3.8"
 source = { virtual = "apps/worker" }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Bumps api, worker, and web to `0.3.8` and syncs lockfiles.

## Since v0.3.7
- Combobox popover is portaled so it is not clipped by cards (#86)