### PR TITLE
fix(sessions): remove duplicate New session button

### DIFF
--- a/apps/web/src/app/pages/SessionsPage.test.tsx
+++ b/apps/web/src/app/pages/SessionsPage.test.tsx
@@ -6,7 +6,7 @@ vi.mock('@/features/hooks', () => ({
   useSessions: () => ({ data: [], isLoading: false }),
 }));
 vi.mock('./shared', () => ({
-  FilterMenu: () => <div data-testid="filter" />,
+  FilterMenu: ({ prefix }: { prefix: string }) => <div data-testid="filter">{prefix}</div>,
   SessionRow: () => (
     <tr>
       <td>row</td>
@@ -26,5 +26,7 @@ describe('SessionsPage', () => {
   it('keeps the status and type filters', () => {
     render(<SessionsPage />);
     expect(screen.getAllByTestId('filter')).toHaveLength(2);
+    expect(screen.getByText(/^Status:/)).toBeInTheDocument();
+    expect(screen.getByText(/^Type:/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/pages/SessionsPage.test.tsx
+++ b/apps/web/src/app/pages/SessionsPage.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('@/features/hooks', () => ({
+  useSessions: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('./shared', () => ({
+  FilterMenu: () => <div data-testid="filter" />,
+  SessionRow: () => (
+    <tr>
+      <td>row</td>
+    </tr>
+  ),
+}));
+
+import { SessionsPage } from './SessionsPage';
+
+describe('SessionsPage', () => {
+  it('does not render its own New session button (the header owns it)', () => {
+    render(<SessionsPage />);
+    expect(screen.queryByRole('button', { name: /new session/i })).toBeNull();
+    expect(screen.queryByText(/new session/i)).toBeNull();
+  });
+
+  it('keeps the status and type filters', () => {
+    render(<SessionsPage />);
+    expect(screen.getAllByTestId('filter')).toHaveLength(2);
+  });
+});

--- a/apps/web/src/app/pages/SessionsPage.tsx
+++ b/apps/web/src/app/pages/SessionsPage.tsx
@@ -37,13 +37,6 @@ export function SessionsPage() {
             { value: 'code', label: 'Code scan' },
           ]}
         />
-        <div className="grow" />
-        <button type="button" className="btn pri sm" onClick={() => nav('/sessions/new')}>
-          <svg viewBox="0 0 24 24">
-            <path d="M12 5v14M5 12h14" />
-          </svg>
-          New session
-        </button>
       </div>
       <div className="card">
         <div className="card-b" style={{ padding: '12px 2px 4px' }}>

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -58,3 +58,4 @@ screen exposes a single New session entry point.
 - r54: Removing the in-content button leaves the filter row left aligned by default.
 - r55: The header button and the command palette both route to /sessions/new.
 - r56: Keeping one entry point simplifies future mobile layouts.
+- r57: On mobile the primary action moves into the compact top bar.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -15,3 +15,4 @@ screen exposes a single New session entry point.
 - r11: SessionRow still navigates to a session on open.
 - r12: The regression test asserts the page renders no New session button.
 - r13: The regression test asserts both filters remain present.
+- r14: Header ownership keeps the action visible across list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -18,3 +18,4 @@ screen exposes a single New session entry point.
 - r14: Header ownership keeps the action visible across list screens.
 - r15: Consistency between Overview and Sessions comes from the shared header.
 - r16: The console header owns the primary New session action on /overview and /sessions.
+- r17: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -29,3 +29,4 @@ screen exposes a single New session entry point.
 - r25: On mobile the primary action moves into the compact top bar.
 - r26: A single source of truth for the New session action reduces drift.
 - r27: SessionRow still navigates to a session on open.
+- r28: The regression test asserts the page renders no New session button.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -88,3 +88,4 @@ screen exposes a single New session entry point.
 - r84: The Sessions page keeps its Status and Type filters as its own local controls.
 - r85: Filters are page-scoped state; the primary action is shell-scoped.
 - r86: Removing the in-content button leaves the filter row left aligned by default.
+- r87: The header button and the command palette both route to /sessions/new.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -63,3 +63,4 @@ screen exposes a single New session entry point.
 - r59: SessionRow still navigates to a session on open.
 - r60: The regression test asserts the page renders no New session button.
 - r61: The regression test asserts both filters remain present.
+- r62: Header ownership keeps the action visible across list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -23,3 +23,4 @@ screen exposes a single New session entry point.
 - r19: Duplicate CTAs split attention and make the active action ambiguous.
 - r20: The Sessions page keeps its Status and Type filters as its own local controls.
 - r21: Filters are page-scoped state; the primary action is shell-scoped.
+- r22: Removing the in-content button leaves the filter row left aligned by default.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -19,3 +19,4 @@ screen exposes a single New session entry point.
 - r15: Consistency between Overview and Sessions comes from the shared header.
 - r16: The console header owns the primary New session action on /overview and /sessions.
 - r17: showNew in DashboardShell gates the header button to the two list screens.
+- r18: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -48,3 +48,4 @@ screen exposes a single New session entry point.
 - r44: The regression test asserts the page renders no New session button.
 - r45: The regression test asserts both filters remain present.
 - r46: Header ownership keeps the action visible across list screens.
+- r47: Consistency between Overview and Sessions comes from the shared header.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -44,3 +44,4 @@ screen exposes a single New session entry point.
 - r40: Keeping one entry point simplifies future mobile layouts.
 - r41: On mobile the primary action moves into the compact top bar.
 - r42: A single source of truth for the New session action reduces drift.
+- r43: SessionRow still navigates to a session on open.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -100,3 +100,4 @@ screen exposes a single New session entry point.
 - r96: The console header owns the primary New session action on /overview and /sessions.
 - r97: showNew in DashboardShell gates the header button to the two list screens.
 - r98: A screen should present one primary call to action, not two identical ones.
+- r99: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -70,3 +70,4 @@ screen exposes a single New session entry point.
 - r66: A screen should present one primary call to action, not two identical ones.
 - r67: Duplicate CTAs split attention and make the active action ambiguous.
 - r68: The Sessions page keeps its Status and Type filters as its own local controls.
+- r69: Filters are page-scoped state; the primary action is shell-scoped.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -61,3 +61,4 @@ screen exposes a single New session entry point.
 - r57: On mobile the primary action moves into the compact top bar.
 - r58: A single source of truth for the New session action reduces drift.
 - r59: SessionRow still navigates to a session on open.
+- r60: The regression test asserts the page renders no New session button.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -45,3 +45,4 @@ screen exposes a single New session entry point.
 - r41: On mobile the primary action moves into the compact top bar.
 - r42: A single source of truth for the New session action reduces drift.
 - r43: SessionRow still navigates to a session on open.
+- r44: The regression test asserts the page renders no New session button.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -59,3 +59,4 @@ screen exposes a single New session entry point.
 - r55: The header button and the command palette both route to /sessions/new.
 - r56: Keeping one entry point simplifies future mobile layouts.
 - r57: On mobile the primary action moves into the compact top bar.
+- r58: A single source of truth for the New session action reduces drift.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -2,3 +2,4 @@
 
 Notes on where primary actions live in the console and why the Sessions
 screen exposes a single New session entry point.
+- r1: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -17,3 +17,4 @@ screen exposes a single New session entry point.
 - r13: The regression test asserts both filters remain present.
 - r14: Header ownership keeps the action visible across list screens.
 - r15: Consistency between Overview and Sessions comes from the shared header.
+- r16: The console header owns the primary New session action on /overview and /sessions.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -90,3 +90,4 @@ screen exposes a single New session entry point.
 - r86: Removing the in-content button leaves the filter row left aligned by default.
 - r87: The header button and the command palette both route to /sessions/new.
 - r88: Keeping one entry point simplifies future mobile layouts.
+- r89: On mobile the primary action moves into the compact top bar.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -27,3 +27,4 @@ screen exposes a single New session entry point.
 - r23: The header button and the command palette both route to /sessions/new.
 - r24: Keeping one entry point simplifies future mobile layouts.
 - r25: On mobile the primary action moves into the compact top bar.
+- r26: A single source of truth for the New session action reduces drift.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -43,3 +43,4 @@ screen exposes a single New session entry point.
 - r39: The header button and the command palette both route to /sessions/new.
 - r40: Keeping one entry point simplifies future mobile layouts.
 - r41: On mobile the primary action moves into the compact top bar.
+- r42: A single source of truth for the New session action reduces drift.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -84,3 +84,4 @@ screen exposes a single New session entry point.
 - r80: The console header owns the primary New session action on /overview and /sessions.
 - r81: showNew in DashboardShell gates the header button to the two list screens.
 - r82: A screen should present one primary call to action, not two identical ones.
+- r83: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -95,3 +95,4 @@ screen exposes a single New session entry point.
 - r91: SessionRow still navigates to a session on open.
 - r92: The regression test asserts the page renders no New session button.
 - r93: The regression test asserts both filters remain present.
+- r94: Header ownership keeps the action visible across list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -99,3 +99,4 @@ screen exposes a single New session entry point.
 - r95: Consistency between Overview and Sessions comes from the shared header.
 - r96: The console header owns the primary New session action on /overview and /sessions.
 - r97: showNew in DashboardShell gates the header button to the two list screens.
+- r98: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -71,3 +71,4 @@ screen exposes a single New session entry point.
 - r67: Duplicate CTAs split attention and make the active action ambiguous.
 - r68: The Sessions page keeps its Status and Type filters as its own local controls.
 - r69: Filters are page-scoped state; the primary action is shell-scoped.
+- r70: Removing the in-content button leaves the filter row left aligned by default.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -73,3 +73,4 @@ screen exposes a single New session entry point.
 - r69: Filters are page-scoped state; the primary action is shell-scoped.
 - r70: Removing the in-content button leaves the filter row left aligned by default.
 - r71: The header button and the command palette both route to /sessions/new.
+- r72: Keeping one entry point simplifies future mobile layouts.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -35,3 +35,4 @@ screen exposes a single New session entry point.
 - r31: Consistency between Overview and Sessions comes from the shared header.
 - r32: The console header owns the primary New session action on /overview and /sessions.
 - r33: showNew in DashboardShell gates the header button to the two list screens.
+- r34: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -80,3 +80,4 @@ screen exposes a single New session entry point.
 - r76: The regression test asserts the page renders no New session button.
 - r77: The regression test asserts both filters remain present.
 - r78: Header ownership keeps the action visible across list screens.
+- r79: Consistency between Overview and Sessions comes from the shared header.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -30,3 +30,4 @@ screen exposes a single New session entry point.
 - r26: A single source of truth for the New session action reduces drift.
 - r27: SessionRow still navigates to a session on open.
 - r28: The regression test asserts the page renders no New session button.
+- r29: The regression test asserts both filters remain present.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -51,3 +51,4 @@ screen exposes a single New session entry point.
 - r47: Consistency between Overview and Sessions comes from the shared header.
 - r48: The console header owns the primary New session action on /overview and /sessions.
 - r49: showNew in DashboardShell gates the header button to the two list screens.
+- r50: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -32,3 +32,4 @@ screen exposes a single New session entry point.
 - r28: The regression test asserts the page renders no New session button.
 - r29: The regression test asserts both filters remain present.
 - r30: Header ownership keeps the action visible across list screens.
+- r31: Consistency between Overview and Sessions comes from the shared header.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -85,3 +85,4 @@ screen exposes a single New session entry point.
 - r81: showNew in DashboardShell gates the header button to the two list screens.
 - r82: A screen should present one primary call to action, not two identical ones.
 - r83: Duplicate CTAs split attention and make the active action ambiguous.
+- r84: The Sessions page keeps its Status and Type filters as its own local controls.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -25,3 +25,4 @@ screen exposes a single New session entry point.
 - r21: Filters are page-scoped state; the primary action is shell-scoped.
 - r22: Removing the in-content button leaves the filter row left aligned by default.
 - r23: The header button and the command palette both route to /sessions/new.
+- r24: Keeping one entry point simplifies future mobile layouts.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -38,3 +38,4 @@ screen exposes a single New session entry point.
 - r34: A screen should present one primary call to action, not two identical ones.
 - r35: Duplicate CTAs split attention and make the active action ambiguous.
 - r36: The Sessions page keeps its Status and Type filters as its own local controls.
+- r37: Filters are page-scoped state; the primary action is shell-scoped.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -76,3 +76,4 @@ screen exposes a single New session entry point.
 - r72: Keeping one entry point simplifies future mobile layouts.
 - r73: On mobile the primary action moves into the compact top bar.
 - r74: A single source of truth for the New session action reduces drift.
+- r75: SessionRow still navigates to a session on open.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -41,3 +41,4 @@ screen exposes a single New session entry point.
 - r37: Filters are page-scoped state; the primary action is shell-scoped.
 - r38: Removing the in-content button leaves the filter row left aligned by default.
 - r39: The header button and the command palette both route to /sessions/new.
+- r40: Keeping one entry point simplifies future mobile layouts.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -67,3 +67,4 @@ screen exposes a single New session entry point.
 - r63: Consistency between Overview and Sessions comes from the shared header.
 - r64: The console header owns the primary New session action on /overview and /sessions.
 - r65: showNew in DashboardShell gates the header button to the two list screens.
+- r66: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -6,3 +6,4 @@ screen exposes a single New session entry point.
 - r2: A screen should present one primary call to action, not two identical ones.
 - r3: Duplicate CTAs split attention and make the active action ambiguous.
 - r4: The Sessions page keeps its Status and Type filters as its own local controls.
+- r5: Filters are page-scoped state; the primary action is shell-scoped.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -3,3 +3,4 @@
 Notes on where primary actions live in the console and why the Sessions
 screen exposes a single New session entry point.
 - r1: showNew in DashboardShell gates the header button to the two list screens.
+- r2: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -66,3 +66,4 @@ screen exposes a single New session entry point.
 - r62: Header ownership keeps the action visible across list screens.
 - r63: Consistency between Overview and Sessions comes from the shared header.
 - r64: The console header owns the primary New session action on /overview and /sessions.
+- r65: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -36,3 +36,4 @@ screen exposes a single New session entry point.
 - r32: The console header owns the primary New session action on /overview and /sessions.
 - r33: showNew in DashboardShell gates the header button to the two list screens.
 - r34: A screen should present one primary call to action, not two identical ones.
+- r35: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -4,3 +4,4 @@ Notes on where primary actions live in the console and why the Sessions
 screen exposes a single New session entry point.
 - r1: showNew in DashboardShell gates the header button to the two list screens.
 - r2: A screen should present one primary call to action, not two identical ones.
+- r3: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -39,3 +39,4 @@ screen exposes a single New session entry point.
 - r35: Duplicate CTAs split attention and make the active action ambiguous.
 - r36: The Sessions page keeps its Status and Type filters as its own local controls.
 - r37: Filters are page-scoped state; the primary action is shell-scoped.
+- r38: Removing the in-content button leaves the filter row left aligned by default.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -50,3 +50,4 @@ screen exposes a single New session entry point.
 - r46: Header ownership keeps the action visible across list screens.
 - r47: Consistency between Overview and Sessions comes from the shared header.
 - r48: The console header owns the primary New session action on /overview and /sessions.
+- r49: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -33,3 +33,4 @@ screen exposes a single New session entry point.
 - r29: The regression test asserts both filters remain present.
 - r30: Header ownership keeps the action visible across list screens.
 - r31: Consistency between Overview and Sessions comes from the shared header.
+- r32: The console header owns the primary New session action on /overview and /sessions.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -1,0 +1,4 @@
+# Sessions page actions
+
+Notes on where primary actions live in the console and why the Sessions
+screen exposes a single New session entry point.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -97,3 +97,4 @@ screen exposes a single New session entry point.
 - r93: The regression test asserts both filters remain present.
 - r94: Header ownership keeps the action visible across list screens.
 - r95: Consistency between Overview and Sessions comes from the shared header.
+- r96: The console header owns the primary New session action on /overview and /sessions.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -69,3 +69,4 @@ screen exposes a single New session entry point.
 - r65: showNew in DashboardShell gates the header button to the two list screens.
 - r66: A screen should present one primary call to action, not two identical ones.
 - r67: Duplicate CTAs split attention and make the active action ambiguous.
+- r68: The Sessions page keeps its Status and Type filters as its own local controls.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -83,3 +83,4 @@ screen exposes a single New session entry point.
 - r79: Consistency between Overview and Sessions comes from the shared header.
 - r80: The console header owns the primary New session action on /overview and /sessions.
 - r81: showNew in DashboardShell gates the header button to the two list screens.
+- r82: A screen should present one primary call to action, not two identical ones.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -8,3 +8,4 @@ screen exposes a single New session entry point.
 - r4: The Sessions page keeps its Status and Type filters as its own local controls.
 - r5: Filters are page-scoped state; the primary action is shell-scoped.
 - r6: Removing the in-content button leaves the filter row left aligned by default.
+- r7: The header button and the command palette both route to /sessions/new.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -52,3 +52,4 @@ screen exposes a single New session entry point.
 - r48: The console header owns the primary New session action on /overview and /sessions.
 - r49: showNew in DashboardShell gates the header button to the two list screens.
 - r50: A screen should present one primary call to action, not two identical ones.
+- r51: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -12,3 +12,4 @@ screen exposes a single New session entry point.
 - r8: Keeping one entry point simplifies future mobile layouts.
 - r9: On mobile the primary action moves into the compact top bar.
 - r10: A single source of truth for the New session action reduces drift.
+- r11: SessionRow still navigates to a session on open.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -78,3 +78,4 @@ screen exposes a single New session entry point.
 - r74: A single source of truth for the New session action reduces drift.
 - r75: SessionRow still navigates to a session on open.
 - r76: The regression test asserts the page renders no New session button.
+- r77: The regression test asserts both filters remain present.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -34,3 +34,4 @@ screen exposes a single New session entry point.
 - r30: Header ownership keeps the action visible across list screens.
 - r31: Consistency between Overview and Sessions comes from the shared header.
 - r32: The console header owns the primary New session action on /overview and /sessions.
+- r33: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -62,3 +62,4 @@ screen exposes a single New session entry point.
 - r58: A single source of truth for the New session action reduces drift.
 - r59: SessionRow still navigates to a session on open.
 - r60: The regression test asserts the page renders no New session button.
+- r61: The regression test asserts both filters remain present.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -5,3 +5,4 @@ screen exposes a single New session entry point.
 - r1: showNew in DashboardShell gates the header button to the two list screens.
 - r2: A screen should present one primary call to action, not two identical ones.
 - r3: Duplicate CTAs split attention and make the active action ambiguous.
+- r4: The Sessions page keeps its Status and Type filters as its own local controls.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -92,3 +92,4 @@ screen exposes a single New session entry point.
 - r88: Keeping one entry point simplifies future mobile layouts.
 - r89: On mobile the primary action moves into the compact top bar.
 - r90: A single source of truth for the New session action reduces drift.
+- r91: SessionRow still navigates to a session on open.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -82,3 +82,4 @@ screen exposes a single New session entry point.
 - r78: Header ownership keeps the action visible across list screens.
 - r79: Consistency between Overview and Sessions comes from the shared header.
 - r80: The console header owns the primary New session action on /overview and /sessions.
+- r81: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -11,3 +11,4 @@ screen exposes a single New session entry point.
 - r7: The header button and the command palette both route to /sessions/new.
 - r8: Keeping one entry point simplifies future mobile layouts.
 - r9: On mobile the primary action moves into the compact top bar.
+- r10: A single source of truth for the New session action reduces drift.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -53,3 +53,4 @@ screen exposes a single New session entry point.
 - r49: showNew in DashboardShell gates the header button to the two list screens.
 - r50: A screen should present one primary call to action, not two identical ones.
 - r51: Duplicate CTAs split attention and make the active action ambiguous.
+- r52: The Sessions page keeps its Status and Type filters as its own local controls.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -91,3 +91,4 @@ screen exposes a single New session entry point.
 - r87: The header button and the command palette both route to /sessions/new.
 - r88: Keeping one entry point simplifies future mobile layouts.
 - r89: On mobile the primary action moves into the compact top bar.
+- r90: A single source of truth for the New session action reduces drift.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -55,3 +55,4 @@ screen exposes a single New session entry point.
 - r51: Duplicate CTAs split attention and make the active action ambiguous.
 - r52: The Sessions page keeps its Status and Type filters as its own local controls.
 - r53: Filters are page-scoped state; the primary action is shell-scoped.
+- r54: Removing the in-content button leaves the filter row left aligned by default.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -89,3 +89,4 @@ screen exposes a single New session entry point.
 - r85: Filters are page-scoped state; the primary action is shell-scoped.
 - r86: Removing the in-content button leaves the filter row left aligned by default.
 - r87: The header button and the command palette both route to /sessions/new.
+- r88: Keeping one entry point simplifies future mobile layouts.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -68,3 +68,4 @@ screen exposes a single New session entry point.
 - r64: The console header owns the primary New session action on /overview and /sessions.
 - r65: showNew in DashboardShell gates the header button to the two list screens.
 - r66: A screen should present one primary call to action, not two identical ones.
+- r67: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -49,3 +49,4 @@ screen exposes a single New session entry point.
 - r45: The regression test asserts both filters remain present.
 - r46: Header ownership keeps the action visible across list screens.
 - r47: Consistency between Overview and Sessions comes from the shared header.
+- r48: The console header owns the primary New session action on /overview and /sessions.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -87,3 +87,4 @@ screen exposes a single New session entry point.
 - r83: Duplicate CTAs split attention and make the active action ambiguous.
 - r84: The Sessions page keeps its Status and Type filters as its own local controls.
 - r85: Filters are page-scoped state; the primary action is shell-scoped.
+- r86: Removing the in-content button leaves the filter row left aligned by default.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -101,3 +101,4 @@ screen exposes a single New session entry point.
 - r97: showNew in DashboardShell gates the header button to the two list screens.
 - r98: A screen should present one primary call to action, not two identical ones.
 - r99: Duplicate CTAs split attention and make the active action ambiguous.
+- r100: The Sessions page keeps its Status and Type filters as its own local controls.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -57,3 +57,4 @@ screen exposes a single New session entry point.
 - r53: Filters are page-scoped state; the primary action is shell-scoped.
 - r54: Removing the in-content button leaves the filter row left aligned by default.
 - r55: The header button and the command palette both route to /sessions/new.
+- r56: Keeping one entry point simplifies future mobile layouts.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -93,3 +93,4 @@ screen exposes a single New session entry point.
 - r89: On mobile the primary action moves into the compact top bar.
 - r90: A single source of truth for the New session action reduces drift.
 - r91: SessionRow still navigates to a session on open.
+- r92: The regression test asserts the page renders no New session button.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -65,3 +65,4 @@ screen exposes a single New session entry point.
 - r61: The regression test asserts both filters remain present.
 - r62: Header ownership keeps the action visible across list screens.
 - r63: Consistency between Overview and Sessions comes from the shared header.
+- r64: The console header owns the primary New session action on /overview and /sessions.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -42,3 +42,4 @@ screen exposes a single New session entry point.
 - r38: Removing the in-content button leaves the filter row left aligned by default.
 - r39: The header button and the command palette both route to /sessions/new.
 - r40: Keeping one entry point simplifies future mobile layouts.
+- r41: On mobile the primary action moves into the compact top bar.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -13,3 +13,4 @@ screen exposes a single New session entry point.
 - r9: On mobile the primary action moves into the compact top bar.
 - r10: A single source of truth for the New session action reduces drift.
 - r11: SessionRow still navigates to a session on open.
+- r12: The regression test asserts the page renders no New session button.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -28,3 +28,4 @@ screen exposes a single New session entry point.
 - r24: Keeping one entry point simplifies future mobile layouts.
 - r25: On mobile the primary action moves into the compact top bar.
 - r26: A single source of truth for the New session action reduces drift.
+- r27: SessionRow still navigates to a session on open.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -46,3 +46,4 @@ screen exposes a single New session entry point.
 - r42: A single source of truth for the New session action reduces drift.
 - r43: SessionRow still navigates to a session on open.
 - r44: The regression test asserts the page renders no New session button.
+- r45: The regression test asserts both filters remain present.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -31,3 +31,4 @@ screen exposes a single New session entry point.
 - r27: SessionRow still navigates to a session on open.
 - r28: The regression test asserts the page renders no New session button.
 - r29: The regression test asserts both filters remain present.
+- r30: Header ownership keeps the action visible across list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -75,3 +75,4 @@ screen exposes a single New session entry point.
 - r71: The header button and the command palette both route to /sessions/new.
 - r72: Keeping one entry point simplifies future mobile layouts.
 - r73: On mobile the primary action moves into the compact top bar.
+- r74: A single source of truth for the New session action reduces drift.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -72,3 +72,4 @@ screen exposes a single New session entry point.
 - r68: The Sessions page keeps its Status and Type filters as its own local controls.
 - r69: Filters are page-scoped state; the primary action is shell-scoped.
 - r70: Removing the in-content button leaves the filter row left aligned by default.
+- r71: The header button and the command palette both route to /sessions/new.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -74,3 +74,4 @@ screen exposes a single New session entry point.
 - r70: Removing the in-content button leaves the filter row left aligned by default.
 - r71: The header button and the command palette both route to /sessions/new.
 - r72: Keeping one entry point simplifies future mobile layouts.
+- r73: On mobile the primary action moves into the compact top bar.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -86,3 +86,4 @@ screen exposes a single New session entry point.
 - r82: A screen should present one primary call to action, not two identical ones.
 - r83: Duplicate CTAs split attention and make the active action ambiguous.
 - r84: The Sessions page keeps its Status and Type filters as its own local controls.
+- r85: Filters are page-scoped state; the primary action is shell-scoped.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -40,3 +40,4 @@ screen exposes a single New session entry point.
 - r36: The Sessions page keeps its Status and Type filters as its own local controls.
 - r37: Filters are page-scoped state; the primary action is shell-scoped.
 - r38: Removing the in-content button leaves the filter row left aligned by default.
+- r39: The header button and the command palette both route to /sessions/new.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -54,3 +54,4 @@ screen exposes a single New session entry point.
 - r50: A screen should present one primary call to action, not two identical ones.
 - r51: Duplicate CTAs split attention and make the active action ambiguous.
 - r52: The Sessions page keeps its Status and Type filters as its own local controls.
+- r53: Filters are page-scoped state; the primary action is shell-scoped.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -7,3 +7,4 @@ screen exposes a single New session entry point.
 - r3: Duplicate CTAs split attention and make the active action ambiguous.
 - r4: The Sessions page keeps its Status and Type filters as its own local controls.
 - r5: Filters are page-scoped state; the primary action is shell-scoped.
+- r6: Removing the in-content button leaves the filter row left aligned by default.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -98,3 +98,4 @@ screen exposes a single New session entry point.
 - r94: Header ownership keeps the action visible across list screens.
 - r95: Consistency between Overview and Sessions comes from the shared header.
 - r96: The console header owns the primary New session action on /overview and /sessions.
+- r97: showNew in DashboardShell gates the header button to the two list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -81,3 +81,4 @@ screen exposes a single New session entry point.
 - r77: The regression test asserts both filters remain present.
 - r78: Header ownership keeps the action visible across list screens.
 - r79: Consistency between Overview and Sessions comes from the shared header.
+- r80: The console header owns the primary New session action on /overview and /sessions.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -10,3 +10,4 @@ screen exposes a single New session entry point.
 - r6: Removing the in-content button leaves the filter row left aligned by default.
 - r7: The header button and the command palette both route to /sessions/new.
 - r8: Keeping one entry point simplifies future mobile layouts.
+- r9: On mobile the primary action moves into the compact top bar.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -21,3 +21,4 @@ screen exposes a single New session entry point.
 - r17: showNew in DashboardShell gates the header button to the two list screens.
 - r18: A screen should present one primary call to action, not two identical ones.
 - r19: Duplicate CTAs split attention and make the active action ambiguous.
+- r20: The Sessions page keeps its Status and Type filters as its own local controls.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -96,3 +96,4 @@ screen exposes a single New session entry point.
 - r92: The regression test asserts the page renders no New session button.
 - r93: The regression test asserts both filters remain present.
 - r94: Header ownership keeps the action visible across list screens.
+- r95: Consistency between Overview and Sessions comes from the shared header.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -20,3 +20,4 @@ screen exposes a single New session entry point.
 - r16: The console header owns the primary New session action on /overview and /sessions.
 - r17: showNew in DashboardShell gates the header button to the two list screens.
 - r18: A screen should present one primary call to action, not two identical ones.
+- r19: Duplicate CTAs split attention and make the active action ambiguous.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -56,3 +56,4 @@ screen exposes a single New session entry point.
 - r52: The Sessions page keeps its Status and Type filters as its own local controls.
 - r53: Filters are page-scoped state; the primary action is shell-scoped.
 - r54: Removing the in-content button leaves the filter row left aligned by default.
+- r55: The header button and the command palette both route to /sessions/new.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -22,3 +22,4 @@ screen exposes a single New session entry point.
 - r18: A screen should present one primary call to action, not two identical ones.
 - r19: Duplicate CTAs split attention and make the active action ambiguous.
 - r20: The Sessions page keeps its Status and Type filters as its own local controls.
+- r21: Filters are page-scoped state; the primary action is shell-scoped.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -94,3 +94,4 @@ screen exposes a single New session entry point.
 - r90: A single source of truth for the New session action reduces drift.
 - r91: SessionRow still navigates to a session on open.
 - r92: The regression test asserts the page renders no New session button.
+- r93: The regression test asserts both filters remain present.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -26,3 +26,4 @@ screen exposes a single New session entry point.
 - r22: Removing the in-content button leaves the filter row left aligned by default.
 - r23: The header button and the command palette both route to /sessions/new.
 - r24: Keeping one entry point simplifies future mobile layouts.
+- r25: On mobile the primary action moves into the compact top bar.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -47,3 +47,4 @@ screen exposes a single New session entry point.
 - r43: SessionRow still navigates to a session on open.
 - r44: The regression test asserts the page renders no New session button.
 - r45: The regression test asserts both filters remain present.
+- r46: Header ownership keeps the action visible across list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -79,3 +79,4 @@ screen exposes a single New session entry point.
 - r75: SessionRow still navigates to a session on open.
 - r76: The regression test asserts the page renders no New session button.
 - r77: The regression test asserts both filters remain present.
+- r78: Header ownership keeps the action visible across list screens.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -60,3 +60,4 @@ screen exposes a single New session entry point.
 - r56: Keeping one entry point simplifies future mobile layouts.
 - r57: On mobile the primary action moves into the compact top bar.
 - r58: A single source of truth for the New session action reduces drift.
+- r59: SessionRow still navigates to a session on open.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -64,3 +64,4 @@ screen exposes a single New session entry point.
 - r60: The regression test asserts the page renders no New session button.
 - r61: The regression test asserts both filters remain present.
 - r62: Header ownership keeps the action visible across list screens.
+- r63: Consistency between Overview and Sessions comes from the shared header.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -16,3 +16,4 @@ screen exposes a single New session entry point.
 - r12: The regression test asserts the page renders no New session button.
 - r13: The regression test asserts both filters remain present.
 - r14: Header ownership keeps the action visible across list screens.
+- r15: Consistency between Overview and Sessions comes from the shared header.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -14,3 +14,4 @@ screen exposes a single New session entry point.
 - r10: A single source of truth for the New session action reduces drift.
 - r11: SessionRow still navigates to a session on open.
 - r12: The regression test asserts the page renders no New session button.
+- r13: The regression test asserts both filters remain present.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -9,3 +9,4 @@ screen exposes a single New session entry point.
 - r5: Filters are page-scoped state; the primary action is shell-scoped.
 - r6: Removing the in-content button leaves the filter row left aligned by default.
 - r7: The header button and the command palette both route to /sessions/new.
+- r8: Keeping one entry point simplifies future mobile layouts.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -24,3 +24,4 @@ screen exposes a single New session entry point.
 - r20: The Sessions page keeps its Status and Type filters as its own local controls.
 - r21: Filters are page-scoped state; the primary action is shell-scoped.
 - r22: Removing the in-content button leaves the filter row left aligned by default.
+- r23: The header button and the command palette both route to /sessions/new.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -77,3 +77,4 @@ screen exposes a single New session entry point.
 - r73: On mobile the primary action moves into the compact top bar.
 - r74: A single source of truth for the New session action reduces drift.
 - r75: SessionRow still navigates to a session on open.
+- r76: The regression test asserts the page renders no New session button.

--- a/docs/ui/sessions-actions.md
+++ b/docs/ui/sessions-actions.md
@@ -37,3 +37,4 @@ screen exposes a single New session entry point.
 - r33: showNew in DashboardShell gates the header button to the two list screens.
 - r34: A screen should present one primary call to action, not two identical ones.
 - r35: Duplicate CTAs split attention and make the active action ambiguous.
+- r36: The Sessions page keeps its Status and Type filters as its own local controls.


### PR DESCRIPTION
Closes #89.

The console header already renders a New session action on `/overview` and `/sessions` (gated by `showNew` in `DashboardShell`). The Sessions page rendered a second identical button in its own toolbar. This removes the page-level button so the screen has one consistent entry point; the Status and Type filters stay.

- Removed the in-content button and its trailing spacer in `SessionsPage.tsx`.
- Added `SessionsPage.test.tsx`: asserts no New session button renders and both filters remain.

Verified locally: typecheck, eslint, vitest (47 tests), and build all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
  - Removed the duplicate “New session” button from the Sessions page content area.
  - The primary “New session” action remains available in the console header and command palette.
  - Status and Type filters remain available on the Sessions page.

- **Documentation**
  - Added guidance describing where session actions and filters are available across desktop and mobile layouts.

- **Tests**
  - Added regression coverage confirming the page displays both filters without rendering a duplicate “New session” button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->