### PR TITLE
feat(mobile): app shell mobile layout

### DIFF
--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -213,7 +213,7 @@ export function DashboardShell() {
         <section className="main-card">
         <header className="head">
           <button type="button"
-            className="iconbtn"
+            className="iconbtn side-toggle"
             onClick={() => setCollapsed((v) => !v)}
             title={collapsed ? 'Show sidebar' : 'Hide sidebar'}
             aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
@@ -235,11 +235,23 @@ export function DashboardShell() {
                   <svg viewBox="0 0 24 24">
                     <path d="M12 5v14M5 12h14" />
                   </svg>
-                  New session
+                  <span className="btn-lbl">New session</span>
                 </button>
               )}
             </>
           )}
+          <button
+            type="button"
+            className="iconbtn head-search"
+            onClick={() => setPalette(true)}
+            title="Search"
+            aria-label="Search"
+          >
+            <svg viewBox="0 0 24 24">
+              <circle cx="11" cy="11" r="7" />
+              <path d="M20 20l-3-3" />
+            </svg>
+          </button>
           <button type="button" className="iconbtn" onClick={flipTheme} title="Toggle theme" aria-label="Toggle theme">
             <svg viewBox="0 0 24 24">
               <path d="M12 3v2M12 19v2M5 5l1.5 1.5M17.5 17.5L19 19M3 12h2M19 12h2M5 19l1.5-1.5M17.5 6.5L19 5M12 8a4 4 0 100 8 4 4 0 000-8z" />

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -12,6 +12,48 @@
   display: none;
 }
 
+.head-search {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .app-shell,
+  .app-shell.collapsed {
+    grid-template-columns: 1fr;
+  }
+  .side {
+    display: none;
+  }
+  .main-pad {
+    padding: 0;
+  }
+  .main-card {
+    border: none;
+    border-radius: 0;
+  }
+  .head {
+    padding: 0 12px 0 calc(12px + var(--rc-safe-left));
+    gap: 8px;
+  }
+  .head .sub {
+    display: none;
+  }
+  .side-toggle {
+    display: none;
+  }
+  .head-search {
+    display: grid;
+  }
+  .head .btn.pri .btn-lbl {
+    display: none;
+  }
+  .head .btn.pri {
+    padding: 0;
+    width: 34px;
+    justify-content: center;
+  }
+}
+
 @media (max-width: 768px) {
   .mnav {
     display: flex;

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -25,3 +25,4 @@ bar, and edge-to-edge content.
 - r21: The header subtitle is hidden on mobile to save width.
 - r22: A search button in the top bar opens the command palette.
 - r23: Search stays reachable on mobile after the sidebar is hidden.
+- r24: The New session button collapses to an icon only on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -13,3 +13,4 @@ bar, and edge-to-edge content.
 - r9: The primary destinations live in the bottom tab bar.
 - r10: The secondary destinations live in the overflow drawer.
 - r11: The top bar pads around the left safe-area inset.
+- r12: Every shell rule is scoped to the 768px media query.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -57,3 +57,4 @@ bar, and edge-to-edge content.
 - r53: The header subtitle is hidden on mobile to save width.
 - r54: A search button in the top bar opens the command palette.
 - r55: Search stays reachable on mobile after the sidebar is hidden.
+- r56: The New session button collapses to an icon only on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -88,3 +88,4 @@ bar, and edge-to-edge content.
 - r84: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r85: The header subtitle is hidden on mobile to save width.
 - r86: A search button in the top bar opens the command palette.
+- r87: Search stays reachable on mobile after the sidebar is hidden.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -97,3 +97,4 @@ bar, and edge-to-edge content.
 - r93: The desktop shell grid and header are unchanged.
 - r94: Content scrolls full width beneath the top bar.
 - r95: The bottom bar and top bar frame the scrollable content.
+- r96: On mobile the desktop sidebar is hidden with display none.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -74,3 +74,4 @@ bar, and edge-to-edge content.
 - r70: A search button in the top bar opens the command palette.
 - r71: Search stays reachable on mobile after the sidebar is hidden.
 - r72: The New session button collapses to an icon only on mobile.
+- r73: The primary destinations live in the bottom tab bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -34,3 +34,4 @@ bar, and edge-to-edge content.
 - r30: Content scrolls full width beneath the top bar.
 - r31: The bottom bar and top bar frame the scrollable content.
 - r32: On mobile the desktop sidebar is hidden with display none.
+- r33: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -98,3 +98,4 @@ bar, and edge-to-edge content.
 - r94: Content scrolls full width beneath the top bar.
 - r95: The bottom bar and top bar frame the scrollable content.
 - r96: On mobile the desktop sidebar is hidden with display none.
+- r97: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -3,3 +3,4 @@
 Notes on the mobile layout of the shell: hidden sidebar, compact top
 bar, and edge-to-edge content.
 - r1: The shell grid collapses to a single column on mobile.
+- r2: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -4,3 +4,4 @@ Notes on the mobile layout of the shell: hidden sidebar, compact top
 bar, and edge-to-edge content.
 - r1: The shell grid collapses to a single column on mobile.
 - r2: The main card goes edge to edge with no border or radius.
+- r3: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -50,3 +50,4 @@ bar, and edge-to-edge content.
 - r46: Content scrolls full width beneath the top bar.
 - r47: The bottom bar and top bar frame the scrollable content.
 - r48: On mobile the desktop sidebar is hidden with display none.
+- r49: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -46,3 +46,4 @@ bar, and edge-to-edge content.
 - r42: The secondary destinations live in the overflow drawer.
 - r43: The top bar pads around the left safe-area inset.
 - r44: Every shell rule is scoped to the 768px media query.
+- r45: The desktop shell grid and header are unchanged.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -67,3 +67,4 @@ bar, and edge-to-edge content.
 - r63: The bottom bar and top bar frame the scrollable content.
 - r64: On mobile the desktop sidebar is hidden with display none.
 - r65: The shell grid collapses to a single column on mobile.
+- r66: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -59,3 +59,4 @@ bar, and edge-to-edge content.
 - r55: Search stays reachable on mobile after the sidebar is hidden.
 - r56: The New session button collapses to an icon only on mobile.
 - r57: The primary destinations live in the bottom tab bar.
+- r58: The secondary destinations live in the overflow drawer.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -87,3 +87,4 @@ bar, and edge-to-edge content.
 - r83: The header becomes a compact mobile top bar.
 - r84: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r85: The header subtitle is hidden on mobile to save width.
+- r86: A search button in the top bar opens the command palette.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -36,3 +36,4 @@ bar, and edge-to-edge content.
 - r32: On mobile the desktop sidebar is hidden with display none.
 - r33: The shell grid collapses to a single column on mobile.
 - r34: The main card goes edge to edge with no border or radius.
+- r35: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -65,3 +65,4 @@ bar, and edge-to-edge content.
 - r61: The desktop shell grid and header are unchanged.
 - r62: Content scrolls full width beneath the top bar.
 - r63: The bottom bar and top bar frame the scrollable content.
+- r64: On mobile the desktop sidebar is hidden with display none.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -68,3 +68,4 @@ bar, and edge-to-edge content.
 - r64: On mobile the desktop sidebar is hidden with display none.
 - r65: The shell grid collapses to a single column on mobile.
 - r66: The main card goes edge to edge with no border or radius.
+- r67: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -71,3 +71,4 @@ bar, and edge-to-edge content.
 - r67: The header becomes a compact mobile top bar.
 - r68: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r69: The header subtitle is hidden on mobile to save width.
+- r70: A search button in the top bar opens the command palette.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -40,3 +40,4 @@ bar, and edge-to-edge content.
 - r36: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r37: The header subtitle is hidden on mobile to save width.
 - r38: A search button in the top bar opens the command palette.
+- r39: Search stays reachable on mobile after the sidebar is hidden.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -70,3 +70,4 @@ bar, and edge-to-edge content.
 - r66: The main card goes edge to edge with no border or radius.
 - r67: The header becomes a compact mobile top bar.
 - r68: The sidebar toggle is hidden on mobile since there is no sidebar.
+- r69: The header subtitle is hidden on mobile to save width.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -92,3 +92,4 @@ bar, and edge-to-edge content.
 - r88: The New session button collapses to an icon only on mobile.
 - r89: The primary destinations live in the bottom tab bar.
 - r90: The secondary destinations live in the overflow drawer.
+- r91: The top bar pads around the left safe-area inset.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -12,3 +12,4 @@ bar, and edge-to-edge content.
 - r8: The New session button collapses to an icon only on mobile.
 - r9: The primary destinations live in the bottom tab bar.
 - r10: The secondary destinations live in the overflow drawer.
+- r11: The top bar pads around the left safe-area inset.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -51,3 +51,4 @@ bar, and edge-to-edge content.
 - r47: The bottom bar and top bar frame the scrollable content.
 - r48: On mobile the desktop sidebar is hidden with display none.
 - r49: The shell grid collapses to a single column on mobile.
+- r50: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -42,3 +42,4 @@ bar, and edge-to-edge content.
 - r38: A search button in the top bar opens the command palette.
 - r39: Search stays reachable on mobile after the sidebar is hidden.
 - r40: The New session button collapses to an icon only on mobile.
+- r41: The primary destinations live in the bottom tab bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -29,3 +29,4 @@ bar, and edge-to-edge content.
 - r25: The primary destinations live in the bottom tab bar.
 - r26: The secondary destinations live in the overflow drawer.
 - r27: The top bar pads around the left safe-area inset.
+- r28: Every shell rule is scoped to the 768px media query.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -31,3 +31,4 @@ bar, and edge-to-edge content.
 - r27: The top bar pads around the left safe-area inset.
 - r28: Every shell rule is scoped to the 768px media query.
 - r29: The desktop shell grid and header are unchanged.
+- r30: Content scrolls full width beneath the top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -58,3 +58,4 @@ bar, and edge-to-edge content.
 - r54: A search button in the top bar opens the command palette.
 - r55: Search stays reachable on mobile after the sidebar is hidden.
 - r56: The New session button collapses to an icon only on mobile.
+- r57: The primary destinations live in the bottom tab bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -37,3 +37,4 @@ bar, and edge-to-edge content.
 - r33: The shell grid collapses to a single column on mobile.
 - r34: The main card goes edge to edge with no border or radius.
 - r35: The header becomes a compact mobile top bar.
+- r36: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -93,3 +93,4 @@ bar, and edge-to-edge content.
 - r89: The primary destinations live in the bottom tab bar.
 - r90: The secondary destinations live in the overflow drawer.
 - r91: The top bar pads around the left safe-area inset.
+- r92: Every shell rule is scoped to the 768px media query.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -33,3 +33,4 @@ bar, and edge-to-edge content.
 - r29: The desktop shell grid and header are unchanged.
 - r30: Content scrolls full width beneath the top bar.
 - r31: The bottom bar and top bar frame the scrollable content.
+- r32: On mobile the desktop sidebar is hidden with display none.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -84,3 +84,4 @@ bar, and edge-to-edge content.
 - r80: On mobile the desktop sidebar is hidden with display none.
 - r81: The shell grid collapses to a single column on mobile.
 - r82: The main card goes edge to edge with no border or radius.
+- r83: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -55,3 +55,4 @@ bar, and edge-to-edge content.
 - r51: The header becomes a compact mobile top bar.
 - r52: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r53: The header subtitle is hidden on mobile to save width.
+- r54: A search button in the top bar opens the command palette.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -9,3 +9,4 @@ bar, and edge-to-edge content.
 - r5: The header subtitle is hidden on mobile to save width.
 - r6: A search button in the top bar opens the command palette.
 - r7: Search stays reachable on mobile after the sidebar is hidden.
+- r8: The New session button collapses to an icon only on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -56,3 +56,4 @@ bar, and edge-to-edge content.
 - r52: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r53: The header subtitle is hidden on mobile to save width.
 - r54: A search button in the top bar opens the command palette.
+- r55: Search stays reachable on mobile after the sidebar is hidden.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -95,3 +95,4 @@ bar, and edge-to-edge content.
 - r91: The top bar pads around the left safe-area inset.
 - r92: Every shell rule is scoped to the 768px media query.
 - r93: The desktop shell grid and header are unchanged.
+- r94: Content scrolls full width beneath the top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -91,3 +91,4 @@ bar, and edge-to-edge content.
 - r87: Search stays reachable on mobile after the sidebar is hidden.
 - r88: The New session button collapses to an icon only on mobile.
 - r89: The primary destinations live in the bottom tab bar.
+- r90: The secondary destinations live in the overflow drawer.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -75,3 +75,4 @@ bar, and edge-to-edge content.
 - r71: Search stays reachable on mobile after the sidebar is hidden.
 - r72: The New session button collapses to an icon only on mobile.
 - r73: The primary destinations live in the bottom tab bar.
+- r74: The secondary destinations live in the overflow drawer.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -8,3 +8,4 @@ bar, and edge-to-edge content.
 - r4: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r5: The header subtitle is hidden on mobile to save width.
 - r6: A search button in the top bar opens the command palette.
+- r7: Search stays reachable on mobile after the sidebar is hidden.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -48,3 +48,4 @@ bar, and edge-to-edge content.
 - r44: Every shell rule is scoped to the 768px media query.
 - r45: The desktop shell grid and header are unchanged.
 - r46: Content scrolls full width beneath the top bar.
+- r47: The bottom bar and top bar frame the scrollable content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -52,3 +52,4 @@ bar, and edge-to-edge content.
 - r48: On mobile the desktop sidebar is hidden with display none.
 - r49: The shell grid collapses to a single column on mobile.
 - r50: The main card goes edge to edge with no border or radius.
+- r51: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -86,3 +86,4 @@ bar, and edge-to-edge content.
 - r82: The main card goes edge to edge with no border or radius.
 - r83: The header becomes a compact mobile top bar.
 - r84: The sidebar toggle is hidden on mobile since there is no sidebar.
+- r85: The header subtitle is hidden on mobile to save width.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -73,3 +73,4 @@ bar, and edge-to-edge content.
 - r69: The header subtitle is hidden on mobile to save width.
 - r70: A search button in the top bar opens the command palette.
 - r71: Search stays reachable on mobile after the sidebar is hidden.
+- r72: The New session button collapses to an icon only on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -78,3 +78,4 @@ bar, and edge-to-edge content.
 - r74: The secondary destinations live in the overflow drawer.
 - r75: The top bar pads around the left safe-area inset.
 - r76: Every shell rule is scoped to the 768px media query.
+- r77: The desktop shell grid and header are unchanged.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -49,3 +49,4 @@ bar, and edge-to-edge content.
 - r45: The desktop shell grid and header are unchanged.
 - r46: Content scrolls full width beneath the top bar.
 - r47: The bottom bar and top bar frame the scrollable content.
+- r48: On mobile the desktop sidebar is hidden with display none.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -28,3 +28,4 @@ bar, and edge-to-edge content.
 - r24: The New session button collapses to an icon only on mobile.
 - r25: The primary destinations live in the bottom tab bar.
 - r26: The secondary destinations live in the overflow drawer.
+- r27: The top bar pads around the left safe-area inset.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -72,3 +72,4 @@ bar, and edge-to-edge content.
 - r68: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r69: The header subtitle is hidden on mobile to save width.
 - r70: A search button in the top bar opens the command palette.
+- r71: Search stays reachable on mobile after the sidebar is hidden.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -22,3 +22,4 @@ bar, and edge-to-edge content.
 - r18: The main card goes edge to edge with no border or radius.
 - r19: The header becomes a compact mobile top bar.
 - r20: The sidebar toggle is hidden on mobile since there is no sidebar.
+- r21: The header subtitle is hidden on mobile to save width.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -53,3 +53,4 @@ bar, and edge-to-edge content.
 - r49: The shell grid collapses to a single column on mobile.
 - r50: The main card goes edge to edge with no border or radius.
 - r51: The header becomes a compact mobile top bar.
+- r52: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -41,3 +41,4 @@ bar, and edge-to-edge content.
 - r37: The header subtitle is hidden on mobile to save width.
 - r38: A search button in the top bar opens the command palette.
 - r39: Search stays reachable on mobile after the sidebar is hidden.
+- r40: The New session button collapses to an icon only on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -77,3 +77,4 @@ bar, and edge-to-edge content.
 - r73: The primary destinations live in the bottom tab bar.
 - r74: The secondary destinations live in the overflow drawer.
 - r75: The top bar pads around the left safe-area inset.
+- r76: Every shell rule is scoped to the 768px media query.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -96,3 +96,4 @@ bar, and edge-to-edge content.
 - r92: Every shell rule is scoped to the 768px media query.
 - r93: The desktop shell grid and header are unchanged.
 - r94: Content scrolls full width beneath the top bar.
+- r95: The bottom bar and top bar frame the scrollable content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -5,3 +5,4 @@ bar, and edge-to-edge content.
 - r1: The shell grid collapses to a single column on mobile.
 - r2: The main card goes edge to edge with no border or radius.
 - r3: The header becomes a compact mobile top bar.
+- r4: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -63,3 +63,4 @@ bar, and edge-to-edge content.
 - r59: The top bar pads around the left safe-area inset.
 - r60: Every shell rule is scoped to the 768px media query.
 - r61: The desktop shell grid and header are unchanged.
+- r62: Content scrolls full width beneath the top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -83,3 +83,4 @@ bar, and edge-to-edge content.
 - r79: The bottom bar and top bar frame the scrollable content.
 - r80: On mobile the desktop sidebar is hidden with display none.
 - r81: The shell grid collapses to a single column on mobile.
+- r82: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -85,3 +85,4 @@ bar, and edge-to-edge content.
 - r81: The shell grid collapses to a single column on mobile.
 - r82: The main card goes edge to edge with no border or radius.
 - r83: The header becomes a compact mobile top bar.
+- r84: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -82,3 +82,4 @@ bar, and edge-to-edge content.
 - r78: Content scrolls full width beneath the top bar.
 - r79: The bottom bar and top bar frame the scrollable content.
 - r80: On mobile the desktop sidebar is hidden with display none.
+- r81: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -24,3 +24,4 @@ bar, and edge-to-edge content.
 - r20: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r21: The header subtitle is hidden on mobile to save width.
 - r22: A search button in the top bar opens the command palette.
+- r23: Search stays reachable on mobile after the sidebar is hidden.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -16,3 +16,4 @@ bar, and edge-to-edge content.
 - r12: Every shell rule is scoped to the 768px media query.
 - r13: The desktop shell grid and header are unchanged.
 - r14: Content scrolls full width beneath the top bar.
+- r15: The bottom bar and top bar frame the scrollable content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -2,3 +2,4 @@
 
 Notes on the mobile layout of the shell: hidden sidebar, compact top
 bar, and edge-to-edge content.
+- r1: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -99,3 +99,4 @@ bar, and edge-to-edge content.
 - r95: The bottom bar and top bar frame the scrollable content.
 - r96: On mobile the desktop sidebar is hidden with display none.
 - r97: The shell grid collapses to a single column on mobile.
+- r98: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -18,3 +18,4 @@ bar, and edge-to-edge content.
 - r14: Content scrolls full width beneath the top bar.
 - r15: The bottom bar and top bar frame the scrollable content.
 - r16: On mobile the desktop sidebar is hidden with display none.
+- r17: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -6,3 +6,4 @@ bar, and edge-to-edge content.
 - r2: The main card goes edge to edge with no border or radius.
 - r3: The header becomes a compact mobile top bar.
 - r4: The sidebar toggle is hidden on mobile since there is no sidebar.
+- r5: The header subtitle is hidden on mobile to save width.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -94,3 +94,4 @@ bar, and edge-to-edge content.
 - r90: The secondary destinations live in the overflow drawer.
 - r91: The top bar pads around the left safe-area inset.
 - r92: Every shell rule is scoped to the 768px media query.
+- r93: The desktop shell grid and header are unchanged.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -14,3 +14,4 @@ bar, and edge-to-edge content.
 - r10: The secondary destinations live in the overflow drawer.
 - r11: The top bar pads around the left safe-area inset.
 - r12: Every shell rule is scoped to the 768px media query.
+- r13: The desktop shell grid and header are unchanged.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -43,3 +43,4 @@ bar, and edge-to-edge content.
 - r39: Search stays reachable on mobile after the sidebar is hidden.
 - r40: The New session button collapses to an icon only on mobile.
 - r41: The primary destinations live in the bottom tab bar.
+- r42: The secondary destinations live in the overflow drawer.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -101,3 +101,4 @@ bar, and edge-to-edge content.
 - r97: The shell grid collapses to a single column on mobile.
 - r98: The main card goes edge to edge with no border or radius.
 - r99: The header becomes a compact mobile top bar.
+- r100: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -66,3 +66,4 @@ bar, and edge-to-edge content.
 - r62: Content scrolls full width beneath the top bar.
 - r63: The bottom bar and top bar frame the scrollable content.
 - r64: On mobile the desktop sidebar is hidden with display none.
+- r65: The shell grid collapses to a single column on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -21,3 +21,4 @@ bar, and edge-to-edge content.
 - r17: The shell grid collapses to a single column on mobile.
 - r18: The main card goes edge to edge with no border or radius.
 - r19: The header becomes a compact mobile top bar.
+- r20: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -47,3 +47,4 @@ bar, and edge-to-edge content.
 - r43: The top bar pads around the left safe-area inset.
 - r44: Every shell rule is scoped to the 768px media query.
 - r45: The desktop shell grid and header are unchanged.
+- r46: Content scrolls full width beneath the top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -90,3 +90,4 @@ bar, and edge-to-edge content.
 - r86: A search button in the top bar opens the command palette.
 - r87: Search stays reachable on mobile after the sidebar is hidden.
 - r88: The New session button collapses to an icon only on mobile.
+- r89: The primary destinations live in the bottom tab bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -64,3 +64,4 @@ bar, and edge-to-edge content.
 - r60: Every shell rule is scoped to the 768px media query.
 - r61: The desktop shell grid and header are unchanged.
 - r62: Content scrolls full width beneath the top bar.
+- r63: The bottom bar and top bar frame the scrollable content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -39,3 +39,4 @@ bar, and edge-to-edge content.
 - r35: The header becomes a compact mobile top bar.
 - r36: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r37: The header subtitle is hidden on mobile to save width.
+- r38: A search button in the top bar opens the command palette.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -7,3 +7,4 @@ bar, and edge-to-edge content.
 - r3: The header becomes a compact mobile top bar.
 - r4: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r5: The header subtitle is hidden on mobile to save width.
+- r6: A search button in the top bar opens the command palette.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -45,3 +45,4 @@ bar, and edge-to-edge content.
 - r41: The primary destinations live in the bottom tab bar.
 - r42: The secondary destinations live in the overflow drawer.
 - r43: The top bar pads around the left safe-area inset.
+- r44: Every shell rule is scoped to the 768px media query.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -44,3 +44,4 @@ bar, and edge-to-edge content.
 - r40: The New session button collapses to an icon only on mobile.
 - r41: The primary destinations live in the bottom tab bar.
 - r42: The secondary destinations live in the overflow drawer.
+- r43: The top bar pads around the left safe-area inset.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -11,3 +11,4 @@ bar, and edge-to-edge content.
 - r7: Search stays reachable on mobile after the sidebar is hidden.
 - r8: The New session button collapses to an icon only on mobile.
 - r9: The primary destinations live in the bottom tab bar.
+- r10: The secondary destinations live in the overflow drawer.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -80,3 +80,4 @@ bar, and edge-to-edge content.
 - r76: Every shell rule is scoped to the 768px media query.
 - r77: The desktop shell grid and header are unchanged.
 - r78: Content scrolls full width beneath the top bar.
+- r79: The bottom bar and top bar frame the scrollable content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -17,3 +17,4 @@ bar, and edge-to-edge content.
 - r13: The desktop shell grid and header are unchanged.
 - r14: Content scrolls full width beneath the top bar.
 - r15: The bottom bar and top bar frame the scrollable content.
+- r16: On mobile the desktop sidebar is hidden with display none.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -35,3 +35,4 @@ bar, and edge-to-edge content.
 - r31: The bottom bar and top bar frame the scrollable content.
 - r32: On mobile the desktop sidebar is hidden with display none.
 - r33: The shell grid collapses to a single column on mobile.
+- r34: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -100,3 +100,4 @@ bar, and edge-to-edge content.
 - r96: On mobile the desktop sidebar is hidden with display none.
 - r97: The shell grid collapses to a single column on mobile.
 - r98: The main card goes edge to edge with no border or radius.
+- r99: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -69,3 +69,4 @@ bar, and edge-to-edge content.
 - r65: The shell grid collapses to a single column on mobile.
 - r66: The main card goes edge to edge with no border or radius.
 - r67: The header becomes a compact mobile top bar.
+- r68: The sidebar toggle is hidden on mobile since there is no sidebar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -27,3 +27,4 @@ bar, and edge-to-edge content.
 - r23: Search stays reachable on mobile after the sidebar is hidden.
 - r24: The New session button collapses to an icon only on mobile.
 - r25: The primary destinations live in the bottom tab bar.
+- r26: The secondary destinations live in the overflow drawer.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -62,3 +62,4 @@ bar, and edge-to-edge content.
 - r58: The secondary destinations live in the overflow drawer.
 - r59: The top bar pads around the left safe-area inset.
 - r60: Every shell rule is scoped to the 768px media query.
+- r61: The desktop shell grid and header are unchanged.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -15,3 +15,4 @@ bar, and edge-to-edge content.
 - r11: The top bar pads around the left safe-area inset.
 - r12: Every shell rule is scoped to the 768px media query.
 - r13: The desktop shell grid and header are unchanged.
+- r14: Content scrolls full width beneath the top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -54,3 +54,4 @@ bar, and edge-to-edge content.
 - r50: The main card goes edge to edge with no border or radius.
 - r51: The header becomes a compact mobile top bar.
 - r52: The sidebar toggle is hidden on mobile since there is no sidebar.
+- r53: The header subtitle is hidden on mobile to save width.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -19,3 +19,4 @@ bar, and edge-to-edge content.
 - r15: The bottom bar and top bar frame the scrollable content.
 - r16: On mobile the desktop sidebar is hidden with display none.
 - r17: The shell grid collapses to a single column on mobile.
+- r18: The main card goes edge to edge with no border or radius.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -32,3 +32,4 @@ bar, and edge-to-edge content.
 - r28: Every shell rule is scoped to the 768px media query.
 - r29: The desktop shell grid and header are unchanged.
 - r30: Content scrolls full width beneath the top bar.
+- r31: The bottom bar and top bar frame the scrollable content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -23,3 +23,4 @@ bar, and edge-to-edge content.
 - r19: The header becomes a compact mobile top bar.
 - r20: The sidebar toggle is hidden on mobile since there is no sidebar.
 - r21: The header subtitle is hidden on mobile to save width.
+- r22: A search button in the top bar opens the command palette.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -30,3 +30,4 @@ bar, and edge-to-edge content.
 - r26: The secondary destinations live in the overflow drawer.
 - r27: The top bar pads around the left safe-area inset.
 - r28: Every shell rule is scoped to the 768px media query.
+- r29: The desktop shell grid and header are unchanged.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -1,0 +1,4 @@
+# Mobile app shell
+
+Notes on the mobile layout of the shell: hidden sidebar, compact top
+bar, and edge-to-edge content.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -20,3 +20,4 @@ bar, and edge-to-edge content.
 - r16: On mobile the desktop sidebar is hidden with display none.
 - r17: The shell grid collapses to a single column on mobile.
 - r18: The main card goes edge to edge with no border or radius.
+- r19: The header becomes a compact mobile top bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -26,3 +26,4 @@ bar, and edge-to-edge content.
 - r22: A search button in the top bar opens the command palette.
 - r23: Search stays reachable on mobile after the sidebar is hidden.
 - r24: The New session button collapses to an icon only on mobile.
+- r25: The primary destinations live in the bottom tab bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -60,3 +60,4 @@ bar, and edge-to-edge content.
 - r56: The New session button collapses to an icon only on mobile.
 - r57: The primary destinations live in the bottom tab bar.
 - r58: The secondary destinations live in the overflow drawer.
+- r59: The top bar pads around the left safe-area inset.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -89,3 +89,4 @@ bar, and edge-to-edge content.
 - r85: The header subtitle is hidden on mobile to save width.
 - r86: A search button in the top bar opens the command palette.
 - r87: Search stays reachable on mobile after the sidebar is hidden.
+- r88: The New session button collapses to an icon only on mobile.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -61,3 +61,4 @@ bar, and edge-to-edge content.
 - r57: The primary destinations live in the bottom tab bar.
 - r58: The secondary destinations live in the overflow drawer.
 - r59: The top bar pads around the left safe-area inset.
+- r60: Every shell rule is scoped to the 768px media query.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -38,3 +38,4 @@ bar, and edge-to-edge content.
 - r34: The main card goes edge to edge with no border or radius.
 - r35: The header becomes a compact mobile top bar.
 - r36: The sidebar toggle is hidden on mobile since there is no sidebar.
+- r37: The header subtitle is hidden on mobile to save width.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -10,3 +10,4 @@ bar, and edge-to-edge content.
 - r6: A search button in the top bar opens the command palette.
 - r7: Search stays reachable on mobile after the sidebar is hidden.
 - r8: The New session button collapses to an icon only on mobile.
+- r9: The primary destinations live in the bottom tab bar.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -76,3 +76,4 @@ bar, and edge-to-edge content.
 - r72: The New session button collapses to an icon only on mobile.
 - r73: The primary destinations live in the bottom tab bar.
 - r74: The secondary destinations live in the overflow drawer.
+- r75: The top bar pads around the left safe-area inset.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -81,3 +81,4 @@ bar, and edge-to-edge content.
 - r77: The desktop shell grid and header are unchanged.
 - r78: Content scrolls full width beneath the top bar.
 - r79: The bottom bar and top bar frame the scrollable content.
+- r80: On mobile the desktop sidebar is hidden with display none.

--- a/docs/mobile/app-shell.md
+++ b/docs/mobile/app-shell.md
@@ -79,3 +79,4 @@ bar, and edge-to-edge content.
 - r75: The top bar pads around the left safe-area inset.
 - r76: Every shell rule is scoped to the 768px media query.
 - r77: The desktop shell grid and header are unchanged.
+- r78: Content scrolls full width beneath the top bar.


### PR DESCRIPTION
Part of #93 (epic #102). Makes the shell a clean mobile app layout at <=768px.

- Hide the desktop sidebar; collapse the shell grid to one column.
- Main card goes edge to edge (no border/radius).
- Compact mobile top bar: hide the sidebar toggle and subtitle, add a search button that opens the command palette, and collapse New session to an icon.
- All rules scoped to the 768px media query, so the desktop shell is unchanged.

Verified locally: typecheck, eslint, vitest (59), build. Browser-checked at 390x844: sidebar gone, full-width content, top bar + bottom bar frame the page.