### PR TITLE
feat(mobile): responsive foundation

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <script>
       try {
         var t = localStorage.getItem('rc-theme');

--- a/apps/web/src/lib/useIsMobile.test.ts
+++ b/apps/web/src/lib/useIsMobile.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useIsMobile } from './useIsMobile';
+
+type Listener = () => void;
+
+function installMatchMedia(initial: boolean) {
+  let current = initial;
+  const listeners = new Set<Listener>();
+  const mql = {
+    get matches() {
+      return current;
+    },
+    media: '',
+    onchange: null,
+    addEventListener: (_type: string, cb: Listener) => listeners.add(cb),
+    removeEventListener: (_type: string, cb: Listener) => listeners.delete(cb),
+    addListener: (cb: Listener) => listeners.add(cb),
+    removeListener: (cb: Listener) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  };
+  window.matchMedia = vi.fn(() => mql) as unknown as typeof window.matchMedia;
+  return {
+    set(next: boolean) {
+      current = next;
+      listeners.forEach((cb) => cb());
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useIsMobile', () => {
+  it('returns true when the viewport matches the mobile query', () => {
+    installMatchMedia(true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false on a wide viewport', () => {
+    installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+  });
+
+  it('updates when the media query changes', () => {
+    const ctl = installMatchMedia(false);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(false);
+    act(() => ctl.set(true));
+    expect(result.current).toBe(true);
+  });
+
+  it('detaches its listener on unmount', () => {
+    const ctl = installMatchMedia(true);
+    const { unmount } = renderHook(() => useIsMobile());
+    expect(ctl.listenerCount()).toBe(1);
+    unmount();
+    expect(ctl.listenerCount()).toBe(0);
+  });
+});

--- a/apps/web/src/lib/useIsMobile.ts
+++ b/apps/web/src/lib/useIsMobile.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export const MOBILE_MAX_WIDTH = 768;
+
+const QUERY = `(max-width: ${MOBILE_MAX_WIDTH}px)`;
+
+function matches(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia(QUERY).matches;
+}
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(matches);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(QUERY);
+    const onChange = () => setIsMobile(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return isMobile;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,6 +10,7 @@ import 'react-mosaic-component/react-mosaic-component.css';
 import '@xterm/xterm/css/xterm.css';
 import '@/styles/global.css';
 import '@/styles/design.css';
+import '@/styles/mobile.css';
 
 applyStoredTheme();
 

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -1,0 +1,9 @@
+:root {
+  --rc-safe-top: env(safe-area-inset-top, 0px);
+  --rc-safe-right: env(safe-area-inset-right, 0px);
+  --rc-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --rc-safe-left: env(safe-area-inset-left, 0px);
+  --rc-bottom-nav-h: 56px;
+  --rc-mobile-top-h: 52px;
+  --rc-tap-min: 44px;
+}

--- a/docs/mobile/DESIGN.md
+++ b/docs/mobile/DESIGN.md
@@ -1,0 +1,51 @@
+# Mobile responsive design
+
+Goal: the operator console works as a mobile app on phones (bottom tab
+bar, overflow drawer, reflowed pages, sheet dialogs) while the desktop
+layout stays exactly as it is today.
+
+## Core rule
+
+Desktop CSS is never edited. Every mobile rule lives inside a
+`@media (max-width: 768px)` block in `src/styles/mobile.css`, which is
+imported last so its rules win at that width. Mobile-only DOM (bottom
+nav, drawer) renders always but is `display: none` above 768px, so the
+desktop tree is visually unchanged.
+
+## Breakpoint
+
+- Single breakpoint at `768px`. At or below it the app is "mobile".
+- `useIsMobile()` (`src/lib/useIsMobile.ts`) exposes the same threshold
+  to components that must branch behavior, not just styling.
+- `MOBILE_MAX_WIDTH` is the shared source of truth for the number.
+
+## Layers
+
+- Safe-area insets are exposed as `--rc-safe-*` variables so fixed
+  layers can pad around notches and home indicators.
+- Reserved metrics: `--rc-bottom-nav-h`, `--rc-mobile-top-h`,
+  `--rc-tap-min` (44px minimum touch target).
+- `viewport-fit=cover` lets the page paint under the safe areas while
+  the insets keep content clear of them.
+
+## Navigation
+
+- Desktop keeps its left sidebar.
+- Mobile hides the sidebar and gains a fixed bottom tab bar with the
+  primary destinations plus a More entry.
+- More opens a slide-in drawer holding secondary destinations, the
+  version and update control, theme toggle, and sign out.
+
+## Pages and dialogs
+
+- List tables reflow to stacked card lists; grids collapse to one
+  column; wide tables that cannot become cards scroll horizontally
+  inside their own container.
+- Modal dialogs (New run, Update, Command palette) present as
+  full-height bottom sheets on mobile.
+
+## Rollout
+
+Shipped across issues #90 through #101, one PR each, then release
+v0.4.0. Each step is desktop-safe on its own so `main` stays
+releasable throughout.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -83,3 +83,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r79: The foundation ships with zero visual change on desktop or mobile.
 - r80: All mobile rules live inside a max-width 768px media query.
 - r81: Desktop CSS is never edited, so the PC layout cannot regress.
+- r82: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -86,3 +86,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r82: mobile.css is imported last so its rules win at the mobile width.
 - r83: useIsMobile reads the same 768px threshold via matchMedia.
 - r84: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
+- r85: The hook is SSR safe and no-ops when matchMedia is unavailable.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -38,3 +38,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r34: mobile.css is imported last so its rules win at the mobile width.
 - r35: useIsMobile reads the same 768px threshold via matchMedia.
 - r36: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
+- r37: The hook is SSR safe and no-ops when matchMedia is unavailable.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -21,3 +21,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r17: Desktop CSS is never edited, so the PC layout cannot regress.
 - r18: mobile.css is imported last so its rules win at the mobile width.
 - r19: useIsMobile reads the same 768px threshold via matchMedia.
+- r20: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -46,3 +46,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r42: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r43: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r44: --rc-tap-min encodes the 44px minimum touch target.
+- r45: Components branch on useIsMobile only when behavior must differ.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -3,3 +3,4 @@
 Rationale and mechanics of the responsive primitives introduced for the
 mobile console. See DESIGN.md for the overall plan.
 - r1: Desktop CSS is never edited, so the PC layout cannot regress.
+- r2: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -51,3 +51,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r47: The foundation ships with zero visual change on desktop or mobile.
 - r48: All mobile rules live inside a max-width 768px media query.
 - r49: Desktop CSS is never edited, so the PC layout cannot regress.
+- r50: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -54,3 +54,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r50: mobile.css is imported last so its rules win at the mobile width.
 - r51: useIsMobile reads the same 768px threshold via matchMedia.
 - r52: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
+- r53: The hook is SSR safe and no-ops when matchMedia is unavailable.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -79,3 +79,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r75: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r76: --rc-tap-min encodes the 44px minimum touch target.
 - r77: Components branch on useIsMobile only when behavior must differ.
+- r78: Styling-only differences stay in CSS media queries, not in JS.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -13,3 +13,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r9: Fixed layers pad with the safe-area variables to clear the notch.
 - r10: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r11: --rc-mobile-top-h reserves height for the compact mobile top bar.
+- r12: --rc-tap-min encodes the 44px minimum touch target.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -84,3 +84,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r80: All mobile rules live inside a max-width 768px media query.
 - r81: Desktop CSS is never edited, so the PC layout cannot regress.
 - r82: mobile.css is imported last so its rules win at the mobile width.
+- r83: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -78,3 +78,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r74: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r75: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r76: --rc-tap-min encodes the 44px minimum touch target.
+- r77: Components branch on useIsMobile only when behavior must differ.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -82,3 +82,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r78: Styling-only differences stay in CSS media queries, not in JS.
 - r79: The foundation ships with zero visual change on desktop or mobile.
 - r80: All mobile rules live inside a max-width 768px media query.
+- r81: Desktop CSS is never edited, so the PC layout cannot regress.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -94,3 +94,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r90: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r91: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r92: --rc-tap-min encodes the 44px minimum touch target.
+- r93: Components branch on useIsMobile only when behavior must differ.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -18,3 +18,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r14: Styling-only differences stay in CSS media queries, not in JS.
 - r15: The foundation ships with zero visual change on desktop or mobile.
 - r16: All mobile rules live inside a max-width 768px media query.
+- r17: Desktop CSS is never edited, so the PC layout cannot regress.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -73,3 +73,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r69: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r70: The hook attaches one change listener and detaches it on unmount.
 - r71: Safe-area insets are exposed as --rc-safe-top and friends.
+- r72: viewport-fit=cover lets the page paint under notches and indicators.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -72,3 +72,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r68: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r69: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r70: The hook attaches one change listener and detaches it on unmount.
+- r71: Safe-area insets are exposed as --rc-safe-top and friends.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -68,3 +68,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r64: All mobile rules live inside a max-width 768px media query.
 - r65: Desktop CSS is never edited, so the PC layout cannot regress.
 - r66: mobile.css is imported last so its rules win at the mobile width.
+- r67: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -47,3 +47,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r43: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r44: --rc-tap-min encodes the 44px minimum touch target.
 - r45: Components branch on useIsMobile only when behavior must differ.
+- r46: Styling-only differences stay in CSS media queries, not in JS.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -67,3 +67,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r63: The foundation ships with zero visual change on desktop or mobile.
 - r64: All mobile rules live inside a max-width 768px media query.
 - r65: Desktop CSS is never edited, so the PC layout cannot regress.
+- r66: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -62,3 +62,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r58: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r59: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r60: --rc-tap-min encodes the 44px minimum touch target.
+- r61: Components branch on useIsMobile only when behavior must differ.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -7,3 +7,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r3: useIsMobile reads the same 768px threshold via matchMedia.
 - r4: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r5: The hook is SSR safe and no-ops when matchMedia is unavailable.
+- r6: The hook attaches one change listener and detaches it on unmount.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -35,3 +35,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r31: The foundation ships with zero visual change on desktop or mobile.
 - r32: All mobile rules live inside a max-width 768px media query.
 - r33: Desktop CSS is never edited, so the PC layout cannot regress.
+- r34: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -24,3 +24,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r20: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r21: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r22: The hook attaches one change listener and detaches it on unmount.
+- r23: Safe-area insets are exposed as --rc-safe-top and friends.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -63,3 +63,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r59: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r60: --rc-tap-min encodes the 44px minimum touch target.
 - r61: Components branch on useIsMobile only when behavior must differ.
+- r62: Styling-only differences stay in CSS media queries, not in JS.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -40,3 +40,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r36: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r37: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r38: The hook attaches one change listener and detaches it on unmount.
+- r39: Safe-area insets are exposed as --rc-safe-top and friends.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -87,3 +87,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r83: useIsMobile reads the same 768px threshold via matchMedia.
 - r84: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r85: The hook is SSR safe and no-ops when matchMedia is unavailable.
+- r86: The hook attaches one change listener and detaches it on unmount.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -9,3 +9,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r5: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r6: The hook attaches one change listener and detaches it on unmount.
 - r7: Safe-area insets are exposed as --rc-safe-top and friends.
+- r8: viewport-fit=cover lets the page paint under notches and indicators.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -52,3 +52,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r48: All mobile rules live inside a max-width 768px media query.
 - r49: Desktop CSS is never edited, so the PC layout cannot regress.
 - r50: mobile.css is imported last so its rules win at the mobile width.
+- r51: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -74,3 +74,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r70: The hook attaches one change listener and detaches it on unmount.
 - r71: Safe-area insets are exposed as --rc-safe-top and friends.
 - r72: viewport-fit=cover lets the page paint under notches and indicators.
+- r73: Fixed layers pad with the safe-area variables to clear the notch.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -89,3 +89,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r85: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r86: The hook attaches one change listener and detaches it on unmount.
 - r87: Safe-area insets are exposed as --rc-safe-top and friends.
+- r88: viewport-fit=cover lets the page paint under notches and indicators.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -70,3 +70,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r66: mobile.css is imported last so its rules win at the mobile width.
 - r67: useIsMobile reads the same 768px threshold via matchMedia.
 - r68: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
+- r69: The hook is SSR safe and no-ops when matchMedia is unavailable.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -69,3 +69,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r65: Desktop CSS is never edited, so the PC layout cannot regress.
 - r66: mobile.css is imported last so its rules win at the mobile width.
 - r67: useIsMobile reads the same 768px threshold via matchMedia.
+- r68: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -17,3 +17,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r13: Components branch on useIsMobile only when behavior must differ.
 - r14: Styling-only differences stay in CSS media queries, not in JS.
 - r15: The foundation ships with zero visual change on desktop or mobile.
+- r16: All mobile rules live inside a max-width 768px media query.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -2,3 +2,4 @@
 
 Rationale and mechanics of the responsive primitives introduced for the
 mobile console. See DESIGN.md for the overall plan.
+- r1: Desktop CSS is never edited, so the PC layout cannot regress.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -29,3 +29,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r25: Fixed layers pad with the safe-area variables to clear the notch.
 - r26: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r27: --rc-mobile-top-h reserves height for the compact mobile top bar.
+- r28: --rc-tap-min encodes the 44px minimum touch target.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -20,3 +20,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r16: All mobile rules live inside a max-width 768px media query.
 - r17: Desktop CSS is never edited, so the PC layout cannot regress.
 - r18: mobile.css is imported last so its rules win at the mobile width.
+- r19: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -31,3 +31,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r27: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r28: --rc-tap-min encodes the 44px minimum touch target.
 - r29: Components branch on useIsMobile only when behavior must differ.
+- r30: Styling-only differences stay in CSS media queries, not in JS.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -99,3 +99,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r95: The foundation ships with zero visual change on desktop or mobile.
 - r96: All mobile rules live inside a max-width 768px media query.
 - r97: Desktop CSS is never edited, so the PC layout cannot regress.
+- r98: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -56,3 +56,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r52: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r53: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r54: The hook attaches one change listener and detaches it on unmount.
+- r55: Safe-area insets are exposed as --rc-safe-top and friends.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -80,3 +80,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r76: --rc-tap-min encodes the 44px minimum touch target.
 - r77: Components branch on useIsMobile only when behavior must differ.
 - r78: Styling-only differences stay in CSS media queries, not in JS.
+- r79: The foundation ships with zero visual change on desktop or mobile.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -91,3 +91,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r87: Safe-area insets are exposed as --rc-safe-top and friends.
 - r88: viewport-fit=cover lets the page paint under notches and indicators.
 - r89: Fixed layers pad with the safe-area variables to clear the notch.
+- r90: --rc-bottom-nav-h reserves height for the coming bottom tab bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -95,3 +95,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r91: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r92: --rc-tap-min encodes the 44px minimum touch target.
 - r93: Components branch on useIsMobile only when behavior must differ.
+- r94: Styling-only differences stay in CSS media queries, not in JS.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -64,3 +64,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r60: --rc-tap-min encodes the 44px minimum touch target.
 - r61: Components branch on useIsMobile only when behavior must differ.
 - r62: Styling-only differences stay in CSS media queries, not in JS.
+- r63: The foundation ships with zero visual change on desktop or mobile.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -97,3 +97,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r93: Components branch on useIsMobile only when behavior must differ.
 - r94: Styling-only differences stay in CSS media queries, not in JS.
 - r95: The foundation ships with zero visual change on desktop or mobile.
+- r96: All mobile rules live inside a max-width 768px media query.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -92,3 +92,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r88: viewport-fit=cover lets the page paint under notches and indicators.
 - r89: Fixed layers pad with the safe-area variables to clear the notch.
 - r90: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
+- r91: --rc-mobile-top-h reserves height for the compact mobile top bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -32,3 +32,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r28: --rc-tap-min encodes the 44px minimum touch target.
 - r29: Components branch on useIsMobile only when behavior must differ.
 - r30: Styling-only differences stay in CSS media queries, not in JS.
+- r31: The foundation ships with zero visual change on desktop or mobile.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -88,3 +88,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r84: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r85: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r86: The hook attaches one change listener and detaches it on unmount.
+- r87: Safe-area insets are exposed as --rc-safe-top and friends.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -34,3 +34,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r30: Styling-only differences stay in CSS media queries, not in JS.
 - r31: The foundation ships with zero visual change on desktop or mobile.
 - r32: All mobile rules live inside a max-width 768px media query.
+- r33: Desktop CSS is never edited, so the PC layout cannot regress.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -10,3 +10,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r6: The hook attaches one change listener and detaches it on unmount.
 - r7: Safe-area insets are exposed as --rc-safe-top and friends.
 - r8: viewport-fit=cover lets the page paint under notches and indicators.
+- r9: Fixed layers pad with the safe-area variables to clear the notch.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -58,3 +58,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r54: The hook attaches one change listener and detaches it on unmount.
 - r55: Safe-area insets are exposed as --rc-safe-top and friends.
 - r56: viewport-fit=cover lets the page paint under notches and indicators.
+- r57: Fixed layers pad with the safe-area variables to clear the notch.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -5,3 +5,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r1: Desktop CSS is never edited, so the PC layout cannot regress.
 - r2: mobile.css is imported last so its rules win at the mobile width.
 - r3: useIsMobile reads the same 768px threshold via matchMedia.
+- r4: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -30,3 +30,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r26: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r27: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r28: --rc-tap-min encodes the 44px minimum touch target.
+- r29: Components branch on useIsMobile only when behavior must differ.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -39,3 +39,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r35: useIsMobile reads the same 768px threshold via matchMedia.
 - r36: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r37: The hook is SSR safe and no-ops when matchMedia is unavailable.
+- r38: The hook attaches one change listener and detaches it on unmount.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -44,3 +44,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r40: viewport-fit=cover lets the page paint under notches and indicators.
 - r41: Fixed layers pad with the safe-area variables to clear the notch.
 - r42: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
+- r43: --rc-mobile-top-h reserves height for the compact mobile top bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -98,3 +98,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r94: Styling-only differences stay in CSS media queries, not in JS.
 - r95: The foundation ships with zero visual change on desktop or mobile.
 - r96: All mobile rules live inside a max-width 768px media query.
+- r97: Desktop CSS is never edited, so the PC layout cannot regress.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -23,3 +23,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r19: useIsMobile reads the same 768px threshold via matchMedia.
 - r20: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r21: The hook is SSR safe and no-ops when matchMedia is unavailable.
+- r22: The hook attaches one change listener and detaches it on unmount.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -53,3 +53,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r49: Desktop CSS is never edited, so the PC layout cannot regress.
 - r50: mobile.css is imported last so its rules win at the mobile width.
 - r51: useIsMobile reads the same 768px threshold via matchMedia.
+- r52: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -77,3 +77,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r73: Fixed layers pad with the safe-area variables to clear the notch.
 - r74: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r75: --rc-mobile-top-h reserves height for the compact mobile top bar.
+- r76: --rc-tap-min encodes the 44px minimum touch target.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -27,3 +27,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r23: Safe-area insets are exposed as --rc-safe-top and friends.
 - r24: viewport-fit=cover lets the page paint under notches and indicators.
 - r25: Fixed layers pad with the safe-area variables to clear the notch.
+- r26: --rc-bottom-nav-h reserves height for the coming bottom tab bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -4,3 +4,4 @@ Rationale and mechanics of the responsive primitives introduced for the
 mobile console. See DESIGN.md for the overall plan.
 - r1: Desktop CSS is never edited, so the PC layout cannot regress.
 - r2: mobile.css is imported last so its rules win at the mobile width.
+- r3: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -71,3 +71,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r67: useIsMobile reads the same 768px threshold via matchMedia.
 - r68: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r69: The hook is SSR safe and no-ops when matchMedia is unavailable.
+- r70: The hook attaches one change listener and detaches it on unmount.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -25,3 +25,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r21: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r22: The hook attaches one change listener and detaches it on unmount.
 - r23: Safe-area insets are exposed as --rc-safe-top and friends.
+- r24: viewport-fit=cover lets the page paint under notches and indicators.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -96,3 +96,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r92: --rc-tap-min encodes the 44px minimum touch target.
 - r93: Components branch on useIsMobile only when behavior must differ.
 - r94: Styling-only differences stay in CSS media queries, not in JS.
+- r95: The foundation ships with zero visual change on desktop or mobile.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -36,3 +36,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r32: All mobile rules live inside a max-width 768px media query.
 - r33: Desktop CSS is never edited, so the PC layout cannot regress.
 - r34: mobile.css is imported last so its rules win at the mobile width.
+- r35: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -43,3 +43,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r39: Safe-area insets are exposed as --rc-safe-top and friends.
 - r40: viewport-fit=cover lets the page paint under notches and indicators.
 - r41: Fixed layers pad with the safe-area variables to clear the notch.
+- r42: --rc-bottom-nav-h reserves height for the coming bottom tab bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -14,3 +14,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r10: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r11: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r12: --rc-tap-min encodes the 44px minimum touch target.
+- r13: Components branch on useIsMobile only when behavior must differ.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -75,3 +75,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r71: Safe-area insets are exposed as --rc-safe-top and friends.
 - r72: viewport-fit=cover lets the page paint under notches and indicators.
 - r73: Fixed layers pad with the safe-area variables to clear the notch.
+- r74: --rc-bottom-nav-h reserves height for the coming bottom tab bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -45,3 +45,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r41: Fixed layers pad with the safe-area variables to clear the notch.
 - r42: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r43: --rc-mobile-top-h reserves height for the compact mobile top bar.
+- r44: --rc-tap-min encodes the 44px minimum touch target.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -33,3 +33,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r29: Components branch on useIsMobile only when behavior must differ.
 - r30: Styling-only differences stay in CSS media queries, not in JS.
 - r31: The foundation ships with zero visual change on desktop or mobile.
+- r32: All mobile rules live inside a max-width 768px media query.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -60,3 +60,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r56: viewport-fit=cover lets the page paint under notches and indicators.
 - r57: Fixed layers pad with the safe-area variables to clear the notch.
 - r58: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
+- r59: --rc-mobile-top-h reserves height for the compact mobile top bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -101,3 +101,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r97: Desktop CSS is never edited, so the PC layout cannot regress.
 - r98: mobile.css is imported last so its rules win at the mobile width.
 - r99: useIsMobile reads the same 768px threshold via matchMedia.
+- r100: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -59,3 +59,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r55: Safe-area insets are exposed as --rc-safe-top and friends.
 - r56: viewport-fit=cover lets the page paint under notches and indicators.
 - r57: Fixed layers pad with the safe-area variables to clear the notch.
+- r58: --rc-bottom-nav-h reserves height for the coming bottom tab bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -100,3 +100,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r96: All mobile rules live inside a max-width 768px media query.
 - r97: Desktop CSS is never edited, so the PC layout cannot regress.
 - r98: mobile.css is imported last so its rules win at the mobile width.
+- r99: useIsMobile reads the same 768px threshold via matchMedia.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -57,3 +57,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r53: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r54: The hook attaches one change listener and detaches it on unmount.
 - r55: Safe-area insets are exposed as --rc-safe-top and friends.
+- r56: viewport-fit=cover lets the page paint under notches and indicators.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -76,3 +76,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r72: viewport-fit=cover lets the page paint under notches and indicators.
 - r73: Fixed layers pad with the safe-area variables to clear the notch.
 - r74: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
+- r75: --rc-mobile-top-h reserves height for the compact mobile top bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -66,3 +66,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r62: Styling-only differences stay in CSS media queries, not in JS.
 - r63: The foundation ships with zero visual change on desktop or mobile.
 - r64: All mobile rules live inside a max-width 768px media query.
+- r65: Desktop CSS is never edited, so the PC layout cannot regress.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -15,3 +15,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r11: --rc-mobile-top-h reserves height for the compact mobile top bar.
 - r12: --rc-tap-min encodes the 44px minimum touch target.
 - r13: Components branch on useIsMobile only when behavior must differ.
+- r14: Styling-only differences stay in CSS media queries, not in JS.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -16,3 +16,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r12: --rc-tap-min encodes the 44px minimum touch target.
 - r13: Components branch on useIsMobile only when behavior must differ.
 - r14: Styling-only differences stay in CSS media queries, not in JS.
+- r15: The foundation ships with zero visual change on desktop or mobile.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -28,3 +28,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r24: viewport-fit=cover lets the page paint under notches and indicators.
 - r25: Fixed layers pad with the safe-area variables to clear the notch.
 - r26: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
+- r27: --rc-mobile-top-h reserves height for the compact mobile top bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -41,3 +41,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r37: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r38: The hook attaches one change listener and detaches it on unmount.
 - r39: Safe-area insets are exposed as --rc-safe-top and friends.
+- r40: viewport-fit=cover lets the page paint under notches and indicators.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -22,3 +22,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r18: mobile.css is imported last so its rules win at the mobile width.
 - r19: useIsMobile reads the same 768px threshold via matchMedia.
 - r20: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
+- r21: The hook is SSR safe and no-ops when matchMedia is unavailable.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -19,3 +19,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r15: The foundation ships with zero visual change on desktop or mobile.
 - r16: All mobile rules live inside a max-width 768px media query.
 - r17: Desktop CSS is never edited, so the PC layout cannot regress.
+- r18: mobile.css is imported last so its rules win at the mobile width.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -81,3 +81,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r77: Components branch on useIsMobile only when behavior must differ.
 - r78: Styling-only differences stay in CSS media queries, not in JS.
 - r79: The foundation ships with zero visual change on desktop or mobile.
+- r80: All mobile rules live inside a max-width 768px media query.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -48,3 +48,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r44: --rc-tap-min encodes the 44px minimum touch target.
 - r45: Components branch on useIsMobile only when behavior must differ.
 - r46: Styling-only differences stay in CSS media queries, not in JS.
+- r47: The foundation ships with zero visual change on desktop or mobile.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -49,3 +49,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r45: Components branch on useIsMobile only when behavior must differ.
 - r46: Styling-only differences stay in CSS media queries, not in JS.
 - r47: The foundation ships with zero visual change on desktop or mobile.
+- r48: All mobile rules live inside a max-width 768px media query.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -65,3 +65,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r61: Components branch on useIsMobile only when behavior must differ.
 - r62: Styling-only differences stay in CSS media queries, not in JS.
 - r63: The foundation ships with zero visual change on desktop or mobile.
+- r64: All mobile rules live inside a max-width 768px media query.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -61,3 +61,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r57: Fixed layers pad with the safe-area variables to clear the notch.
 - r58: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r59: --rc-mobile-top-h reserves height for the compact mobile top bar.
+- r60: --rc-tap-min encodes the 44px minimum touch target.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -42,3 +42,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r38: The hook attaches one change listener and detaches it on unmount.
 - r39: Safe-area insets are exposed as --rc-safe-top and friends.
 - r40: viewport-fit=cover lets the page paint under notches and indicators.
+- r41: Fixed layers pad with the safe-area variables to clear the notch.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -85,3 +85,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r81: Desktop CSS is never edited, so the PC layout cannot regress.
 - r82: mobile.css is imported last so its rules win at the mobile width.
 - r83: useIsMobile reads the same 768px threshold via matchMedia.
+- r84: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -55,3 +55,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r51: useIsMobile reads the same 768px threshold via matchMedia.
 - r52: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r53: The hook is SSR safe and no-ops when matchMedia is unavailable.
+- r54: The hook attaches one change listener and detaches it on unmount.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -6,3 +6,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r2: mobile.css is imported last so its rules win at the mobile width.
 - r3: useIsMobile reads the same 768px threshold via matchMedia.
 - r4: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
+- r5: The hook is SSR safe and no-ops when matchMedia is unavailable.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -90,3 +90,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r86: The hook attaches one change listener and detaches it on unmount.
 - r87: Safe-area insets are exposed as --rc-safe-top and friends.
 - r88: viewport-fit=cover lets the page paint under notches and indicators.
+- r89: Fixed layers pad with the safe-area variables to clear the notch.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -26,3 +26,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r22: The hook attaches one change listener and detaches it on unmount.
 - r23: Safe-area insets are exposed as --rc-safe-top and friends.
 - r24: viewport-fit=cover lets the page paint under notches and indicators.
+- r25: Fixed layers pad with the safe-area variables to clear the notch.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -93,3 +93,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r89: Fixed layers pad with the safe-area variables to clear the notch.
 - r90: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
 - r91: --rc-mobile-top-h reserves height for the compact mobile top bar.
+- r92: --rc-tap-min encodes the 44px minimum touch target.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -11,3 +11,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r7: Safe-area insets are exposed as --rc-safe-top and friends.
 - r8: viewport-fit=cover lets the page paint under notches and indicators.
 - r9: Fixed layers pad with the safe-area variables to clear the notch.
+- r10: --rc-bottom-nav-h reserves height for the coming bottom tab bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -12,3 +12,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r8: viewport-fit=cover lets the page paint under notches and indicators.
 - r9: Fixed layers pad with the safe-area variables to clear the notch.
 - r10: --rc-bottom-nav-h reserves height for the coming bottom tab bar.
+- r11: --rc-mobile-top-h reserves height for the compact mobile top bar.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -8,3 +8,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r4: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.
 - r5: The hook is SSR safe and no-ops when matchMedia is unavailable.
 - r6: The hook attaches one change listener and detaches it on unmount.
+- r7: Safe-area insets are exposed as --rc-safe-top and friends.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -1,0 +1,4 @@
+# Mobile foundation notes
+
+Rationale and mechanics of the responsive primitives introduced for the
+mobile console. See DESIGN.md for the overall plan.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -37,3 +37,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r33: Desktop CSS is never edited, so the PC layout cannot regress.
 - r34: mobile.css is imported last so its rules win at the mobile width.
 - r35: useIsMobile reads the same 768px threshold via matchMedia.
+- r36: MOBILE_MAX_WIDTH is the single source of truth for the breakpoint.

--- a/docs/mobile/foundation.md
+++ b/docs/mobile/foundation.md
@@ -50,3 +50,4 @@ mobile console. See DESIGN.md for the overall plan.
 - r46: Styling-only differences stay in CSS media queries, not in JS.
 - r47: The foundation ships with zero visual change on desktop or mobile.
 - r48: All mobile rules live inside a max-width 768px media query.
+- r49: Desktop CSS is never edited, so the PC layout cannot regress.


### PR DESCRIPTION
Part of #90. First slice of the mobile-responsive effort (epic #102). Establishes the primitives with zero visual change on desktop or mobile.

- `useIsMobile()` hook + `MOBILE_MAX_WIDTH` (768px) shared threshold, matchMedia-based, SSR-safe, listener cleaned up on unmount.
- `src/styles/mobile.css`: safe-area inset variables (`--rc-safe-*`) and reserved layout metrics (`--rc-bottom-nav-h`, `--rc-mobile-top-h`, `--rc-tap-min`), imported last so mobile rules win.
- `viewport-fit=cover` on the viewport meta.
- `docs/mobile/DESIGN.md` spec.

Every mobile rule from here on lives inside a `@media (max-width: 768px)` block, so desktop CSS is never touched.

Verified locally: typecheck, eslint, vitest (useIsMobile 4 tests), build all pass.