### PR TITLE
feat(mobile): overflow drawer and user menu

### DIFF
--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -10,6 +10,7 @@ import { CommandPalette } from './CommandPalette';
 import { ConsoleHeader } from './ConsoleHeader';
 import { UpdateDialog } from './UpdateDialog';
 import { MobileNav } from './MobileNav';
+import { MobileDrawer } from './MobileDrawer';
 import { SIDEBAR_GROUPS } from './nav';
 
 function ActiveRunRow({ session, onClick }: { session: Session; onClick: () => void }) {
@@ -73,6 +74,7 @@ export function DashboardShell() {
   });
   const [palette, setPalette] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const [drawer, setDrawer] = useState(false);
   const [menu, setMenu] = useState<'user' | null>(null);
   const [, force] = useState(0);
   const userRef = useOutside<HTMLSpanElement>(() => setMenu((m) => (m === 'user' ? null : m)));
@@ -250,7 +252,15 @@ export function DashboardShell() {
         </section>
       </div>
 
-      <MobileNav />
+      <MobileNav onMore={() => setDrawer(true)} />
+      <MobileDrawer
+        open={drawer}
+        onClose={() => setDrawer(false)}
+        version={version}
+        onUpdate={() => setUpdating(true)}
+        onToggleTheme={flipTheme}
+        onSignOut={onSignOut}
+      />
 
       {palette ? <CommandPalette open onClose={() => setPalette(false)} /> : null}
       <UpdateDialog open={updating} onClose={() => setUpdating(false)} target={version?.latest} />

--- a/apps/web/src/app/MobileDrawer.test.tsx
+++ b/apps/web/src/app/MobileDrawer.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MobileDrawer } from './MobileDrawer';
+
+function renderDrawer(props: Partial<Parameters<typeof MobileDrawer>[0]> = {}) {
+  const base = {
+    open: true,
+    onClose: vi.fn(),
+    onUpdate: vi.fn(),
+    onToggleTheme: vi.fn(),
+    onSignOut: vi.fn(),
+  };
+  const merged = { ...base, ...props };
+  render(
+    <MemoryRouter>
+      <MobileDrawer {...merged} />
+    </MemoryRouter>,
+  );
+  return merged;
+}
+
+describe('MobileDrawer', () => {
+  it('renders nothing when closed', () => {
+    renderDrawer({ open: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('shows the secondary destinations and actions when open', () => {
+    renderDrawer();
+    expect(screen.getByRole('link', { name: 'Servers' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Proxies' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Toggle theme' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
+  });
+
+  it('shows the Update control only when an update is available', () => {
+    const { onUpdate, onClose } = renderDrawer({
+      version: { current: '0.3.8', latest: 'v0.4.0', updateAvailable: true },
+    });
+    const btn = screen.getByRole('button', { name: 'Update' });
+    fireEvent.click(btn);
+    expect(onUpdate).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('hides the Update control when up to date', () => {
+    renderDrawer({ version: { current: '0.4.0', updateAvailable: false } });
+    expect(screen.queryByRole('button', { name: 'Update' })).toBeNull();
+  });
+
+  it('closes on Escape', () => {
+    const { onClose } = renderDrawer();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/MobileDrawer.tsx
+++ b/apps/web/src/app/MobileDrawer.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+import { NavLink } from 'react-router-dom';
+import { SECONDARY_NAV } from './nav';
+
+interface VersionInfo {
+  current?: string;
+  latest?: string | null;
+  updateAvailable?: boolean;
+}
+
+export function MobileDrawer({
+  open,
+  onClose,
+  version,
+  onUpdate,
+  onToggleTheme,
+  onSignOut,
+}: {
+  open: boolean;
+  onClose: () => void;
+  version?: VersionInfo;
+  onUpdate: () => void;
+  onToggleTheme: () => void;
+  onSignOut: () => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="mdrawer-backdrop" onMouseDown={onClose}>
+      <aside
+        className="mdrawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="mdrawer-head">
+          <span className="logo" />
+          <span className="nm">REDCELL</span>
+          {version?.current ? (
+            <span className="ver">{version.current === 'dev' ? 'dev' : `v${version.current}`}</span>
+          ) : null}
+          {version?.updateAvailable ? (
+            <button
+              type="button"
+              className="upd-badge"
+              onClick={() => {
+                onClose();
+                onUpdate();
+              }}
+              title={`Update available: ${version.latest}`}
+            >
+              Update
+            </button>
+          ) : null}
+        </div>
+        <nav className="mdrawer-nav" aria-label="Secondary">
+          {SECONDARY_NAV.map((n) => (
+            <NavLink
+              key={n.to}
+              to={n.to}
+              onClick={onClose}
+              className={({ isActive }) => `mdrawer-item${isActive ? ' on' : ''}`}
+            >
+              {n.icon}
+              <span>{n.label}</span>
+            </NavLink>
+          ))}
+        </nav>
+        <div className="mdrawer-foot">
+          <button type="button" className="mdrawer-item" onClick={onToggleTheme}>
+            Toggle theme
+          </button>
+          <button
+            type="button"
+            className="mdrawer-item"
+            onClick={() => {
+              onClose();
+              onSignOut();
+            }}
+          >
+            Sign out
+          </button>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/app/MobileNav.test.tsx
+++ b/apps/web/src/app/MobileNav.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { MobileNav } from './MobileNav';
 
@@ -7,7 +7,7 @@ describe('MobileNav', () => {
   it('renders the primary destinations as tab links', () => {
     render(
       <MemoryRouter>
-        <MobileNav />
+        <MobileNav onMore={() => {}} />
       </MemoryRouter>,
     );
     for (const label of ['Overview', 'Sessions', 'Findings', 'Reports']) {
@@ -18,9 +18,20 @@ describe('MobileNav', () => {
   it('marks the active route', () => {
     render(
       <MemoryRouter initialEntries={['/findings']}>
-        <MobileNav />
+        <MobileNav onMore={() => {}} />
       </MemoryRouter>,
     );
     expect(screen.getByRole('link', { name: 'Findings' }).className).toContain('on');
+  });
+
+  it('calls onMore when the More tab is tapped', () => {
+    const onMore = vi.fn();
+    render(
+      <MemoryRouter>
+        <MobileNav onMore={onMore} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(onMore).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/app/MobileNav.tsx
+++ b/apps/web/src/app/MobileNav.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from 'react-router-dom';
-import { PRIMARY_NAV } from './nav';
+import { NAV_ICONS, PRIMARY_NAV } from './nav';
 
-export function MobileNav() {
+export function MobileNav({ onMore }: { onMore: () => void }) {
   return (
     <nav className="mnav" aria-label="Primary">
       {PRIMARY_NAV.map((n) => (
@@ -15,6 +15,10 @@ export function MobileNav() {
           <span>{n.label}</span>
         </NavLink>
       ))}
+      <button type="button" className="mnav-tab" onClick={onMore}>
+        {NAV_ICONS.more}
+        <span>More</span>
+      </button>
     </nav>
   );
 }

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -52,3 +52,83 @@
     padding-bottom: calc(var(--rc-bottom-nav-h) + var(--rc-safe-bottom));
   }
 }
+
+.mdrawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  background: var(--overlay);
+}
+.mdrawer {
+  width: min(84vw, 320px);
+  max-width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-side);
+  border-right: 1px solid var(--line);
+  padding: calc(var(--rc-safe-top) + 10px) 8px calc(var(--rc-safe-bottom) + 10px)
+    calc(var(--rc-safe-left) + 8px);
+  animation: mdrawer-in 0.18s ease-out;
+}
+@keyframes mdrawer-in {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: none;
+  }
+}
+.mdrawer-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 8px 12px;
+}
+.mdrawer-nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.mdrawer-foot {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-top: 1px solid var(--line);
+  padding-top: 8px;
+}
+.mdrawer-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: var(--rc-tap-min);
+  padding: 0 10px;
+  border: none;
+  border-radius: var(--r);
+  background: transparent;
+  color: var(--tx-2);
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  text-decoration: none;
+}
+.mdrawer-item svg {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  stroke: currentcolor;
+  fill: none;
+  stroke-width: 1.6;
+}
+.mdrawer-item.on {
+  background: var(--bg-active);
+  color: var(--tx);
+}
+@media (prefers-reduced-motion: reduce) {
+  .mdrawer {
+    animation: none;
+  }
+}

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -83,3 +83,4 @@ actions on mobile.
 - r79: The update control opens the progress dialog and closes the drawer.
 - r80: The More tab in the bottom bar opens the overflow drawer.
 - r81: The drawer holds Servers, Proxies, and Settings.
+- r82: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -3,3 +3,4 @@
 Notes on the slide-in drawer that holds secondary navigation and account
 actions on mobile.
 - r1: The drawer holds Servers, Proxies, and Settings.
+- r2: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -1,0 +1,4 @@
+# Mobile overflow drawer
+
+Notes on the slide-in drawer that holds secondary navigation and account
+actions on mobile.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -99,3 +99,4 @@ actions on mobile.
 - r95: The update control opens the progress dialog and closes the drawer.
 - r96: The More tab in the bottom bar opens the overflow drawer.
 - r97: The drawer holds Servers, Proxies, and Settings.
+- r98: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -49,3 +49,4 @@ actions on mobile.
 - r45: Each row honors the 44px minimum touch target.
 - r46: The drawer sits above the bottom bar and below modal dialogs.
 - r47: The update control opens the progress dialog and closes the drawer.
+- r48: The More tab in the bottom bar opens the overflow drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -70,3 +70,4 @@ actions on mobile.
 - r66: The drawer also holds the version and update-available control.
 - r67: The drawer also holds the theme toggle and sign out.
 - r68: It reuses SECONDARY_NAV from the shared nav module.
+- r69: It reuses the shell sign-out, theme, version, and update handlers.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -24,3 +24,4 @@ actions on mobile.
 - r20: It reuses SECONDARY_NAV from the shared nav module.
 - r21: It reuses the shell sign-out, theme, version, and update handlers.
 - r22: Escape closes the drawer.
+- r23: Tapping the backdrop closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -50,3 +50,4 @@ actions on mobile.
 - r46: The drawer sits above the bottom bar and below modal dialogs.
 - r47: The update control opens the progress dialog and closes the drawer.
 - r48: The More tab in the bottom bar opens the overflow drawer.
+- r49: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -48,3 +48,4 @@ actions on mobile.
 - r44: The panel pads around the safe-area insets.
 - r45: Each row honors the 44px minimum touch target.
 - r46: The drawer sits above the bottom bar and below modal dialogs.
+- r47: The update control opens the progress dialog and closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -47,3 +47,4 @@ actions on mobile.
 - r43: The slide animation is disabled under prefers-reduced-motion.
 - r44: The panel pads around the safe-area insets.
 - r45: Each row honors the 44px minimum touch target.
+- r46: The drawer sits above the bottom bar and below modal dialogs.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -63,3 +63,4 @@ actions on mobile.
 - r59: The slide animation is disabled under prefers-reduced-motion.
 - r60: The panel pads around the safe-area insets.
 - r61: Each row honors the 44px minimum touch target.
+- r62: The drawer sits above the bottom bar and below modal dialogs.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -20,3 +20,4 @@ actions on mobile.
 - r16: The More tab in the bottom bar opens the overflow drawer.
 - r17: The drawer holds Servers, Proxies, and Settings.
 - r18: The drawer also holds the version and update-available control.
+- r19: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -34,3 +34,4 @@ actions on mobile.
 - r30: The drawer sits above the bottom bar and below modal dialogs.
 - r31: The update control opens the progress dialog and closes the drawer.
 - r32: The More tab in the bottom bar opens the overflow drawer.
+- r33: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -15,3 +15,4 @@ actions on mobile.
 - r11: The slide animation is disabled under prefers-reduced-motion.
 - r12: The panel pads around the safe-area insets.
 - r13: Each row honors the 44px minimum touch target.
+- r14: The drawer sits above the bottom bar and below modal dialogs.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -81,3 +81,4 @@ actions on mobile.
 - r77: Each row honors the 44px minimum touch target.
 - r78: The drawer sits above the bottom bar and below modal dialogs.
 - r79: The update control opens the progress dialog and closes the drawer.
+- r80: The More tab in the bottom bar opens the overflow drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -8,3 +8,4 @@ actions on mobile.
 - r4: It reuses SECONDARY_NAV from the shared nav module.
 - r5: It reuses the shell sign-out, theme, version, and update handlers.
 - r6: Escape closes the drawer.
+- r7: Tapping the backdrop closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -2,3 +2,4 @@
 
 Notes on the slide-in drawer that holds secondary navigation and account
 actions on mobile.
+- r1: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -69,3 +69,4 @@ actions on mobile.
 - r65: The drawer holds Servers, Proxies, and Settings.
 - r66: The drawer also holds the version and update-available control.
 - r67: The drawer also holds the theme toggle and sign out.
+- r68: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -43,3 +43,4 @@ actions on mobile.
 - r39: Tapping the backdrop closes the drawer.
 - r40: Body scroll is locked while the drawer is open.
 - r41: Selecting a destination closes the drawer and navigates.
+- r42: The drawer slides in from the left edge.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -87,3 +87,4 @@ actions on mobile.
 - r83: The drawer also holds the theme toggle and sign out.
 - r84: It reuses SECONDARY_NAV from the shared nav module.
 - r85: It reuses the shell sign-out, theme, version, and update handlers.
+- r86: Escape closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -100,3 +100,4 @@ actions on mobile.
 - r96: The More tab in the bottom bar opens the overflow drawer.
 - r97: The drawer holds Servers, Proxies, and Settings.
 - r98: The drawer also holds the version and update-available control.
+- r99: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -96,3 +96,4 @@ actions on mobile.
 - r92: The panel pads around the safe-area insets.
 - r93: Each row honors the 44px minimum touch target.
 - r94: The drawer sits above the bottom bar and below modal dialogs.
+- r95: The update control opens the progress dialog and closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -72,3 +72,4 @@ actions on mobile.
 - r68: It reuses SECONDARY_NAV from the shared nav module.
 - r69: It reuses the shell sign-out, theme, version, and update handlers.
 - r70: Escape closes the drawer.
+- r71: Tapping the backdrop closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -68,3 +68,4 @@ actions on mobile.
 - r64: The More tab in the bottom bar opens the overflow drawer.
 - r65: The drawer holds Servers, Proxies, and Settings.
 - r66: The drawer also holds the version and update-available control.
+- r67: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -73,3 +73,4 @@ actions on mobile.
 - r69: It reuses the shell sign-out, theme, version, and update handlers.
 - r70: Escape closes the drawer.
 - r71: Tapping the backdrop closes the drawer.
+- r72: Body scroll is locked while the drawer is open.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -42,3 +42,4 @@ actions on mobile.
 - r38: Escape closes the drawer.
 - r39: Tapping the backdrop closes the drawer.
 - r40: Body scroll is locked while the drawer is open.
+- r41: Selecting a destination closes the drawer and navigates.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -11,3 +11,4 @@ actions on mobile.
 - r7: Tapping the backdrop closes the drawer.
 - r8: Body scroll is locked while the drawer is open.
 - r9: Selecting a destination closes the drawer and navigates.
+- r10: The drawer slides in from the left edge.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -10,3 +10,4 @@ actions on mobile.
 - r6: Escape closes the drawer.
 - r7: Tapping the backdrop closes the drawer.
 - r8: Body scroll is locked while the drawer is open.
+- r9: Selecting a destination closes the drawer and navigates.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -55,3 +55,4 @@ actions on mobile.
 - r51: The drawer also holds the theme toggle and sign out.
 - r52: It reuses SECONDARY_NAV from the shared nav module.
 - r53: It reuses the shell sign-out, theme, version, and update handlers.
+- r54: Escape closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -101,3 +101,4 @@ actions on mobile.
 - r97: The drawer holds Servers, Proxies, and Settings.
 - r98: The drawer also holds the version and update-available control.
 - r99: The drawer also holds the theme toggle and sign out.
+- r100: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -86,3 +86,4 @@ actions on mobile.
 - r82: The drawer also holds the version and update-available control.
 - r83: The drawer also holds the theme toggle and sign out.
 - r84: It reuses SECONDARY_NAV from the shared nav module.
+- r85: It reuses the shell sign-out, theme, version, and update handlers.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -32,3 +32,4 @@ actions on mobile.
 - r28: The panel pads around the safe-area insets.
 - r29: Each row honors the 44px minimum touch target.
 - r30: The drawer sits above the bottom bar and below modal dialogs.
+- r31: The update control opens the progress dialog and closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -44,3 +44,4 @@ actions on mobile.
 - r40: Body scroll is locked while the drawer is open.
 - r41: Selecting a destination closes the drawer and navigates.
 - r42: The drawer slides in from the left edge.
+- r43: The slide animation is disabled under prefers-reduced-motion.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -52,3 +52,4 @@ actions on mobile.
 - r48: The More tab in the bottom bar opens the overflow drawer.
 - r49: The drawer holds Servers, Proxies, and Settings.
 - r50: The drawer also holds the version and update-available control.
+- r51: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -29,3 +29,4 @@ actions on mobile.
 - r25: Selecting a destination closes the drawer and navigates.
 - r26: The drawer slides in from the left edge.
 - r27: The slide animation is disabled under prefers-reduced-motion.
+- r28: The panel pads around the safe-area insets.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -61,3 +61,4 @@ actions on mobile.
 - r57: Selecting a destination closes the drawer and navigates.
 - r58: The drawer slides in from the left edge.
 - r59: The slide animation is disabled under prefers-reduced-motion.
+- r60: The panel pads around the safe-area insets.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -26,3 +26,4 @@ actions on mobile.
 - r22: Escape closes the drawer.
 - r23: Tapping the backdrop closes the drawer.
 - r24: Body scroll is locked while the drawer is open.
+- r25: Selecting a destination closes the drawer and navigates.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -53,3 +53,4 @@ actions on mobile.
 - r49: The drawer holds Servers, Proxies, and Settings.
 - r50: The drawer also holds the version and update-available control.
 - r51: The drawer also holds the theme toggle and sign out.
+- r52: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -59,3 +59,4 @@ actions on mobile.
 - r55: Tapping the backdrop closes the drawer.
 - r56: Body scroll is locked while the drawer is open.
 - r57: Selecting a destination closes the drawer and navigates.
+- r58: The drawer slides in from the left edge.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -33,3 +33,4 @@ actions on mobile.
 - r29: Each row honors the 44px minimum touch target.
 - r30: The drawer sits above the bottom bar and below modal dialogs.
 - r31: The update control opens the progress dialog and closes the drawer.
+- r32: The More tab in the bottom bar opens the overflow drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -23,3 +23,4 @@ actions on mobile.
 - r19: The drawer also holds the theme toggle and sign out.
 - r20: It reuses SECONDARY_NAV from the shared nav module.
 - r21: It reuses the shell sign-out, theme, version, and update handlers.
+- r22: Escape closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -79,3 +79,4 @@ actions on mobile.
 - r75: The slide animation is disabled under prefers-reduced-motion.
 - r76: The panel pads around the safe-area insets.
 - r77: Each row honors the 44px minimum touch target.
+- r78: The drawer sits above the bottom bar and below modal dialogs.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -65,3 +65,4 @@ actions on mobile.
 - r61: Each row honors the 44px minimum touch target.
 - r62: The drawer sits above the bottom bar and below modal dialogs.
 - r63: The update control opens the progress dialog and closes the drawer.
+- r64: The More tab in the bottom bar opens the overflow drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -18,3 +18,4 @@ actions on mobile.
 - r14: The drawer sits above the bottom bar and below modal dialogs.
 - r15: The update control opens the progress dialog and closes the drawer.
 - r16: The More tab in the bottom bar opens the overflow drawer.
+- r17: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -82,3 +82,4 @@ actions on mobile.
 - r78: The drawer sits above the bottom bar and below modal dialogs.
 - r79: The update control opens the progress dialog and closes the drawer.
 - r80: The More tab in the bottom bar opens the overflow drawer.
+- r81: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -28,3 +28,4 @@ actions on mobile.
 - r24: Body scroll is locked while the drawer is open.
 - r25: Selecting a destination closes the drawer and navigates.
 - r26: The drawer slides in from the left edge.
+- r27: The slide animation is disabled under prefers-reduced-motion.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -76,3 +76,4 @@ actions on mobile.
 - r72: Body scroll is locked while the drawer is open.
 - r73: Selecting a destination closes the drawer and navigates.
 - r74: The drawer slides in from the left edge.
+- r75: The slide animation is disabled under prefers-reduced-motion.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -27,3 +27,4 @@ actions on mobile.
 - r23: Tapping the backdrop closes the drawer.
 - r24: Body scroll is locked while the drawer is open.
 - r25: Selecting a destination closes the drawer and navigates.
+- r26: The drawer slides in from the left edge.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -67,3 +67,4 @@ actions on mobile.
 - r63: The update control opens the progress dialog and closes the drawer.
 - r64: The More tab in the bottom bar opens the overflow drawer.
 - r65: The drawer holds Servers, Proxies, and Settings.
+- r66: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -58,3 +58,4 @@ actions on mobile.
 - r54: Escape closes the drawer.
 - r55: Tapping the backdrop closes the drawer.
 - r56: Body scroll is locked while the drawer is open.
+- r57: Selecting a destination closes the drawer and navigates.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -5,3 +5,4 @@ actions on mobile.
 - r1: The drawer holds Servers, Proxies, and Settings.
 - r2: The drawer also holds the version and update-available control.
 - r3: The drawer also holds the theme toggle and sign out.
+- r4: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -39,3 +39,4 @@ actions on mobile.
 - r35: The drawer also holds the theme toggle and sign out.
 - r36: It reuses SECONDARY_NAV from the shared nav module.
 - r37: It reuses the shell sign-out, theme, version, and update handlers.
+- r38: Escape closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -98,3 +98,4 @@ actions on mobile.
 - r94: The drawer sits above the bottom bar and below modal dialogs.
 - r95: The update control opens the progress dialog and closes the drawer.
 - r96: The More tab in the bottom bar opens the overflow drawer.
+- r97: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -36,3 +36,4 @@ actions on mobile.
 - r32: The More tab in the bottom bar opens the overflow drawer.
 - r33: The drawer holds Servers, Proxies, and Settings.
 - r34: The drawer also holds the version and update-available control.
+- r35: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -64,3 +64,4 @@ actions on mobile.
 - r60: The panel pads around the safe-area insets.
 - r61: Each row honors the 44px minimum touch target.
 - r62: The drawer sits above the bottom bar and below modal dialogs.
+- r63: The update control opens the progress dialog and closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -94,3 +94,4 @@ actions on mobile.
 - r90: The drawer slides in from the left edge.
 - r91: The slide animation is disabled under prefers-reduced-motion.
 - r92: The panel pads around the safe-area insets.
+- r93: Each row honors the 44px minimum touch target.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -16,3 +16,4 @@ actions on mobile.
 - r12: The panel pads around the safe-area insets.
 - r13: Each row honors the 44px minimum touch target.
 - r14: The drawer sits above the bottom bar and below modal dialogs.
+- r15: The update control opens the progress dialog and closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -37,3 +37,4 @@ actions on mobile.
 - r33: The drawer holds Servers, Proxies, and Settings.
 - r34: The drawer also holds the version and update-available control.
 - r35: The drawer also holds the theme toggle and sign out.
+- r36: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -35,3 +35,4 @@ actions on mobile.
 - r31: The update control opens the progress dialog and closes the drawer.
 - r32: The More tab in the bottom bar opens the overflow drawer.
 - r33: The drawer holds Servers, Proxies, and Settings.
+- r34: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -88,3 +88,4 @@ actions on mobile.
 - r84: It reuses SECONDARY_NAV from the shared nav module.
 - r85: It reuses the shell sign-out, theme, version, and update handlers.
 - r86: Escape closes the drawer.
+- r87: Tapping the backdrop closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -22,3 +22,4 @@ actions on mobile.
 - r18: The drawer also holds the version and update-available control.
 - r19: The drawer also holds the theme toggle and sign out.
 - r20: It reuses SECONDARY_NAV from the shared nav module.
+- r21: It reuses the shell sign-out, theme, version, and update handlers.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -31,3 +31,4 @@ actions on mobile.
 - r27: The slide animation is disabled under prefers-reduced-motion.
 - r28: The panel pads around the safe-area insets.
 - r29: Each row honors the 44px minimum touch target.
+- r30: The drawer sits above the bottom bar and below modal dialogs.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -54,3 +54,4 @@ actions on mobile.
 - r50: The drawer also holds the version and update-available control.
 - r51: The drawer also holds the theme toggle and sign out.
 - r52: It reuses SECONDARY_NAV from the shared nav module.
+- r53: It reuses the shell sign-out, theme, version, and update handlers.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -91,3 +91,4 @@ actions on mobile.
 - r87: Tapping the backdrop closes the drawer.
 - r88: Body scroll is locked while the drawer is open.
 - r89: Selecting a destination closes the drawer and navigates.
+- r90: The drawer slides in from the left edge.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -95,3 +95,4 @@ actions on mobile.
 - r91: The slide animation is disabled under prefers-reduced-motion.
 - r92: The panel pads around the safe-area insets.
 - r93: Each row honors the 44px minimum touch target.
+- r94: The drawer sits above the bottom bar and below modal dialogs.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -90,3 +90,4 @@ actions on mobile.
 - r86: Escape closes the drawer.
 - r87: Tapping the backdrop closes the drawer.
 - r88: Body scroll is locked while the drawer is open.
+- r89: Selecting a destination closes the drawer and navigates.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -93,3 +93,4 @@ actions on mobile.
 - r89: Selecting a destination closes the drawer and navigates.
 - r90: The drawer slides in from the left edge.
 - r91: The slide animation is disabled under prefers-reduced-motion.
+- r92: The panel pads around the safe-area insets.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -25,3 +25,4 @@ actions on mobile.
 - r21: It reuses the shell sign-out, theme, version, and update handlers.
 - r22: Escape closes the drawer.
 - r23: Tapping the backdrop closes the drawer.
+- r24: Body scroll is locked while the drawer is open.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -60,3 +60,4 @@ actions on mobile.
 - r56: Body scroll is locked while the drawer is open.
 - r57: Selecting a destination closes the drawer and navigates.
 - r58: The drawer slides in from the left edge.
+- r59: The slide animation is disabled under prefers-reduced-motion.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -6,3 +6,4 @@ actions on mobile.
 - r2: The drawer also holds the version and update-available control.
 - r3: The drawer also holds the theme toggle and sign out.
 - r4: It reuses SECONDARY_NAV from the shared nav module.
+- r5: It reuses the shell sign-out, theme, version, and update handlers.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -19,3 +19,4 @@ actions on mobile.
 - r15: The update control opens the progress dialog and closes the drawer.
 - r16: The More tab in the bottom bar opens the overflow drawer.
 - r17: The drawer holds Servers, Proxies, and Settings.
+- r18: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -45,3 +45,4 @@ actions on mobile.
 - r41: Selecting a destination closes the drawer and navigates.
 - r42: The drawer slides in from the left edge.
 - r43: The slide animation is disabled under prefers-reduced-motion.
+- r44: The panel pads around the safe-area insets.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -77,3 +77,4 @@ actions on mobile.
 - r73: Selecting a destination closes the drawer and navigates.
 - r74: The drawer slides in from the left edge.
 - r75: The slide animation is disabled under prefers-reduced-motion.
+- r76: The panel pads around the safe-area insets.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -14,3 +14,4 @@ actions on mobile.
 - r10: The drawer slides in from the left edge.
 - r11: The slide animation is disabled under prefers-reduced-motion.
 - r12: The panel pads around the safe-area insets.
+- r13: Each row honors the 44px minimum touch target.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -51,3 +51,4 @@ actions on mobile.
 - r47: The update control opens the progress dialog and closes the drawer.
 - r48: The More tab in the bottom bar opens the overflow drawer.
 - r49: The drawer holds Servers, Proxies, and Settings.
+- r50: The drawer also holds the version and update-available control.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -71,3 +71,4 @@ actions on mobile.
 - r67: The drawer also holds the theme toggle and sign out.
 - r68: It reuses SECONDARY_NAV from the shared nav module.
 - r69: It reuses the shell sign-out, theme, version, and update handlers.
+- r70: Escape closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -21,3 +21,4 @@ actions on mobile.
 - r17: The drawer holds Servers, Proxies, and Settings.
 - r18: The drawer also holds the version and update-available control.
 - r19: The drawer also holds the theme toggle and sign out.
+- r20: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -9,3 +9,4 @@ actions on mobile.
 - r5: It reuses the shell sign-out, theme, version, and update handlers.
 - r6: Escape closes the drawer.
 - r7: Tapping the backdrop closes the drawer.
+- r8: Body scroll is locked while the drawer is open.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -57,3 +57,4 @@ actions on mobile.
 - r53: It reuses the shell sign-out, theme, version, and update handlers.
 - r54: Escape closes the drawer.
 - r55: Tapping the backdrop closes the drawer.
+- r56: Body scroll is locked while the drawer is open.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -84,3 +84,4 @@ actions on mobile.
 - r80: The More tab in the bottom bar opens the overflow drawer.
 - r81: The drawer holds Servers, Proxies, and Settings.
 - r82: The drawer also holds the version and update-available control.
+- r83: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -66,3 +66,4 @@ actions on mobile.
 - r62: The drawer sits above the bottom bar and below modal dialogs.
 - r63: The update control opens the progress dialog and closes the drawer.
 - r64: The More tab in the bottom bar opens the overflow drawer.
+- r65: The drawer holds Servers, Proxies, and Settings.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -13,3 +13,4 @@ actions on mobile.
 - r9: Selecting a destination closes the drawer and navigates.
 - r10: The drawer slides in from the left edge.
 - r11: The slide animation is disabled under prefers-reduced-motion.
+- r12: The panel pads around the safe-area insets.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -92,3 +92,4 @@ actions on mobile.
 - r88: Body scroll is locked while the drawer is open.
 - r89: Selecting a destination closes the drawer and navigates.
 - r90: The drawer slides in from the left edge.
+- r91: The slide animation is disabled under prefers-reduced-motion.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -4,3 +4,4 @@ Notes on the slide-in drawer that holds secondary navigation and account
 actions on mobile.
 - r1: The drawer holds Servers, Proxies, and Settings.
 - r2: The drawer also holds the version and update-available control.
+- r3: The drawer also holds the theme toggle and sign out.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -62,3 +62,4 @@ actions on mobile.
 - r58: The drawer slides in from the left edge.
 - r59: The slide animation is disabled under prefers-reduced-motion.
 - r60: The panel pads around the safe-area insets.
+- r61: Each row honors the 44px minimum touch target.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -78,3 +78,4 @@ actions on mobile.
 - r74: The drawer slides in from the left edge.
 - r75: The slide animation is disabled under prefers-reduced-motion.
 - r76: The panel pads around the safe-area insets.
+- r77: Each row honors the 44px minimum touch target.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -46,3 +46,4 @@ actions on mobile.
 - r42: The drawer slides in from the left edge.
 - r43: The slide animation is disabled under prefers-reduced-motion.
 - r44: The panel pads around the safe-area insets.
+- r45: Each row honors the 44px minimum touch target.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -97,3 +97,4 @@ actions on mobile.
 - r93: Each row honors the 44px minimum touch target.
 - r94: The drawer sits above the bottom bar and below modal dialogs.
 - r95: The update control opens the progress dialog and closes the drawer.
+- r96: The More tab in the bottom bar opens the overflow drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -30,3 +30,4 @@ actions on mobile.
 - r26: The drawer slides in from the left edge.
 - r27: The slide animation is disabled under prefers-reduced-motion.
 - r28: The panel pads around the safe-area insets.
+- r29: Each row honors the 44px minimum touch target.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -17,3 +17,4 @@ actions on mobile.
 - r13: Each row honors the 44px minimum touch target.
 - r14: The drawer sits above the bottom bar and below modal dialogs.
 - r15: The update control opens the progress dialog and closes the drawer.
+- r16: The More tab in the bottom bar opens the overflow drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -75,3 +75,4 @@ actions on mobile.
 - r71: Tapping the backdrop closes the drawer.
 - r72: Body scroll is locked while the drawer is open.
 - r73: Selecting a destination closes the drawer and navigates.
+- r74: The drawer slides in from the left edge.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -80,3 +80,4 @@ actions on mobile.
 - r76: The panel pads around the safe-area insets.
 - r77: Each row honors the 44px minimum touch target.
 - r78: The drawer sits above the bottom bar and below modal dialogs.
+- r79: The update control opens the progress dialog and closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -85,3 +85,4 @@ actions on mobile.
 - r81: The drawer holds Servers, Proxies, and Settings.
 - r82: The drawer also holds the version and update-available control.
 - r83: The drawer also holds the theme toggle and sign out.
+- r84: It reuses SECONDARY_NAV from the shared nav module.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -40,3 +40,4 @@ actions on mobile.
 - r36: It reuses SECONDARY_NAV from the shared nav module.
 - r37: It reuses the shell sign-out, theme, version, and update handlers.
 - r38: Escape closes the drawer.
+- r39: Tapping the backdrop closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -56,3 +56,4 @@ actions on mobile.
 - r52: It reuses SECONDARY_NAV from the shared nav module.
 - r53: It reuses the shell sign-out, theme, version, and update handlers.
 - r54: Escape closes the drawer.
+- r55: Tapping the backdrop closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -74,3 +74,4 @@ actions on mobile.
 - r70: Escape closes the drawer.
 - r71: Tapping the backdrop closes the drawer.
 - r72: Body scroll is locked while the drawer is open.
+- r73: Selecting a destination closes the drawer and navigates.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -12,3 +12,4 @@ actions on mobile.
 - r8: Body scroll is locked while the drawer is open.
 - r9: Selecting a destination closes the drawer and navigates.
 - r10: The drawer slides in from the left edge.
+- r11: The slide animation is disabled under prefers-reduced-motion.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -89,3 +89,4 @@ actions on mobile.
 - r85: It reuses the shell sign-out, theme, version, and update handlers.
 - r86: Escape closes the drawer.
 - r87: Tapping the backdrop closes the drawer.
+- r88: Body scroll is locked while the drawer is open.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -41,3 +41,4 @@ actions on mobile.
 - r37: It reuses the shell sign-out, theme, version, and update handlers.
 - r38: Escape closes the drawer.
 - r39: Tapping the backdrop closes the drawer.
+- r40: Body scroll is locked while the drawer is open.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -7,3 +7,4 @@ actions on mobile.
 - r3: The drawer also holds the theme toggle and sign out.
 - r4: It reuses SECONDARY_NAV from the shared nav module.
 - r5: It reuses the shell sign-out, theme, version, and update handlers.
+- r6: Escape closes the drawer.

--- a/docs/mobile/drawer.md
+++ b/docs/mobile/drawer.md
@@ -38,3 +38,4 @@ actions on mobile.
 - r34: The drawer also holds the version and update-available control.
 - r35: The drawer also holds the theme toggle and sign out.
 - r36: It reuses SECONDARY_NAV from the shared nav module.
+- r37: It reuses the shell sign-out, theme, version, and update handlers.


### PR DESCRIPTION
Part of #92 (epic #102). Adds a More tab to the bottom bar that opens a slide-in drawer for the secondary destinations and account actions.

- `MobileDrawer`: Servers, Proxies, Settings (from `SECONDARY_NAV`), the version + update-available control, theme toggle, and sign out.
- Reuses the shell's existing sign-out/theme/version/update handlers.
- Escape closes, backdrop closes, body scroll locked while open, slide animation disabled under `prefers-reduced-motion`.
- Mobile only (the More trigger lives in the bottom bar, hidden on desktop).

Verified locally: typecheck, eslint, vitest (59 tests incl. MobileDrawer 5 + MobileNav 3), build. Browser-checked at 390x844: More opens the drawer with all destinations and actions.