### PR TITLE
feat(mobile): Overview page responsive

### DIFF
--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -55,6 +55,24 @@
 }
 
 @media (max-width: 768px) {
+  .wrap {
+    padding: 14px;
+    gap: 14px;
+  }
+  .kpis {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .two {
+    grid-template-columns: 1fr;
+  }
+  .tbl {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}
+
+@media (max-width: 768px) {
   .mnav {
     display: flex;
     position: fixed;

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -6,3 +6,4 @@ Notes on how the Overview reflows on mobile.
 - r3: Wide tables scroll horizontally within their card.
 - r4: Horizontal table scroll keeps the page from scrolling sideways.
 - r5: Per-page card layouts replace the scroll fallback later.
+- r6: The severity bars keep their full width when stacked.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -40,3 +40,4 @@ Notes on how the Overview reflows on mobile.
 - r37: Per-page card layouts replace the scroll fallback later.
 - r38: The severity bars keep their full width when stacked.
 - r39: The cumulative findings chart fits the viewport width.
+- r40: KPI values stay legible at the narrower tile width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -94,3 +94,4 @@ Notes on how the Overview reflows on mobile.
 - r91: The desktop Overview grid is unchanged.
 - r92: Two column sections become one column on mobile.
 - r93: The wrap container drops its desktop padding on mobile.
+- r94: Cards remain full width with comfortable inner spacing.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -4,3 +4,4 @@ Notes on how the Overview reflows on mobile.
 - r1: The chart and severity cards stack to a single column.
 - r2: The page padding tightens on small screens.
 - r3: Wide tables scroll horizontally within their card.
+- r4: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -91,3 +91,4 @@ Notes on how the Overview reflows on mobile.
 - r88: KPI values stay legible at the narrower tile width.
 - r89: The Recent sessions table becomes cards once SessionRow is responsive.
 - r90: All Overview rules are scoped to the 768px media query.
+- r91: The desktop Overview grid is unchanged.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -98,3 +98,4 @@ Notes on how the Overview reflows on mobile.
 - r95: The layout reads top to bottom like a mobile dashboard.
 - r96: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r97: The chart and severity cards stack to a single column.
+- r98: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -3,3 +3,4 @@
 Notes on how the Overview reflows on mobile.
 - r1: The chart and severity cards stack to a single column.
 - r2: The page padding tightens on small screens.
+- r3: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -55,3 +55,4 @@ Notes on how the Overview reflows on mobile.
 - r52: Horizontal table scroll keeps the page from scrolling sideways.
 - r53: Per-page card layouts replace the scroll fallback later.
 - r54: The severity bars keep their full width when stacked.
+- r55: The cumulative findings chart fits the viewport width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -2,3 +2,4 @@
 
 Notes on how the Overview reflows on mobile.
 - r1: The chart and severity cards stack to a single column.
+- r2: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -89,3 +89,4 @@ Notes on how the Overview reflows on mobile.
 - r86: The severity bars keep their full width when stacked.
 - r87: The cumulative findings chart fits the viewport width.
 - r88: KPI values stay legible at the narrower tile width.
+- r89: The Recent sessions table becomes cards once SessionRow is responsive.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -66,3 +66,4 @@ Notes on how the Overview reflows on mobile.
 - r63: The layout reads top to bottom like a mobile dashboard.
 - r64: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r65: The chart and severity cards stack to a single column.
+- r66: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -50,3 +50,4 @@ Notes on how the Overview reflows on mobile.
 - r47: The layout reads top to bottom like a mobile dashboard.
 - r48: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r49: The chart and severity cards stack to a single column.
+- r50: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -72,3 +72,4 @@ Notes on how the Overview reflows on mobile.
 - r69: Per-page card layouts replace the scroll fallback later.
 - r70: The severity bars keep their full width when stacked.
 - r71: The cumulative findings chart fits the viewport width.
+- r72: KPI values stay legible at the narrower tile width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -61,3 +61,4 @@ Notes on how the Overview reflows on mobile.
 - r58: All Overview rules are scoped to the 768px media query.
 - r59: The desktop Overview grid is unchanged.
 - r60: Two column sections become one column on mobile.
+- r61: The wrap container drops its desktop padding on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -70,3 +70,4 @@ Notes on how the Overview reflows on mobile.
 - r67: Wide tables scroll horizontally within their card.
 - r68: Horizontal table scroll keeps the page from scrolling sideways.
 - r69: Per-page card layouts replace the scroll fallback later.
+- r70: The severity bars keep their full width when stacked.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -38,3 +38,4 @@ Notes on how the Overview reflows on mobile.
 - r35: Wide tables scroll horizontally within their card.
 - r36: Horizontal table scroll keeps the page from scrolling sideways.
 - r37: Per-page card layouts replace the scroll fallback later.
+- r38: The severity bars keep their full width when stacked.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -27,3 +27,4 @@ Notes on how the Overview reflows on mobile.
 - r24: KPI values stay legible at the narrower tile width.
 - r25: The Recent sessions table becomes cards once SessionRow is responsive.
 - r26: All Overview rules are scoped to the 768px media query.
+- r27: The desktop Overview grid is unchanged.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -13,3 +13,4 @@ Notes on how the Overview reflows on mobile.
 - r10: All Overview rules are scoped to the 768px media query.
 - r11: The desktop Overview grid is unchanged.
 - r12: Two column sections become one column on mobile.
+- r13: The wrap container drops its desktop padding on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -29,3 +29,4 @@ Notes on how the Overview reflows on mobile.
 - r26: All Overview rules are scoped to the 768px media query.
 - r27: The desktop Overview grid is unchanged.
 - r28: Two column sections become one column on mobile.
+- r29: The wrap container drops its desktop padding on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -30,3 +30,4 @@ Notes on how the Overview reflows on mobile.
 - r27: The desktop Overview grid is unchanged.
 - r28: Two column sections become one column on mobile.
 - r29: The wrap container drops its desktop padding on mobile.
+- r30: Cards remain full width with comfortable inner spacing.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -49,3 +49,4 @@ Notes on how the Overview reflows on mobile.
 - r46: Cards remain full width with comfortable inner spacing.
 - r47: The layout reads top to bottom like a mobile dashboard.
 - r48: KPI tiles collapse from four across to a 2x2 grid on mobile.
+- r49: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -41,3 +41,4 @@ Notes on how the Overview reflows on mobile.
 - r38: The severity bars keep their full width when stacked.
 - r39: The cumulative findings chart fits the viewport width.
 - r40: KPI values stay legible at the narrower tile width.
+- r41: The Recent sessions table becomes cards once SessionRow is responsive.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -97,3 +97,4 @@ Notes on how the Overview reflows on mobile.
 - r94: Cards remain full width with comfortable inner spacing.
 - r95: The layout reads top to bottom like a mobile dashboard.
 - r96: KPI tiles collapse from four across to a 2x2 grid on mobile.
+- r97: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -52,3 +52,4 @@ Notes on how the Overview reflows on mobile.
 - r49: The chart and severity cards stack to a single column.
 - r50: The page padding tightens on small screens.
 - r51: Wide tables scroll horizontally within their card.
+- r52: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -99,3 +99,4 @@ Notes on how the Overview reflows on mobile.
 - r96: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r97: The chart and severity cards stack to a single column.
 - r98: The page padding tightens on small screens.
+- r99: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -11,3 +11,4 @@ Notes on how the Overview reflows on mobile.
 - r8: KPI values stay legible at the narrower tile width.
 - r9: The Recent sessions table becomes cards once SessionRow is responsive.
 - r10: All Overview rules are scoped to the 768px media query.
+- r11: The desktop Overview grid is unchanged.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -68,3 +68,4 @@ Notes on how the Overview reflows on mobile.
 - r65: The chart and severity cards stack to a single column.
 - r66: The page padding tightens on small screens.
 - r67: Wide tables scroll horizontally within their card.
+- r68: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -36,3 +36,4 @@ Notes on how the Overview reflows on mobile.
 - r33: The chart and severity cards stack to a single column.
 - r34: The page padding tightens on small screens.
 - r35: Wide tables scroll horizontally within their card.
+- r36: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -1,0 +1,3 @@
+# Mobile Overview page
+
+Notes on how the Overview reflows on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -62,3 +62,4 @@ Notes on how the Overview reflows on mobile.
 - r59: The desktop Overview grid is unchanged.
 - r60: Two column sections become one column on mobile.
 - r61: The wrap container drops its desktop padding on mobile.
+- r62: Cards remain full width with comfortable inner spacing.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -17,3 +17,4 @@ Notes on how the Overview reflows on mobile.
 - r14: Cards remain full width with comfortable inner spacing.
 - r15: The layout reads top to bottom like a mobile dashboard.
 - r16: KPI tiles collapse from four across to a 2x2 grid on mobile.
+- r17: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -92,3 +92,4 @@ Notes on how the Overview reflows on mobile.
 - r89: The Recent sessions table becomes cards once SessionRow is responsive.
 - r90: All Overview rules are scoped to the 768px media query.
 - r91: The desktop Overview grid is unchanged.
+- r92: Two column sections become one column on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -9,3 +9,4 @@ Notes on how the Overview reflows on mobile.
 - r6: The severity bars keep their full width when stacked.
 - r7: The cumulative findings chart fits the viewport width.
 - r8: KPI values stay legible at the narrower tile width.
+- r9: The Recent sessions table becomes cards once SessionRow is responsive.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -44,3 +44,4 @@ Notes on how the Overview reflows on mobile.
 - r41: The Recent sessions table becomes cards once SessionRow is responsive.
 - r42: All Overview rules are scoped to the 768px media query.
 - r43: The desktop Overview grid is unchanged.
+- r44: Two column sections become one column on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -51,3 +51,4 @@ Notes on how the Overview reflows on mobile.
 - r48: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r49: The chart and severity cards stack to a single column.
 - r50: The page padding tightens on small screens.
+- r51: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -14,3 +14,4 @@ Notes on how the Overview reflows on mobile.
 - r11: The desktop Overview grid is unchanged.
 - r12: Two column sections become one column on mobile.
 - r13: The wrap container drops its desktop padding on mobile.
+- r14: Cards remain full width with comfortable inner spacing.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -5,3 +5,4 @@ Notes on how the Overview reflows on mobile.
 - r2: The page padding tightens on small screens.
 - r3: Wide tables scroll horizontally within their card.
 - r4: Horizontal table scroll keeps the page from scrolling sideways.
+- r5: Per-page card layouts replace the scroll fallback later.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -69,3 +69,4 @@ Notes on how the Overview reflows on mobile.
 - r66: The page padding tightens on small screens.
 - r67: Wide tables scroll horizontally within their card.
 - r68: Horizontal table scroll keeps the page from scrolling sideways.
+- r69: Per-page card layouts replace the scroll fallback later.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -48,3 +48,4 @@ Notes on how the Overview reflows on mobile.
 - r45: The wrap container drops its desktop padding on mobile.
 - r46: Cards remain full width with comfortable inner spacing.
 - r47: The layout reads top to bottom like a mobile dashboard.
+- r48: KPI tiles collapse from four across to a 2x2 grid on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -83,3 +83,4 @@ Notes on how the Overview reflows on mobile.
 - r80: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r81: The chart and severity cards stack to a single column.
 - r82: The page padding tightens on small screens.
+- r83: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -56,3 +56,4 @@ Notes on how the Overview reflows on mobile.
 - r53: Per-page card layouts replace the scroll fallback later.
 - r54: The severity bars keep their full width when stacked.
 - r55: The cumulative findings chart fits the viewport width.
+- r56: KPI values stay legible at the narrower tile width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -84,3 +84,4 @@ Notes on how the Overview reflows on mobile.
 - r81: The chart and severity cards stack to a single column.
 - r82: The page padding tightens on small screens.
 - r83: Wide tables scroll horizontally within their card.
+- r84: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -45,3 +45,4 @@ Notes on how the Overview reflows on mobile.
 - r42: All Overview rules are scoped to the 768px media query.
 - r43: The desktop Overview grid is unchanged.
 - r44: Two column sections become one column on mobile.
+- r45: The wrap container drops its desktop padding on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -93,3 +93,4 @@ Notes on how the Overview reflows on mobile.
 - r90: All Overview rules are scoped to the 768px media query.
 - r91: The desktop Overview grid is unchanged.
 - r92: Two column sections become one column on mobile.
+- r93: The wrap container drops its desktop padding on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -77,3 +77,4 @@ Notes on how the Overview reflows on mobile.
 - r74: All Overview rules are scoped to the 768px media query.
 - r75: The desktop Overview grid is unchanged.
 - r76: Two column sections become one column on mobile.
+- r77: The wrap container drops its desktop padding on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -20,3 +20,4 @@ Notes on how the Overview reflows on mobile.
 - r17: The chart and severity cards stack to a single column.
 - r18: The page padding tightens on small screens.
 - r19: Wide tables scroll horizontally within their card.
+- r20: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -74,3 +74,4 @@ Notes on how the Overview reflows on mobile.
 - r71: The cumulative findings chart fits the viewport width.
 - r72: KPI values stay legible at the narrower tile width.
 - r73: The Recent sessions table becomes cards once SessionRow is responsive.
+- r74: All Overview rules are scoped to the 768px media query.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -76,3 +76,4 @@ Notes on how the Overview reflows on mobile.
 - r73: The Recent sessions table becomes cards once SessionRow is responsive.
 - r74: All Overview rules are scoped to the 768px media query.
 - r75: The desktop Overview grid is unchanged.
+- r76: Two column sections become one column on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -28,3 +28,4 @@ Notes on how the Overview reflows on mobile.
 - r25: The Recent sessions table becomes cards once SessionRow is responsive.
 - r26: All Overview rules are scoped to the 768px media query.
 - r27: The desktop Overview grid is unchanged.
+- r28: Two column sections become one column on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -32,3 +32,4 @@ Notes on how the Overview reflows on mobile.
 - r29: The wrap container drops its desktop padding on mobile.
 - r30: Cards remain full width with comfortable inner spacing.
 - r31: The layout reads top to bottom like a mobile dashboard.
+- r32: KPI tiles collapse from four across to a 2x2 grid on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -88,3 +88,4 @@ Notes on how the Overview reflows on mobile.
 - r85: Per-page card layouts replace the scroll fallback later.
 - r86: The severity bars keep their full width when stacked.
 - r87: The cumulative findings chart fits the viewport width.
+- r88: KPI values stay legible at the narrower tile width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -54,3 +54,4 @@ Notes on how the Overview reflows on mobile.
 - r51: Wide tables scroll horizontally within their card.
 - r52: Horizontal table scroll keeps the page from scrolling sideways.
 - r53: Per-page card layouts replace the scroll fallback later.
+- r54: The severity bars keep their full width when stacked.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -85,3 +85,4 @@ Notes on how the Overview reflows on mobile.
 - r82: The page padding tightens on small screens.
 - r83: Wide tables scroll horizontally within their card.
 - r84: Horizontal table scroll keeps the page from scrolling sideways.
+- r85: Per-page card layouts replace the scroll fallback later.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -57,3 +57,4 @@ Notes on how the Overview reflows on mobile.
 - r54: The severity bars keep their full width when stacked.
 - r55: The cumulative findings chart fits the viewport width.
 - r56: KPI values stay legible at the narrower tile width.
+- r57: The Recent sessions table becomes cards once SessionRow is responsive.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -47,3 +47,4 @@ Notes on how the Overview reflows on mobile.
 - r44: Two column sections become one column on mobile.
 - r45: The wrap container drops its desktop padding on mobile.
 - r46: Cards remain full width with comfortable inner spacing.
+- r47: The layout reads top to bottom like a mobile dashboard.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -65,3 +65,4 @@ Notes on how the Overview reflows on mobile.
 - r62: Cards remain full width with comfortable inner spacing.
 - r63: The layout reads top to bottom like a mobile dashboard.
 - r64: KPI tiles collapse from four across to a 2x2 grid on mobile.
+- r65: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -33,3 +33,4 @@ Notes on how the Overview reflows on mobile.
 - r30: Cards remain full width with comfortable inner spacing.
 - r31: The layout reads top to bottom like a mobile dashboard.
 - r32: KPI tiles collapse from four across to a 2x2 grid on mobile.
+- r33: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -53,3 +53,4 @@ Notes on how the Overview reflows on mobile.
 - r50: The page padding tightens on small screens.
 - r51: Wide tables scroll horizontally within their card.
 - r52: Horizontal table scroll keeps the page from scrolling sideways.
+- r53: Per-page card layouts replace the scroll fallback later.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -82,3 +82,4 @@ Notes on how the Overview reflows on mobile.
 - r79: The layout reads top to bottom like a mobile dashboard.
 - r80: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r81: The chart and severity cards stack to a single column.
+- r82: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -46,3 +46,4 @@ Notes on how the Overview reflows on mobile.
 - r43: The desktop Overview grid is unchanged.
 - r44: Two column sections become one column on mobile.
 - r45: The wrap container drops its desktop padding on mobile.
+- r46: Cards remain full width with comfortable inner spacing.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -81,3 +81,4 @@ Notes on how the Overview reflows on mobile.
 - r78: Cards remain full width with comfortable inner spacing.
 - r79: The layout reads top to bottom like a mobile dashboard.
 - r80: KPI tiles collapse from four across to a 2x2 grid on mobile.
+- r81: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -10,3 +10,4 @@ Notes on how the Overview reflows on mobile.
 - r7: The cumulative findings chart fits the viewport width.
 - r8: KPI values stay legible at the narrower tile width.
 - r9: The Recent sessions table becomes cards once SessionRow is responsive.
+- r10: All Overview rules are scoped to the 768px media query.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -7,3 +7,4 @@ Notes on how the Overview reflows on mobile.
 - r4: Horizontal table scroll keeps the page from scrolling sideways.
 - r5: Per-page card layouts replace the scroll fallback later.
 - r6: The severity bars keep their full width when stacked.
+- r7: The cumulative findings chart fits the viewport width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -87,3 +87,4 @@ Notes on how the Overview reflows on mobile.
 - r84: Horizontal table scroll keeps the page from scrolling sideways.
 - r85: Per-page card layouts replace the scroll fallback later.
 - r86: The severity bars keep their full width when stacked.
+- r87: The cumulative findings chart fits the viewport width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -26,3 +26,4 @@ Notes on how the Overview reflows on mobile.
 - r23: The cumulative findings chart fits the viewport width.
 - r24: KPI values stay legible at the narrower tile width.
 - r25: The Recent sessions table becomes cards once SessionRow is responsive.
+- r26: All Overview rules are scoped to the 768px media query.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -23,3 +23,4 @@ Notes on how the Overview reflows on mobile.
 - r20: Horizontal table scroll keeps the page from scrolling sideways.
 - r21: Per-page card layouts replace the scroll fallback later.
 - r22: The severity bars keep their full width when stacked.
+- r23: The cumulative findings chart fits the viewport width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -16,3 +16,4 @@ Notes on how the Overview reflows on mobile.
 - r13: The wrap container drops its desktop padding on mobile.
 - r14: Cards remain full width with comfortable inner spacing.
 - r15: The layout reads top to bottom like a mobile dashboard.
+- r16: KPI tiles collapse from four across to a 2x2 grid on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -63,3 +63,4 @@ Notes on how the Overview reflows on mobile.
 - r60: Two column sections become one column on mobile.
 - r61: The wrap container drops its desktop padding on mobile.
 - r62: Cards remain full width with comfortable inner spacing.
+- r63: The layout reads top to bottom like a mobile dashboard.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -75,3 +75,4 @@ Notes on how the Overview reflows on mobile.
 - r72: KPI values stay legible at the narrower tile width.
 - r73: The Recent sessions table becomes cards once SessionRow is responsive.
 - r74: All Overview rules are scoped to the 768px media query.
+- r75: The desktop Overview grid is unchanged.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -12,3 +12,4 @@ Notes on how the Overview reflows on mobile.
 - r9: The Recent sessions table becomes cards once SessionRow is responsive.
 - r10: All Overview rules are scoped to the 768px media query.
 - r11: The desktop Overview grid is unchanged.
+- r12: Two column sections become one column on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -78,3 +78,4 @@ Notes on how the Overview reflows on mobile.
 - r75: The desktop Overview grid is unchanged.
 - r76: Two column sections become one column on mobile.
 - r77: The wrap container drops its desktop padding on mobile.
+- r78: Cards remain full width with comfortable inner spacing.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -95,3 +95,4 @@ Notes on how the Overview reflows on mobile.
 - r92: Two column sections become one column on mobile.
 - r93: The wrap container drops its desktop padding on mobile.
 - r94: Cards remain full width with comfortable inner spacing.
+- r95: The layout reads top to bottom like a mobile dashboard.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -60,3 +60,4 @@ Notes on how the Overview reflows on mobile.
 - r57: The Recent sessions table becomes cards once SessionRow is responsive.
 - r58: All Overview rules are scoped to the 768px media query.
 - r59: The desktop Overview grid is unchanged.
+- r60: Two column sections become one column on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -43,3 +43,4 @@ Notes on how the Overview reflows on mobile.
 - r40: KPI values stay legible at the narrower tile width.
 - r41: The Recent sessions table becomes cards once SessionRow is responsive.
 - r42: All Overview rules are scoped to the 768px media query.
+- r43: The desktop Overview grid is unchanged.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -31,3 +31,4 @@ Notes on how the Overview reflows on mobile.
 - r28: Two column sections become one column on mobile.
 - r29: The wrap container drops its desktop padding on mobile.
 - r30: Cards remain full width with comfortable inner spacing.
+- r31: The layout reads top to bottom like a mobile dashboard.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -80,3 +80,4 @@ Notes on how the Overview reflows on mobile.
 - r77: The wrap container drops its desktop padding on mobile.
 - r78: Cards remain full width with comfortable inner spacing.
 - r79: The layout reads top to bottom like a mobile dashboard.
+- r80: KPI tiles collapse from four across to a 2x2 grid on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -22,3 +22,4 @@ Notes on how the Overview reflows on mobile.
 - r19: Wide tables scroll horizontally within their card.
 - r20: Horizontal table scroll keeps the page from scrolling sideways.
 - r21: Per-page card layouts replace the scroll fallback later.
+- r22: The severity bars keep their full width when stacked.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -86,3 +86,4 @@ Notes on how the Overview reflows on mobile.
 - r83: Wide tables scroll horizontally within their card.
 - r84: Horizontal table scroll keeps the page from scrolling sideways.
 - r85: Per-page card layouts replace the scroll fallback later.
+- r86: The severity bars keep their full width when stacked.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -73,3 +73,4 @@ Notes on how the Overview reflows on mobile.
 - r70: The severity bars keep their full width when stacked.
 - r71: The cumulative findings chart fits the viewport width.
 - r72: KPI values stay legible at the narrower tile width.
+- r73: The Recent sessions table becomes cards once SessionRow is responsive.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -71,3 +71,4 @@ Notes on how the Overview reflows on mobile.
 - r68: Horizontal table scroll keeps the page from scrolling sideways.
 - r69: Per-page card layouts replace the scroll fallback later.
 - r70: The severity bars keep their full width when stacked.
+- r71: The cumulative findings chart fits the viewport width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -21,3 +21,4 @@ Notes on how the Overview reflows on mobile.
 - r18: The page padding tightens on small screens.
 - r19: Wide tables scroll horizontally within their card.
 - r20: Horizontal table scroll keeps the page from scrolling sideways.
+- r21: Per-page card layouts replace the scroll fallback later.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -8,3 +8,4 @@ Notes on how the Overview reflows on mobile.
 - r5: Per-page card layouts replace the scroll fallback later.
 - r6: The severity bars keep their full width when stacked.
 - r7: The cumulative findings chart fits the viewport width.
+- r8: KPI values stay legible at the narrower tile width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -58,3 +58,4 @@ Notes on how the Overview reflows on mobile.
 - r55: The cumulative findings chart fits the viewport width.
 - r56: KPI values stay legible at the narrower tile width.
 - r57: The Recent sessions table becomes cards once SessionRow is responsive.
+- r58: All Overview rules are scoped to the 768px media query.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -79,3 +79,4 @@ Notes on how the Overview reflows on mobile.
 - r76: Two column sections become one column on mobile.
 - r77: The wrap container drops its desktop padding on mobile.
 - r78: Cards remain full width with comfortable inner spacing.
+- r79: The layout reads top to bottom like a mobile dashboard.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -1,3 +1,4 @@
 # Mobile Overview page
 
 Notes on how the Overview reflows on mobile.
+- r1: The chart and severity cards stack to a single column.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -37,3 +37,4 @@ Notes on how the Overview reflows on mobile.
 - r34: The page padding tightens on small screens.
 - r35: Wide tables scroll horizontally within their card.
 - r36: Horizontal table scroll keeps the page from scrolling sideways.
+- r37: Per-page card layouts replace the scroll fallback later.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -90,3 +90,4 @@ Notes on how the Overview reflows on mobile.
 - r87: The cumulative findings chart fits the viewport width.
 - r88: KPI values stay legible at the narrower tile width.
 - r89: The Recent sessions table becomes cards once SessionRow is responsive.
+- r90: All Overview rules are scoped to the 768px media query.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -24,3 +24,4 @@ Notes on how the Overview reflows on mobile.
 - r21: Per-page card layouts replace the scroll fallback later.
 - r22: The severity bars keep their full width when stacked.
 - r23: The cumulative findings chart fits the viewport width.
+- r24: KPI values stay legible at the narrower tile width.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -59,3 +59,4 @@ Notes on how the Overview reflows on mobile.
 - r56: KPI values stay legible at the narrower tile width.
 - r57: The Recent sessions table becomes cards once SessionRow is responsive.
 - r58: All Overview rules are scoped to the 768px media query.
+- r59: The desktop Overview grid is unchanged.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -96,3 +96,4 @@ Notes on how the Overview reflows on mobile.
 - r93: The wrap container drops its desktop padding on mobile.
 - r94: Cards remain full width with comfortable inner spacing.
 - r95: The layout reads top to bottom like a mobile dashboard.
+- r96: KPI tiles collapse from four across to a 2x2 grid on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -35,3 +35,4 @@ Notes on how the Overview reflows on mobile.
 - r32: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r33: The chart and severity cards stack to a single column.
 - r34: The page padding tightens on small screens.
+- r35: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -34,3 +34,4 @@ Notes on how the Overview reflows on mobile.
 - r31: The layout reads top to bottom like a mobile dashboard.
 - r32: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r33: The chart and severity cards stack to a single column.
+- r34: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -42,3 +42,4 @@ Notes on how the Overview reflows on mobile.
 - r39: The cumulative findings chart fits the viewport width.
 - r40: KPI values stay legible at the narrower tile width.
 - r41: The Recent sessions table becomes cards once SessionRow is responsive.
+- r42: All Overview rules are scoped to the 768px media query.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -15,3 +15,4 @@ Notes on how the Overview reflows on mobile.
 - r12: Two column sections become one column on mobile.
 - r13: The wrap container drops its desktop padding on mobile.
 - r14: Cards remain full width with comfortable inner spacing.
+- r15: The layout reads top to bottom like a mobile dashboard.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -100,3 +100,4 @@ Notes on how the Overview reflows on mobile.
 - r97: The chart and severity cards stack to a single column.
 - r98: The page padding tightens on small screens.
 - r99: Wide tables scroll horizontally within their card.
+- r100: Horizontal table scroll keeps the page from scrolling sideways.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -18,3 +18,4 @@ Notes on how the Overview reflows on mobile.
 - r15: The layout reads top to bottom like a mobile dashboard.
 - r16: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r17: The chart and severity cards stack to a single column.
+- r18: The page padding tightens on small screens.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -19,3 +19,4 @@ Notes on how the Overview reflows on mobile.
 - r16: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r17: The chart and severity cards stack to a single column.
 - r18: The page padding tightens on small screens.
+- r19: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -67,3 +67,4 @@ Notes on how the Overview reflows on mobile.
 - r64: KPI tiles collapse from four across to a 2x2 grid on mobile.
 - r65: The chart and severity cards stack to a single column.
 - r66: The page padding tightens on small screens.
+- r67: Wide tables scroll horizontally within their card.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -25,3 +25,4 @@ Notes on how the Overview reflows on mobile.
 - r22: The severity bars keep their full width when stacked.
 - r23: The cumulative findings chart fits the viewport width.
 - r24: KPI values stay legible at the narrower tile width.
+- r25: The Recent sessions table becomes cards once SessionRow is responsive.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -64,3 +64,4 @@ Notes on how the Overview reflows on mobile.
 - r61: The wrap container drops its desktop padding on mobile.
 - r62: Cards remain full width with comfortable inner spacing.
 - r63: The layout reads top to bottom like a mobile dashboard.
+- r64: KPI tiles collapse from four across to a 2x2 grid on mobile.

--- a/docs/mobile/overview.md
+++ b/docs/mobile/overview.md
@@ -39,3 +39,4 @@ Notes on how the Overview reflows on mobile.
 - r36: Horizontal table scroll keeps the page from scrolling sideways.
 - r37: Per-page card layouts replace the scroll fallback later.
 - r38: The severity bars keep their full width when stacked.
+- r39: The cumulative findings chart fits the viewport width.


### PR DESCRIPTION
Part of #94 (epic #102). Reflows the Overview for mobile.

- KPI tiles: four across becomes a 2x2 grid.
- The chart and severity cards stack to one column.
- Tighter page padding.
- Wide tables scroll horizontally within their card so the page never scrolls sideways (per-page card layouts replace this later).

All scoped to the 768px media query; desktop Overview unchanged.

Verified locally: typecheck, eslint, vitest (59), build. Browser-checked at 390x844.