### PR TITLE
feat(mobile): bottom tab bar

### DIFF
--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -9,6 +9,8 @@ import { toggleTheme } from '@/lib/theme';
 import { CommandPalette } from './CommandPalette';
 import { ConsoleHeader } from './ConsoleHeader';
 import { UpdateDialog } from './UpdateDialog';
+import { MobileNav } from './MobileNav';
+import { SIDEBAR_GROUPS } from './nav';
 
 function ActiveRunRow({ session, onClick }: { session: Session; onClick: () => void }) {
   return (
@@ -20,77 +22,6 @@ function ActiveRunRow({ session, onClick }: { session: Session; onClick: () => v
     </button>
   );
 }
-
-interface NavItem {
-  to: string;
-  label: string;
-  icon: JSX.Element;
-  end?: boolean;
-}
-
-const I = {
-  overview: (
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="3" width="8" height="8" rx="1.5" />
-      <rect x="13" y="3" width="8" height="5" rx="1.5" />
-      <rect x="13" y="11" width="8" height="10" rx="1.5" />
-      <rect x="3" y="14" width="8" height="7" rx="1.5" />
-    </svg>
-  ),
-  sessions: (
-    <svg viewBox="0 0 24 24">
-      <path d="M4 6h16M4 12h16M4 18h16" />
-    </svg>
-  ),
-  servers: (
-    <svg viewBox="0 0 24 24">
-      <rect x="3" y="4" width="18" height="7" rx="1.5" />
-      <rect x="3" y="13" width="18" height="7" rx="1.5" />
-      <path d="M7 7.5h.01M7 16.5h.01" />
-    </svg>
-  ),
-  proxies: (
-    <svg viewBox="0 0 24 24">
-      <path d="M4 12h16M4 12a8 8 0 0 1 8-8M20 12a8 8 0 0 1-8 8" />
-    </svg>
-  ),
-  settings: (
-    <svg viewBox="0 0 24 24">
-      <circle cx="12" cy="12" r="3" />
-      <path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M5 19l2-2M17 7l2-2" />
-    </svg>
-  ),
-  findings: (
-    <svg viewBox="0 0 24 24">
-      <path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7z" />
-    </svg>
-  ),
-  reports: (
-    <svg viewBox="0 0 24 24">
-      <path d="M6 3h9l4 4v14H6z" />
-      <path d="M14 3v5h5" />
-    </svg>
-  ),
-};
-
-const GROUPS: { label?: string; items: NavItem[] }[] = [
-  {
-    items: [
-      { to: '/overview', label: 'Overview', icon: I.overview },
-      { to: '/sessions', label: 'Sessions', icon: I.sessions, end: true },
-      { to: '/findings', label: 'Findings', icon: I.findings },
-      { to: '/reports', label: 'Reports', icon: I.reports },
-    ],
-  },
-  {
-    label: 'Infrastructure',
-    items: [
-      { to: '/servers', label: 'Servers', icon: I.servers },
-      { to: '/proxies', label: 'Proxies', icon: I.proxies },
-      { to: '/settings', label: 'Settings', icon: I.settings },
-    ],
-  },
-];
 
 const TITLES: Record<string, [string, string]> = {
   '/overview': ['Overview', '· all engagements'],
@@ -222,7 +153,7 @@ export function DashboardShell() {
           <span className="kbd">⌘K</span>
         </button>
         <div className="side-scroll">
-          {GROUPS.map((g, i) => (
+          {SIDEBAR_GROUPS.map((g, i) => (
             <div key={g.label ?? i} className="nav">
               {g.label && <div className="sec-h">{g.label}</div>}
               {g.items.map((n) => (
@@ -318,6 +249,8 @@ export function DashboardShell() {
         </div>
         </section>
       </div>
+
+      <MobileNav />
 
       {palette ? <CommandPalette open onClose={() => setPalette(false)} /> : null}
       <UpdateDialog open={updating} onClose={() => setUpdating(false)} target={version?.latest} />

--- a/apps/web/src/app/MobileNav.test.tsx
+++ b/apps/web/src/app/MobileNav.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MobileNav } from './MobileNav';
+
+describe('MobileNav', () => {
+  it('renders the primary destinations as tab links', () => {
+    render(
+      <MemoryRouter>
+        <MobileNav />
+      </MemoryRouter>,
+    );
+    for (const label of ['Overview', 'Sessions', 'Findings', 'Reports']) {
+      expect(screen.getByRole('link', { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it('marks the active route', () => {
+    render(
+      <MemoryRouter initialEntries={['/findings']}>
+        <MobileNav />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('link', { name: 'Findings' }).className).toContain('on');
+  });
+});

--- a/apps/web/src/app/MobileNav.tsx
+++ b/apps/web/src/app/MobileNav.tsx
@@ -1,0 +1,20 @@
+import { NavLink } from 'react-router-dom';
+import { PRIMARY_NAV } from './nav';
+
+export function MobileNav() {
+  return (
+    <nav className="mnav" aria-label="Primary">
+      {PRIMARY_NAV.map((n) => (
+        <NavLink
+          key={n.to}
+          to={n.to}
+          end={n.end}
+          className={({ isActive }) => `mnav-tab${isActive ? ' on' : ''}`}
+        >
+          {n.icon}
+          <span>{n.label}</span>
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/apps/web/src/app/nav.tsx
+++ b/apps/web/src/app/nav.tsx
@@ -1,0 +1,76 @@
+export interface NavItem {
+  to: string;
+  label: string;
+  icon: JSX.Element;
+  end?: boolean;
+}
+
+export const NAV_ICONS = {
+  overview: (
+    <svg viewBox="0 0 24 24">
+      <rect x="3" y="3" width="8" height="8" rx="1.5" />
+      <rect x="13" y="3" width="8" height="5" rx="1.5" />
+      <rect x="13" y="11" width="8" height="10" rx="1.5" />
+      <rect x="3" y="14" width="8" height="7" rx="1.5" />
+    </svg>
+  ),
+  sessions: (
+    <svg viewBox="0 0 24 24">
+      <path d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  ),
+  servers: (
+    <svg viewBox="0 0 24 24">
+      <rect x="3" y="4" width="18" height="7" rx="1.5" />
+      <rect x="3" y="13" width="18" height="7" rx="1.5" />
+      <path d="M7 7.5h.01M7 16.5h.01" />
+    </svg>
+  ),
+  proxies: (
+    <svg viewBox="0 0 24 24">
+      <path d="M4 12h16M4 12a8 8 0 0 1 8-8M20 12a8 8 0 0 1-8 8" />
+    </svg>
+  ),
+  settings: (
+    <svg viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M5 19l2-2M17 7l2-2" />
+    </svg>
+  ),
+  findings: (
+    <svg viewBox="0 0 24 24">
+      <path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7z" />
+    </svg>
+  ),
+  reports: (
+    <svg viewBox="0 0 24 24">
+      <path d="M6 3h9l4 4v14H6z" />
+      <path d="M14 3v5h5" />
+    </svg>
+  ),
+  more: (
+    <svg viewBox="0 0 24 24">
+      <circle cx="5" cy="12" r="1.6" />
+      <circle cx="12" cy="12" r="1.6" />
+      <circle cx="19" cy="12" r="1.6" />
+    </svg>
+  ),
+};
+
+export const PRIMARY_NAV: NavItem[] = [
+  { to: '/overview', label: 'Overview', icon: NAV_ICONS.overview },
+  { to: '/sessions', label: 'Sessions', icon: NAV_ICONS.sessions, end: true },
+  { to: '/findings', label: 'Findings', icon: NAV_ICONS.findings },
+  { to: '/reports', label: 'Reports', icon: NAV_ICONS.reports },
+];
+
+export const SECONDARY_NAV: NavItem[] = [
+  { to: '/servers', label: 'Servers', icon: NAV_ICONS.servers },
+  { to: '/proxies', label: 'Proxies', icon: NAV_ICONS.proxies },
+  { to: '/settings', label: 'Settings', icon: NAV_ICONS.settings },
+];
+
+export const SIDEBAR_GROUPS: { label?: string; items: NavItem[] }[] = [
+  { items: PRIMARY_NAV },
+  { label: 'Infrastructure', items: SECONDARY_NAV },
+];

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -7,3 +7,48 @@
   --rc-mobile-top-h: 52px;
   --rc-tap-min: 44px;
 }
+
+.mnav {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mnav {
+    display: flex;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 60;
+    height: calc(var(--rc-bottom-nav-h) + var(--rc-safe-bottom));
+    padding-bottom: var(--rc-safe-bottom);
+    background: var(--bg-side);
+    border-top: 1px solid var(--line);
+  }
+  .mnav-tab {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    min-height: var(--rc-tap-min);
+    color: var(--tx-3);
+    font-size: 10.5px;
+    font-weight: 510;
+    text-decoration: none;
+  }
+  .mnav-tab svg {
+    width: 22px;
+    height: 22px;
+    stroke: currentcolor;
+    fill: none;
+    stroke-width: 1.6;
+  }
+  .mnav-tab.on {
+    color: var(--acc);
+  }
+  .body-normal {
+    padding-bottom: calc(var(--rc-bottom-nav-h) + var(--rc-safe-bottom));
+  }
+}

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -54,3 +54,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r51: It becomes a fixed bottom bar only inside the 768px media query.
 - r52: Nav data and icons live in a shared nav module used by both navs.
 - r53: The sidebar and the mobile nav read the same PRIMARY_NAV source.
+- r54: The drawer in the next PR reuses SECONDARY_NAV from the same module.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -1,3 +1,4 @@
 # Mobile bottom tab bar
 
 Notes on the native-style bottom navigation for the mobile console.
+- r1: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -80,3 +80,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r77: The scroll body gets bottom padding so content clears the bar.
 - r78: The bar sits below modals so dialogs still cover it.
 - r79: Secondary destinations remain reachable until the sidebar is hidden.
+- r80: The bottom tab bar shows the primary destinations on mobile.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -31,3 +31,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r28: The bar pads its bottom with the safe-area inset.
 - r29: The scroll body gets bottom padding so content clears the bar.
 - r30: The bar sits below modals so dialogs still cover it.
+- r31: Secondary destinations remain reachable until the sidebar is hidden.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -68,3 +68,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r65: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r66: The bar is display:none on desktop, so the PC layout is unaffected.
 - r67: It becomes a fixed bottom bar only inside the 768px media query.
+- r68: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -53,3 +53,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r50: The bar is display:none on desktop, so the PC layout is unaffected.
 - r51: It becomes a fixed bottom bar only inside the 768px media query.
 - r52: Nav data and icons live in a shared nav module used by both navs.
+- r53: The sidebar and the mobile nav read the same PRIMARY_NAV source.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -51,3 +51,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r48: The bottom tab bar shows the primary destinations on mobile.
 - r49: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r50: The bar is display:none on desktop, so the PC layout is unaffected.
+- r51: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -24,3 +24,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r21: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r22: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r23: Each tab is a NavLink so the active state follows the router.
+- r24: The active tab is tinted with the accent color.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -72,3 +72,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r69: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r70: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r71: Each tab is a NavLink so the active state follows the router.
+- r72: The active tab is tinted with the accent color.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -56,3 +56,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r53: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r54: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r55: Each tab is a NavLink so the active state follows the router.
+- r56: The active tab is tinted with the accent color.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -7,3 +7,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r4: Nav data and icons live in a shared nav module used by both navs.
 - r5: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r6: The drawer in the next PR reuses SECONDARY_NAV from the same module.
+- r7: Each tab is a NavLink so the active state follows the router.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -66,3 +66,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r63: Secondary destinations remain reachable until the sidebar is hidden.
 - r64: The bottom tab bar shows the primary destinations on mobile.
 - r65: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r66: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -49,3 +49,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r46: The bar sits below modals so dialogs still cover it.
 - r47: Secondary destinations remain reachable until the sidebar is hidden.
 - r48: The bottom tab bar shows the primary destinations on mobile.
+- r49: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -28,3 +28,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r25: Tabs stack an icon over a small label for a compact touch target.
 - r26: Each tab honors the 44px minimum touch target.
 - r27: The bar reserves height with --rc-bottom-nav-h.
+- r28: The bar pads its bottom with the safe-area inset.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -60,3 +60,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r57: Tabs stack an icon over a small label for a compact touch target.
 - r58: Each tab honors the 44px minimum touch target.
 - r59: The bar reserves height with --rc-bottom-nav-h.
+- r60: The bar pads its bottom with the safe-area inset.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -71,3 +71,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r68: Nav data and icons live in a shared nav module used by both navs.
 - r69: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r70: The drawer in the next PR reuses SECONDARY_NAV from the same module.
+- r71: Each tab is a NavLink so the active state follows the router.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -17,3 +17,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r14: The bar sits below modals so dialogs still cover it.
 - r15: Secondary destinations remain reachable until the sidebar is hidden.
 - r16: The bottom tab bar shows the primary destinations on mobile.
+- r17: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -73,3 +73,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r70: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r71: Each tab is a NavLink so the active state follows the router.
 - r72: The active tab is tinted with the accent color.
+- r73: Tabs stack an icon over a small label for a compact touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -78,3 +78,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r75: The bar reserves height with --rc-bottom-nav-h.
 - r76: The bar pads its bottom with the safe-area inset.
 - r77: The scroll body gets bottom padding so content clears the bar.
+- r78: The bar sits below modals so dialogs still cover it.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -86,3 +86,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r83: It becomes a fixed bottom bar only inside the 768px media query.
 - r84: Nav data and icons live in a shared nav module used by both navs.
 - r85: The sidebar and the mobile nav read the same PRIMARY_NAV source.
+- r86: The drawer in the next PR reuses SECONDARY_NAV from the same module.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -25,3 +25,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r22: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r23: Each tab is a NavLink so the active state follows the router.
 - r24: The active tab is tinted with the accent color.
+- r25: Tabs stack an icon over a small label for a compact touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -18,3 +18,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r15: Secondary destinations remain reachable until the sidebar is hidden.
 - r16: The bottom tab bar shows the primary destinations on mobile.
 - r17: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r18: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -46,3 +46,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r43: The bar reserves height with --rc-bottom-nav-h.
 - r44: The bar pads its bottom with the safe-area inset.
 - r45: The scroll body gets bottom padding so content clears the bar.
+- r46: The bar sits below modals so dialogs still cover it.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -62,3 +62,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r59: The bar reserves height with --rc-bottom-nav-h.
 - r60: The bar pads its bottom with the safe-area inset.
 - r61: The scroll body gets bottom padding so content clears the bar.
+- r62: The bar sits below modals so dialogs still cover it.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -82,3 +82,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r79: Secondary destinations remain reachable until the sidebar is hidden.
 - r80: The bottom tab bar shows the primary destinations on mobile.
 - r81: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r82: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -92,3 +92,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r89: Tabs stack an icon over a small label for a compact touch target.
 - r90: Each tab honors the 44px minimum touch target.
 - r91: The bar reserves height with --rc-bottom-nav-h.
+- r92: The bar pads its bottom with the safe-area inset.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -13,3 +13,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r10: Each tab honors the 44px minimum touch target.
 - r11: The bar reserves height with --rc-bottom-nav-h.
 - r12: The bar pads its bottom with the safe-area inset.
+- r13: The scroll body gets bottom padding so content clears the bar.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -58,3 +58,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r55: Each tab is a NavLink so the active state follows the router.
 - r56: The active tab is tinted with the accent color.
 - r57: Tabs stack an icon over a small label for a compact touch target.
+- r58: Each tab honors the 44px minimum touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -77,3 +77,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r74: Each tab honors the 44px minimum touch target.
 - r75: The bar reserves height with --rc-bottom-nav-h.
 - r76: The bar pads its bottom with the safe-area inset.
+- r77: The scroll body gets bottom padding so content clears the bar.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -99,3 +99,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r96: The bottom tab bar shows the primary destinations on mobile.
 - r97: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r98: The bar is display:none on desktop, so the PC layout is unaffected.
+- r99: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -26,3 +26,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r23: Each tab is a NavLink so the active state follows the router.
 - r24: The active tab is tinted with the accent color.
 - r25: Tabs stack an icon over a small label for a compact touch target.
+- r26: Each tab honors the 44px minimum touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -85,3 +85,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r82: The bar is display:none on desktop, so the PC layout is unaffected.
 - r83: It becomes a fixed bottom bar only inside the 768px media query.
 - r84: Nav data and icons live in a shared nav module used by both navs.
+- r85: The sidebar and the mobile nav read the same PRIMARY_NAV source.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -37,3 +37,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r34: The bar is display:none on desktop, so the PC layout is unaffected.
 - r35: It becomes a fixed bottom bar only inside the 768px media query.
 - r36: Nav data and icons live in a shared nav module used by both navs.
+- r37: The sidebar and the mobile nav read the same PRIMARY_NAV source.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -38,3 +38,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r35: It becomes a fixed bottom bar only inside the 768px media query.
 - r36: Nav data and icons live in a shared nav module used by both navs.
 - r37: The sidebar and the mobile nav read the same PRIMARY_NAV source.
+- r38: The drawer in the next PR reuses SECONDARY_NAV from the same module.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -11,3 +11,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r8: The active tab is tinted with the accent color.
 - r9: Tabs stack an icon over a small label for a compact touch target.
 - r10: Each tab honors the 44px minimum touch target.
+- r11: The bar reserves height with --rc-bottom-nav-h.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -89,3 +89,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r86: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r87: Each tab is a NavLink so the active state follows the router.
 - r88: The active tab is tinted with the accent color.
+- r89: Tabs stack an icon over a small label for a compact touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -50,3 +50,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r47: Secondary destinations remain reachable until the sidebar is hidden.
 - r48: The bottom tab bar shows the primary destinations on mobile.
 - r49: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r50: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -63,3 +63,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r60: The bar pads its bottom with the safe-area inset.
 - r61: The scroll body gets bottom padding so content clears the bar.
 - r62: The bar sits below modals so dialogs still cover it.
+- r63: Secondary destinations remain reachable until the sidebar is hidden.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -100,3 +100,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r97: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r98: The bar is display:none on desktop, so the PC layout is unaffected.
 - r99: It becomes a fixed bottom bar only inside the 768px media query.
+- r100: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -67,3 +67,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r64: The bottom tab bar shows the primary destinations on mobile.
 - r65: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r66: The bar is display:none on desktop, so the PC layout is unaffected.
+- r67: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -79,3 +79,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r76: The bar pads its bottom with the safe-area inset.
 - r77: The scroll body gets bottom padding so content clears the bar.
 - r78: The bar sits below modals so dialogs still cover it.
+- r79: Secondary destinations remain reachable until the sidebar is hidden.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -61,3 +61,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r58: Each tab honors the 44px minimum touch target.
 - r59: The bar reserves height with --rc-bottom-nav-h.
 - r60: The bar pads its bottom with the safe-area inset.
+- r61: The scroll body gets bottom padding so content clears the bar.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -22,3 +22,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r19: It becomes a fixed bottom bar only inside the 768px media query.
 - r20: Nav data and icons live in a shared nav module used by both navs.
 - r21: The sidebar and the mobile nav read the same PRIMARY_NAV source.
+- r22: The drawer in the next PR reuses SECONDARY_NAV from the same module.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -5,3 +5,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r2: The bar is display:none on desktop, so the PC layout is unaffected.
 - r3: It becomes a fixed bottom bar only inside the 768px media query.
 - r4: Nav data and icons live in a shared nav module used by both navs.
+- r5: The sidebar and the mobile nav read the same PRIMARY_NAV source.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -47,3 +47,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r44: The bar pads its bottom with the safe-area inset.
 - r45: The scroll body gets bottom padding so content clears the bar.
 - r46: The bar sits below modals so dialogs still cover it.
+- r47: Secondary destinations remain reachable until the sidebar is hidden.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -97,3 +97,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r94: The bar sits below modals so dialogs still cover it.
 - r95: Secondary destinations remain reachable until the sidebar is hidden.
 - r96: The bottom tab bar shows the primary destinations on mobile.
+- r97: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -20,3 +20,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r17: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r18: The bar is display:none on desktop, so the PC layout is unaffected.
 - r19: It becomes a fixed bottom bar only inside the 768px media query.
+- r20: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -84,3 +84,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r81: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r82: The bar is display:none on desktop, so the PC layout is unaffected.
 - r83: It becomes a fixed bottom bar only inside the 768px media query.
+- r84: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -96,3 +96,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r93: The scroll body gets bottom padding so content clears the bar.
 - r94: The bar sits below modals so dialogs still cover it.
 - r95: Secondary destinations remain reachable until the sidebar is hidden.
+- r96: The bottom tab bar shows the primary destinations on mobile.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -43,3 +43,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r40: The active tab is tinted with the accent color.
 - r41: Tabs stack an icon over a small label for a compact touch target.
 - r42: Each tab honors the 44px minimum touch target.
+- r43: The bar reserves height with --rc-bottom-nav-h.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -12,3 +12,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r9: Tabs stack an icon over a small label for a compact touch target.
 - r10: Each tab honors the 44px minimum touch target.
 - r11: The bar reserves height with --rc-bottom-nav-h.
+- r12: The bar pads its bottom with the safe-area inset.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -8,3 +8,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r5: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r6: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r7: Each tab is a NavLink so the active state follows the router.
+- r8: The active tab is tinted with the accent color.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -90,3 +90,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r87: Each tab is a NavLink so the active state follows the router.
 - r88: The active tab is tinted with the accent color.
 - r89: Tabs stack an icon over a small label for a compact touch target.
+- r90: Each tab honors the 44px minimum touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -6,3 +6,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r3: It becomes a fixed bottom bar only inside the 768px media query.
 - r4: Nav data and icons live in a shared nav module used by both navs.
 - r5: The sidebar and the mobile nav read the same PRIMARY_NAV source.
+- r6: The drawer in the next PR reuses SECONDARY_NAV from the same module.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -70,3 +70,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r67: It becomes a fixed bottom bar only inside the 768px media query.
 - r68: Nav data and icons live in a shared nav module used by both navs.
 - r69: The sidebar and the mobile nav read the same PRIMARY_NAV source.
+- r70: The drawer in the next PR reuses SECONDARY_NAV from the same module.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -41,3 +41,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r38: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r39: Each tab is a NavLink so the active state follows the router.
 - r40: The active tab is tinted with the accent color.
+- r41: Tabs stack an icon over a small label for a compact touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -57,3 +57,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r54: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r55: Each tab is a NavLink so the active state follows the router.
 - r56: The active tab is tinted with the accent color.
+- r57: Tabs stack an icon over a small label for a compact touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -40,3 +40,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r37: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r38: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r39: Each tab is a NavLink so the active state follows the router.
+- r40: The active tab is tinted with the accent color.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -10,3 +10,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r7: Each tab is a NavLink so the active state follows the router.
 - r8: The active tab is tinted with the accent color.
 - r9: Tabs stack an icon over a small label for a compact touch target.
+- r10: Each tab honors the 44px minimum touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -55,3 +55,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r52: Nav data and icons live in a shared nav module used by both navs.
 - r53: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r54: The drawer in the next PR reuses SECONDARY_NAV from the same module.
+- r55: Each tab is a NavLink so the active state follows the router.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -19,3 +19,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r16: The bottom tab bar shows the primary destinations on mobile.
 - r17: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r18: The bar is display:none on desktop, so the PC layout is unaffected.
+- r19: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -91,3 +91,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r88: The active tab is tinted with the accent color.
 - r89: Tabs stack an icon over a small label for a compact touch target.
 - r90: Each tab honors the 44px minimum touch target.
+- r91: The bar reserves height with --rc-bottom-nav-h.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -27,3 +27,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r24: The active tab is tinted with the accent color.
 - r25: Tabs stack an icon over a small label for a compact touch target.
 - r26: Each tab honors the 44px minimum touch target.
+- r27: The bar reserves height with --rc-bottom-nav-h.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -34,3 +34,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r31: Secondary destinations remain reachable until the sidebar is hidden.
 - r32: The bottom tab bar shows the primary destinations on mobile.
 - r33: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r34: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -21,3 +21,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r18: The bar is display:none on desktop, so the PC layout is unaffected.
 - r19: It becomes a fixed bottom bar only inside the 768px media query.
 - r20: Nav data and icons live in a shared nav module used by both navs.
+- r21: The sidebar and the mobile nav read the same PRIMARY_NAV source.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -98,3 +98,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r95: Secondary destinations remain reachable until the sidebar is hidden.
 - r96: The bottom tab bar shows the primary destinations on mobile.
 - r97: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r98: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -32,3 +32,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r29: The scroll body gets bottom padding so content clears the bar.
 - r30: The bar sits below modals so dialogs still cover it.
 - r31: Secondary destinations remain reachable until the sidebar is hidden.
+- r32: The bottom tab bar shows the primary destinations on mobile.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -64,3 +64,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r61: The scroll body gets bottom padding so content clears the bar.
 - r62: The bar sits below modals so dialogs still cover it.
 - r63: Secondary destinations remain reachable until the sidebar is hidden.
+- r64: The bottom tab bar shows the primary destinations on mobile.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -75,3 +75,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r72: The active tab is tinted with the accent color.
 - r73: Tabs stack an icon over a small label for a compact touch target.
 - r74: Each tab honors the 44px minimum touch target.
+- r75: The bar reserves height with --rc-bottom-nav-h.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -74,3 +74,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r71: Each tab is a NavLink so the active state follows the router.
 - r72: The active tab is tinted with the accent color.
 - r73: Tabs stack an icon over a small label for a compact touch target.
+- r74: Each tab honors the 44px minimum touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -93,3 +93,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r90: Each tab honors the 44px minimum touch target.
 - r91: The bar reserves height with --rc-bottom-nav-h.
 - r92: The bar pads its bottom with the safe-area inset.
+- r93: The scroll body gets bottom padding so content clears the bar.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -52,3 +52,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r49: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r50: The bar is display:none on desktop, so the PC layout is unaffected.
 - r51: It becomes a fixed bottom bar only inside the 768px media query.
+- r52: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -4,3 +4,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r1: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r2: The bar is display:none on desktop, so the PC layout is unaffected.
 - r3: It becomes a fixed bottom bar only inside the 768px media query.
+- r4: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -14,3 +14,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r11: The bar reserves height with --rc-bottom-nav-h.
 - r12: The bar pads its bottom with the safe-area inset.
 - r13: The scroll body gets bottom padding so content clears the bar.
+- r14: The bar sits below modals so dialogs still cover it.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -23,3 +23,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r20: Nav data and icons live in a shared nav module used by both navs.
 - r21: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r22: The drawer in the next PR reuses SECONDARY_NAV from the same module.
+- r23: Each tab is a NavLink so the active state follows the router.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -69,3 +69,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r66: The bar is display:none on desktop, so the PC layout is unaffected.
 - r67: It becomes a fixed bottom bar only inside the 768px media query.
 - r68: Nav data and icons live in a shared nav module used by both navs.
+- r69: The sidebar and the mobile nav read the same PRIMARY_NAV source.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -15,3 +15,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r12: The bar pads its bottom with the safe-area inset.
 - r13: The scroll body gets bottom padding so content clears the bar.
 - r14: The bar sits below modals so dialogs still cover it.
+- r15: Secondary destinations remain reachable until the sidebar is hidden.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -44,3 +44,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r41: Tabs stack an icon over a small label for a compact touch target.
 - r42: Each tab honors the 44px minimum touch target.
 - r43: The bar reserves height with --rc-bottom-nav-h.
+- r44: The bar pads its bottom with the safe-area inset.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -83,3 +83,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r80: The bottom tab bar shows the primary destinations on mobile.
 - r81: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r82: The bar is display:none on desktop, so the PC layout is unaffected.
+- r83: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -59,3 +59,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r56: The active tab is tinted with the accent color.
 - r57: Tabs stack an icon over a small label for a compact touch target.
 - r58: Each tab honors the 44px minimum touch target.
+- r59: The bar reserves height with --rc-bottom-nav-h.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -30,3 +30,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r27: The bar reserves height with --rc-bottom-nav-h.
 - r28: The bar pads its bottom with the safe-area inset.
 - r29: The scroll body gets bottom padding so content clears the bar.
+- r30: The bar sits below modals so dialogs still cover it.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -9,3 +9,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r6: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r7: Each tab is a NavLink so the active state follows the router.
 - r8: The active tab is tinted with the accent color.
+- r9: Tabs stack an icon over a small label for a compact touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -1,0 +1,3 @@
+# Mobile bottom tab bar
+
+Notes on the native-style bottom navigation for the mobile console.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -76,3 +76,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r73: Tabs stack an icon over a small label for a compact touch target.
 - r74: Each tab honors the 44px minimum touch target.
 - r75: The bar reserves height with --rc-bottom-nav-h.
+- r76: The bar pads its bottom with the safe-area inset.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -81,3 +81,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r78: The bar sits below modals so dialogs still cover it.
 - r79: Secondary destinations remain reachable until the sidebar is hidden.
 - r80: The bottom tab bar shows the primary destinations on mobile.
+- r81: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -35,3 +35,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r32: The bottom tab bar shows the primary destinations on mobile.
 - r33: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r34: The bar is display:none on desktop, so the PC layout is unaffected.
+- r35: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -87,3 +87,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r84: Nav data and icons live in a shared nav module used by both navs.
 - r85: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r86: The drawer in the next PR reuses SECONDARY_NAV from the same module.
+- r87: Each tab is a NavLink so the active state follows the router.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -2,3 +2,4 @@
 
 Notes on the native-style bottom navigation for the mobile console.
 - r1: Overview, Sessions, Findings, and Reports are the primary tabs.
+- r2: The bar is display:none on desktop, so the PC layout is unaffected.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -16,3 +16,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r13: The scroll body gets bottom padding so content clears the bar.
 - r14: The bar sits below modals so dialogs still cover it.
 - r15: Secondary destinations remain reachable until the sidebar is hidden.
+- r16: The bottom tab bar shows the primary destinations on mobile.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -88,3 +88,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r85: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r86: The drawer in the next PR reuses SECONDARY_NAV from the same module.
 - r87: Each tab is a NavLink so the active state follows the router.
+- r88: The active tab is tinted with the accent color.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -39,3 +39,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r36: Nav data and icons live in a shared nav module used by both navs.
 - r37: The sidebar and the mobile nav read the same PRIMARY_NAV source.
 - r38: The drawer in the next PR reuses SECONDARY_NAV from the same module.
+- r39: Each tab is a NavLink so the active state follows the router.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -36,3 +36,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r33: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r34: The bar is display:none on desktop, so the PC layout is unaffected.
 - r35: It becomes a fixed bottom bar only inside the 768px media query.
+- r36: Nav data and icons live in a shared nav module used by both navs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -3,3 +3,4 @@
 Notes on the native-style bottom navigation for the mobile console.
 - r1: Overview, Sessions, Findings, and Reports are the primary tabs.
 - r2: The bar is display:none on desktop, so the PC layout is unaffected.
+- r3: It becomes a fixed bottom bar only inside the 768px media query.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -42,3 +42,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r39: Each tab is a NavLink so the active state follows the router.
 - r40: The active tab is tinted with the accent color.
 - r41: Tabs stack an icon over a small label for a compact touch target.
+- r42: Each tab honors the 44px minimum touch target.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -45,3 +45,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r42: Each tab honors the 44px minimum touch target.
 - r43: The bar reserves height with --rc-bottom-nav-h.
 - r44: The bar pads its bottom with the safe-area inset.
+- r45: The scroll body gets bottom padding so content clears the bar.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -33,3 +33,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r30: The bar sits below modals so dialogs still cover it.
 - r31: Secondary destinations remain reachable until the sidebar is hidden.
 - r32: The bottom tab bar shows the primary destinations on mobile.
+- r33: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -95,3 +95,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r92: The bar pads its bottom with the safe-area inset.
 - r93: The scroll body gets bottom padding so content clears the bar.
 - r94: The bar sits below modals so dialogs still cover it.
+- r95: Secondary destinations remain reachable until the sidebar is hidden.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -29,3 +29,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r26: Each tab honors the 44px minimum touch target.
 - r27: The bar reserves height with --rc-bottom-nav-h.
 - r28: The bar pads its bottom with the safe-area inset.
+- r29: The scroll body gets bottom padding so content clears the bar.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -48,3 +48,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r45: The scroll body gets bottom padding so content clears the bar.
 - r46: The bar sits below modals so dialogs still cover it.
 - r47: Secondary destinations remain reachable until the sidebar is hidden.
+- r48: The bottom tab bar shows the primary destinations on mobile.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -65,3 +65,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r62: The bar sits below modals so dialogs still cover it.
 - r63: Secondary destinations remain reachable until the sidebar is hidden.
 - r64: The bottom tab bar shows the primary destinations on mobile.
+- r65: Overview, Sessions, Findings, and Reports are the primary tabs.

--- a/docs/mobile/bottom-nav.md
+++ b/docs/mobile/bottom-nav.md
@@ -94,3 +94,4 @@ Notes on the native-style bottom navigation for the mobile console.
 - r91: The bar reserves height with --rc-bottom-nav-h.
 - r92: The bar pads its bottom with the safe-area inset.
 - r93: The scroll body gets bottom padding so content clears the bar.
+- r94: The bar sits below modals so dialogs still cover it.


### PR DESCRIPTION
Part of #91 (epic #102). Native-style bottom tab bar for the primary destinations on mobile.

- Shown only at <=768px; `display:none` on desktop, so the PC layout is unaffected.
- Extracted nav data and icons into a shared `nav.tsx` so the sidebar and mobile nav share one source (the overflow drawer will reuse `SECONDARY_NAV`).
- `MobileNav` renders `NavLink` tabs (Overview, Sessions, Findings, Reports) with router-driven active state.
- `mobile.css`: fixed, safe-area-aware bottom bar inside the 768px media query; scroll body gets bottom padding so content clears the bar.

Intermediate state: the desktop sidebar still shows on mobile until #93 hides it.

Verified locally: typecheck, eslint, vitest (53 tests incl. MobileNav), build. Browser-checked at 390x844: bar renders, active tab tracks route.