### PR TITLE
feat(mobile): Sessions list and New Session page

### DIFF
--- a/apps/web/src/app/pages/OverviewPage.tsx
+++ b/apps/web/src/app/pages/OverviewPage.tsx
@@ -126,7 +126,7 @@ export function OverviewPage() {
           </button>
         </div>
         <div className="card-b" style={{ padding: '12px 2px 4px' }}>
-          <table className="tbl">
+          <table className="tbl tbl-cards">
             <thead>
               <tr>
                 <th>Session</th>

--- a/apps/web/src/app/pages/SessionsPage.tsx
+++ b/apps/web/src/app/pages/SessionsPage.tsx
@@ -40,7 +40,7 @@ export function SessionsPage() {
       </div>
       <div className="card">
         <div className="card-b" style={{ padding: '12px 2px 4px' }}>
-          <table className="tbl">
+          <table className="tbl tbl-cards">
             <thead>
               <tr>
                 <th>Session</th>

--- a/apps/web/src/app/pages/shared.tsx
+++ b/apps/web/src/app/pages/shared.tsx
@@ -32,24 +32,28 @@ export function SessionRow({ s, onOpen }: { s: Session; onOpen: () => void }) {
           </span>
         </div>
       </td>
-      <td>
+      <td data-label="Type">
         <span className="kind" style={{ textTransform: 'capitalize' }}>
           {s.kind}
         </span>
       </td>
-      <td>
+      <td data-label="Status">
         <span className={`status${s.status === 'active' ? ' live' : ''}`} style={{ textTransform: 'capitalize' }}>
           {s.status}
         </span>
       </td>
-      <td>
+      <td data-label="Findings">
         <div className="sevbar">{sevBar(s.severityCounts)}</div>
       </td>
-      <td className="meta mono">{s.targets.length || '—'}</td>
-      <td>
+      <td className="meta mono" data-label="Targets">
+        {s.targets.length || '—'}
+      </td>
+      <td data-label="Model">
         <span className="model">{s.model ?? '—'}</span>
       </td>
-      <td className="tright meta">{timeAgo(s.createdAt)}</td>
+      <td className="tright meta" data-label="Last active">
+        {timeAgo(s.createdAt)}
+      </td>
     </tr>
   );
 }

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -73,6 +73,61 @@
 }
 
 @media (max-width: 768px) {
+  .split {
+    grid-template-columns: 1fr;
+  }
+  .grid2 {
+    grid-template-columns: 1fr;
+  }
+  .chatcard {
+    height: 420px;
+  }
+  .filters {
+    flex-wrap: wrap;
+  }
+  .tbl-cards {
+    overflow-x: visible;
+    white-space: normal;
+  }
+  .tbl-cards thead {
+    display: none;
+  }
+  .tbl-cards tbody {
+    display: block;
+  }
+  .tbl-cards tr.row {
+    display: grid;
+    gap: 7px;
+    padding: 12px;
+    margin-bottom: 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--r);
+  }
+  .tbl-cards tr.row td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0;
+    border: none;
+  }
+  .tbl-cards tr.row td[data-label]::before {
+    content: attr(data-label);
+    color: var(--tx-3);
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .tbl-cards tr.row td:first-child {
+    padding-bottom: 8px;
+    margin-bottom: 2px;
+    border-bottom: 1px solid var(--line);
+  }
+  .tbl-cards tr.row td.tright {
+    text-align: left;
+  }
+}
+
+@media (max-width: 768px) {
   .mnav {
     display: flex;
     position: fixed;

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -45,3 +45,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r42: Paired form rows collapse from two columns to one on mobile.
 - r43: The planner chat card takes a shorter height on mobile.
 - r44: Form fields span the full width with comfortable spacing.
+- r45: The desktop tables and two column form are unchanged.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -18,3 +18,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r15: Cards read top to bottom like a mobile list.
 - r16: The Sessions list becomes a stacked card list on mobile.
 - r17: Each session renders as a card instead of a table row.
+- r18: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -39,3 +39,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r36: Overview reuses SessionRow so its recent sessions also become cards.
 - r37: The session name and client form the card title.
 - r38: Each remaining cell shows its label on the left and value on the right.
+- r39: The card layout overrides the horizontal scroll fallback.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -84,3 +84,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r81: Each session renders as a card instead of a table row.
 - r82: SessionRow cells carry data-label attributes for the card labels.
 - r83: The tbl-cards class opts a session table into the card layout.
+- r84: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -17,3 +17,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r14: All Sessions rules are scoped to the 768px media query.
 - r15: Cards read top to bottom like a mobile list.
 - r16: The Sessions list becomes a stacked card list on mobile.
+- r17: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -85,3 +85,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r82: SessionRow cells carry data-label attributes for the card labels.
 - r83: The tbl-cards class opts a session table into the card layout.
 - r84: Overview reuses SessionRow so its recent sessions also become cards.
+- r85: The session name and client form the card title.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -44,3 +44,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r41: New Session stacks the planner and the form to one column.
 - r42: Paired form rows collapse from two columns to one on mobile.
 - r43: The planner chat card takes a shorter height on mobile.
+- r44: Form fields span the full width with comfortable spacing.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -5,3 +5,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r2: SessionRow cells carry data-label attributes for the card labels.
 - r3: The tbl-cards class opts a session table into the card layout.
 - r4: Overview reuses SessionRow so its recent sessions also become cards.
+- r5: The session name and client form the card title.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -59,3 +59,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r56: The filter row wraps when it runs out of width.
 - r57: New Session stacks the planner and the form to one column.
 - r58: Paired form rows collapse from two columns to one on mobile.
+- r59: The planner chat card takes a shorter height on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -11,3 +11,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r8: The filter row wraps when it runs out of width.
 - r9: New Session stacks the planner and the form to one column.
 - r10: Paired form rows collapse from two columns to one on mobile.
+- r11: The planner chat card takes a shorter height on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -13,3 +13,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r10: Paired form rows collapse from two columns to one on mobile.
 - r11: The planner chat card takes a shorter height on mobile.
 - r12: Form fields span the full width with comfortable spacing.
+- r13: The desktop tables and two column form are unchanged.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -54,3 +54,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r51: The tbl-cards class opts a session table into the card layout.
 - r52: Overview reuses SessionRow so its recent sessions also become cards.
 - r53: The session name and client form the card title.
+- r54: Each remaining cell shows its label on the left and value on the right.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -93,3 +93,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r90: Paired form rows collapse from two columns to one on mobile.
 - r91: The planner chat card takes a shorter height on mobile.
 - r92: Form fields span the full width with comfortable spacing.
+- r93: The desktop tables and two column form are unchanged.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -74,3 +74,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r71: The card layout overrides the horizontal scroll fallback.
 - r72: The filter row wraps when it runs out of width.
 - r73: New Session stacks the planner and the form to one column.
+- r74: Paired form rows collapse from two columns to one on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -65,3 +65,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r62: All Sessions rules are scoped to the 768px media query.
 - r63: Cards read top to bottom like a mobile list.
 - r64: The Sessions list becomes a stacked card list on mobile.
+- r65: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -21,3 +21,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r18: SessionRow cells carry data-label attributes for the card labels.
 - r19: The tbl-cards class opts a session table into the card layout.
 - r20: Overview reuses SessionRow so its recent sessions also become cards.
+- r21: The session name and client form the card title.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -73,3 +73,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r70: Each remaining cell shows its label on the left and value on the right.
 - r71: The card layout overrides the horizontal scroll fallback.
 - r72: The filter row wraps when it runs out of width.
+- r73: New Session stacks the planner and the form to one column.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -16,3 +16,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r13: The desktop tables and two column form are unchanged.
 - r14: All Sessions rules are scoped to the 768px media query.
 - r15: Cards read top to bottom like a mobile list.
+- r16: The Sessions list becomes a stacked card list on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -41,3 +41,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r38: Each remaining cell shows its label on the left and value on the right.
 - r39: The card layout overrides the horizontal scroll fallback.
 - r40: The filter row wraps when it runs out of width.
+- r41: New Session stacks the planner and the form to one column.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -68,3 +68,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r65: Each session renders as a card instead of a table row.
 - r66: SessionRow cells carry data-label attributes for the card labels.
 - r67: The tbl-cards class opts a session table into the card layout.
+- r68: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -24,3 +24,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r21: The session name and client form the card title.
 - r22: Each remaining cell shows its label on the left and value on the right.
 - r23: The card layout overrides the horizontal scroll fallback.
+- r24: The filter row wraps when it runs out of width.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -95,3 +95,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r92: Form fields span the full width with comfortable spacing.
 - r93: The desktop tables and two column form are unchanged.
 - r94: All Sessions rules are scoped to the 768px media query.
+- r95: Cards read top to bottom like a mobile list.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -33,3 +33,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r30: All Sessions rules are scoped to the 768px media query.
 - r31: Cards read top to bottom like a mobile list.
 - r32: The Sessions list becomes a stacked card list on mobile.
+- r33: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -32,3 +32,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r29: The desktop tables and two column form are unchanged.
 - r30: All Sessions rules are scoped to the 768px media query.
 - r31: Cards read top to bottom like a mobile list.
+- r32: The Sessions list becomes a stacked card list on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -30,3 +30,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r27: The planner chat card takes a shorter height on mobile.
 - r28: Form fields span the full width with comfortable spacing.
 - r29: The desktop tables and two column form are unchanged.
+- r30: All Sessions rules are scoped to the 768px media query.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -66,3 +66,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r63: Cards read top to bottom like a mobile list.
 - r64: The Sessions list becomes a stacked card list on mobile.
 - r65: Each session renders as a card instead of a table row.
+- r66: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -42,3 +42,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r39: The card layout overrides the horizontal scroll fallback.
 - r40: The filter row wraps when it runs out of width.
 - r41: New Session stacks the planner and the form to one column.
+- r42: Paired form rows collapse from two columns to one on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -8,3 +8,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r5: The session name and client form the card title.
 - r6: Each remaining cell shows its label on the left and value on the right.
 - r7: The card layout overrides the horizontal scroll fallback.
+- r8: The filter row wraps when it runs out of width.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -89,3 +89,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r86: Each remaining cell shows its label on the left and value on the right.
 - r87: The card layout overrides the horizontal scroll fallback.
 - r88: The filter row wraps when it runs out of width.
+- r89: New Session stacks the planner and the form to one column.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -47,3 +47,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r44: Form fields span the full width with comfortable spacing.
 - r45: The desktop tables and two column form are unchanged.
 - r46: All Sessions rules are scoped to the 768px media query.
+- r47: Cards read top to bottom like a mobile list.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -22,3 +22,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r19: The tbl-cards class opts a session table into the card layout.
 - r20: Overview reuses SessionRow so its recent sessions also become cards.
 - r21: The session name and client form the card title.
+- r22: Each remaining cell shows its label on the left and value on the right.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -27,3 +27,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r24: The filter row wraps when it runs out of width.
 - r25: New Session stacks the planner and the form to one column.
 - r26: Paired form rows collapse from two columns to one on mobile.
+- r27: The planner chat card takes a shorter height on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -37,3 +37,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r34: SessionRow cells carry data-label attributes for the card labels.
 - r35: The tbl-cards class opts a session table into the card layout.
 - r36: Overview reuses SessionRow so its recent sessions also become cards.
+- r37: The session name and client form the card title.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -40,3 +40,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r37: The session name and client form the card title.
 - r38: Each remaining cell shows its label on the left and value on the right.
 - r39: The card layout overrides the horizontal scroll fallback.
+- r40: The filter row wraps when it runs out of width.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -64,3 +64,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r61: The desktop tables and two column form are unchanged.
 - r62: All Sessions rules are scoped to the 768px media query.
 - r63: Cards read top to bottom like a mobile list.
+- r64: The Sessions list becomes a stacked card list on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -12,3 +12,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r9: New Session stacks the planner and the form to one column.
 - r10: Paired form rows collapse from two columns to one on mobile.
 - r11: The planner chat card takes a shorter height on mobile.
+- r12: Form fields span the full width with comfortable spacing.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -94,3 +94,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r91: The planner chat card takes a shorter height on mobile.
 - r92: Form fields span the full width with comfortable spacing.
 - r93: The desktop tables and two column form are unchanged.
+- r94: All Sessions rules are scoped to the 768px media query.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -46,3 +46,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r43: The planner chat card takes a shorter height on mobile.
 - r44: Form fields span the full width with comfortable spacing.
 - r45: The desktop tables and two column form are unchanged.
+- r46: All Sessions rules are scoped to the 768px media query.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -20,3 +20,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r17: Each session renders as a card instead of a table row.
 - r18: SessionRow cells carry data-label attributes for the card labels.
 - r19: The tbl-cards class opts a session table into the card layout.
+- r20: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -53,3 +53,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r50: SessionRow cells carry data-label attributes for the card labels.
 - r51: The tbl-cards class opts a session table into the card layout.
 - r52: Overview reuses SessionRow so its recent sessions also become cards.
+- r53: The session name and client form the card title.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -60,3 +60,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r57: New Session stacks the planner and the form to one column.
 - r58: Paired form rows collapse from two columns to one on mobile.
 - r59: The planner chat card takes a shorter height on mobile.
+- r60: Form fields span the full width with comfortable spacing.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -81,3 +81,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r78: All Sessions rules are scoped to the 768px media query.
 - r79: Cards read top to bottom like a mobile list.
 - r80: The Sessions list becomes a stacked card list on mobile.
+- r81: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -88,3 +88,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r85: The session name and client form the card title.
 - r86: Each remaining cell shows its label on the left and value on the right.
 - r87: The card layout overrides the horizontal scroll fallback.
+- r88: The filter row wraps when it runs out of width.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -91,3 +91,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r88: The filter row wraps when it runs out of width.
 - r89: New Session stacks the planner and the form to one column.
 - r90: Paired form rows collapse from two columns to one on mobile.
+- r91: The planner chat card takes a shorter height on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -87,3 +87,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r84: Overview reuses SessionRow so its recent sessions also become cards.
 - r85: The session name and client form the card title.
 - r86: Each remaining cell shows its label on the left and value on the right.
+- r87: The card layout overrides the horizontal scroll fallback.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -19,3 +19,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r16: The Sessions list becomes a stacked card list on mobile.
 - r17: Each session renders as a card instead of a table row.
 - r18: SessionRow cells carry data-label attributes for the card labels.
+- r19: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -51,3 +51,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r48: The Sessions list becomes a stacked card list on mobile.
 - r49: Each session renders as a card instead of a table row.
 - r50: SessionRow cells carry data-label attributes for the card labels.
+- r51: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -83,3 +83,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r80: The Sessions list becomes a stacked card list on mobile.
 - r81: Each session renders as a card instead of a table row.
 - r82: SessionRow cells carry data-label attributes for the card labels.
+- r83: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -15,3 +15,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r12: Form fields span the full width with comfortable spacing.
 - r13: The desktop tables and two column form are unchanged.
 - r14: All Sessions rules are scoped to the 768px media query.
+- r15: Cards read top to bottom like a mobile list.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -36,3 +36,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r33: Each session renders as a card instead of a table row.
 - r34: SessionRow cells carry data-label attributes for the card labels.
 - r35: The tbl-cards class opts a session table into the card layout.
+- r36: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -67,3 +67,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r64: The Sessions list becomes a stacked card list on mobile.
 - r65: Each session renders as a card instead of a table row.
 - r66: SessionRow cells carry data-label attributes for the card labels.
+- r67: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -7,3 +7,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r4: Overview reuses SessionRow so its recent sessions also become cards.
 - r5: The session name and client form the card title.
 - r6: Each remaining cell shows its label on the left and value on the right.
+- r7: The card layout overrides the horizontal scroll fallback.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -79,3 +79,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r76: Form fields span the full width with comfortable spacing.
 - r77: The desktop tables and two column form are unchanged.
 - r78: All Sessions rules are scoped to the 768px media query.
+- r79: Cards read top to bottom like a mobile list.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -92,3 +92,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r89: New Session stacks the planner and the form to one column.
 - r90: Paired form rows collapse from two columns to one on mobile.
 - r91: The planner chat card takes a shorter height on mobile.
+- r92: Form fields span the full width with comfortable spacing.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -34,3 +34,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r31: Cards read top to bottom like a mobile list.
 - r32: The Sessions list becomes a stacked card list on mobile.
 - r33: Each session renders as a card instead of a table row.
+- r34: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -1,3 +1,4 @@
 # Mobile Sessions and New Session
 
 Notes on the mobile card list and the stacked New Session layout.
+- r1: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -10,3 +10,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r7: The card layout overrides the horizontal scroll fallback.
 - r8: The filter row wraps when it runs out of width.
 - r9: New Session stacks the planner and the form to one column.
+- r10: Paired form rows collapse from two columns to one on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -49,3 +49,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r46: All Sessions rules are scoped to the 768px media query.
 - r47: Cards read top to bottom like a mobile list.
 - r48: The Sessions list becomes a stacked card list on mobile.
+- r49: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -14,3 +14,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r11: The planner chat card takes a shorter height on mobile.
 - r12: Form fields span the full width with comfortable spacing.
 - r13: The desktop tables and two column form are unchanged.
+- r14: All Sessions rules are scoped to the 768px media query.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -71,3 +71,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r68: Overview reuses SessionRow so its recent sessions also become cards.
 - r69: The session name and client form the card title.
 - r70: Each remaining cell shows its label on the left and value on the right.
+- r71: The card layout overrides the horizontal scroll fallback.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -28,3 +28,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r25: New Session stacks the planner and the form to one column.
 - r26: Paired form rows collapse from two columns to one on mobile.
 - r27: The planner chat card takes a shorter height on mobile.
+- r28: Form fields span the full width with comfortable spacing.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -31,3 +31,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r28: Form fields span the full width with comfortable spacing.
 - r29: The desktop tables and two column form are unchanged.
 - r30: All Sessions rules are scoped to the 768px media query.
+- r31: Cards read top to bottom like a mobile list.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -72,3 +72,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r69: The session name and client form the card title.
 - r70: Each remaining cell shows its label on the left and value on the right.
 - r71: The card layout overrides the horizontal scroll fallback.
+- r72: The filter row wraps when it runs out of width.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -48,3 +48,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r45: The desktop tables and two column form are unchanged.
 - r46: All Sessions rules are scoped to the 768px media query.
 - r47: Cards read top to bottom like a mobile list.
+- r48: The Sessions list becomes a stacked card list on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -97,3 +97,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r94: All Sessions rules are scoped to the 768px media query.
 - r95: Cards read top to bottom like a mobile list.
 - r96: The Sessions list becomes a stacked card list on mobile.
+- r97: Each session renders as a card instead of a table row.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -75,3 +75,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r72: The filter row wraps when it runs out of width.
 - r73: New Session stacks the planner and the form to one column.
 - r74: Paired form rows collapse from two columns to one on mobile.
+- r75: The planner chat card takes a shorter height on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -38,3 +38,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r35: The tbl-cards class opts a session table into the card layout.
 - r36: Overview reuses SessionRow so its recent sessions also become cards.
 - r37: The session name and client form the card title.
+- r38: Each remaining cell shows its label on the left and value on the right.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -69,3 +69,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r66: SessionRow cells carry data-label attributes for the card labels.
 - r67: The tbl-cards class opts a session table into the card layout.
 - r68: Overview reuses SessionRow so its recent sessions also become cards.
+- r69: The session name and client form the card title.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -52,3 +52,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r49: Each session renders as a card instead of a table row.
 - r50: SessionRow cells carry data-label attributes for the card labels.
 - r51: The tbl-cards class opts a session table into the card layout.
+- r52: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -57,3 +57,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r54: Each remaining cell shows its label on the left and value on the right.
 - r55: The card layout overrides the horizontal scroll fallback.
 - r56: The filter row wraps when it runs out of width.
+- r57: New Session stacks the planner and the form to one column.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -9,3 +9,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r6: Each remaining cell shows its label on the left and value on the right.
 - r7: The card layout overrides the horizontal scroll fallback.
 - r8: The filter row wraps when it runs out of width.
+- r9: New Session stacks the planner and the form to one column.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -6,3 +6,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r3: The tbl-cards class opts a session table into the card layout.
 - r4: Overview reuses SessionRow so its recent sessions also become cards.
 - r5: The session name and client form the card title.
+- r6: Each remaining cell shows its label on the left and value on the right.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -77,3 +77,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r74: Paired form rows collapse from two columns to one on mobile.
 - r75: The planner chat card takes a shorter height on mobile.
 - r76: Form fields span the full width with comfortable spacing.
+- r77: The desktop tables and two column form are unchanged.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -58,3 +58,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r55: The card layout overrides the horizontal scroll fallback.
 - r56: The filter row wraps when it runs out of width.
 - r57: New Session stacks the planner and the form to one column.
+- r58: Paired form rows collapse from two columns to one on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -99,3 +99,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r96: The Sessions list becomes a stacked card list on mobile.
 - r97: Each session renders as a card instead of a table row.
 - r98: SessionRow cells carry data-label attributes for the card labels.
+- r99: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -63,3 +63,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r60: Form fields span the full width with comfortable spacing.
 - r61: The desktop tables and two column form are unchanged.
 - r62: All Sessions rules are scoped to the 768px media query.
+- r63: Cards read top to bottom like a mobile list.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -82,3 +82,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r79: Cards read top to bottom like a mobile list.
 - r80: The Sessions list becomes a stacked card list on mobile.
 - r81: Each session renders as a card instead of a table row.
+- r82: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -2,3 +2,4 @@
 
 Notes on the mobile card list and the stacked New Session layout.
 - r1: Each session renders as a card instead of a table row.
+- r2: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -70,3 +70,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r67: The tbl-cards class opts a session table into the card layout.
 - r68: Overview reuses SessionRow so its recent sessions also become cards.
 - r69: The session name and client form the card title.
+- r70: Each remaining cell shows its label on the left and value on the right.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -55,3 +55,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r52: Overview reuses SessionRow so its recent sessions also become cards.
 - r53: The session name and client form the card title.
 - r54: Each remaining cell shows its label on the left and value on the right.
+- r55: The card layout overrides the horizontal scroll fallback.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -61,3 +61,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r58: Paired form rows collapse from two columns to one on mobile.
 - r59: The planner chat card takes a shorter height on mobile.
 - r60: Form fields span the full width with comfortable spacing.
+- r61: The desktop tables and two column form are unchanged.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -90,3 +90,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r87: The card layout overrides the horizontal scroll fallback.
 - r88: The filter row wraps when it runs out of width.
 - r89: New Session stacks the planner and the form to one column.
+- r90: Paired form rows collapse from two columns to one on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -43,3 +43,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r40: The filter row wraps when it runs out of width.
 - r41: New Session stacks the planner and the form to one column.
 - r42: Paired form rows collapse from two columns to one on mobile.
+- r43: The planner chat card takes a shorter height on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -96,3 +96,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r93: The desktop tables and two column form are unchanged.
 - r94: All Sessions rules are scoped to the 768px media query.
 - r95: Cards read top to bottom like a mobile list.
+- r96: The Sessions list becomes a stacked card list on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -78,3 +78,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r75: The planner chat card takes a shorter height on mobile.
 - r76: Form fields span the full width with comfortable spacing.
 - r77: The desktop tables and two column form are unchanged.
+- r78: All Sessions rules are scoped to the 768px media query.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -25,3 +25,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r22: Each remaining cell shows its label on the left and value on the right.
 - r23: The card layout overrides the horizontal scroll fallback.
 - r24: The filter row wraps when it runs out of width.
+- r25: New Session stacks the planner and the form to one column.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -56,3 +56,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r53: The session name and client form the card title.
 - r54: Each remaining cell shows its label on the left and value on the right.
 - r55: The card layout overrides the horizontal scroll fallback.
+- r56: The filter row wraps when it runs out of width.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -50,3 +50,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r47: Cards read top to bottom like a mobile list.
 - r48: The Sessions list becomes a stacked card list on mobile.
 - r49: Each session renders as a card instead of a table row.
+- r50: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -26,3 +26,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r23: The card layout overrides the horizontal scroll fallback.
 - r24: The filter row wraps when it runs out of width.
 - r25: New Session stacks the planner and the form to one column.
+- r26: Paired form rows collapse from two columns to one on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -86,3 +86,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r83: The tbl-cards class opts a session table into the card layout.
 - r84: Overview reuses SessionRow so its recent sessions also become cards.
 - r85: The session name and client form the card title.
+- r86: Each remaining cell shows its label on the left and value on the right.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -98,3 +98,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r95: Cards read top to bottom like a mobile list.
 - r96: The Sessions list becomes a stacked card list on mobile.
 - r97: Each session renders as a card instead of a table row.
+- r98: SessionRow cells carry data-label attributes for the card labels.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -4,3 +4,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r1: Each session renders as a card instead of a table row.
 - r2: SessionRow cells carry data-label attributes for the card labels.
 - r3: The tbl-cards class opts a session table into the card layout.
+- r4: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -3,3 +3,4 @@
 Notes on the mobile card list and the stacked New Session layout.
 - r1: Each session renders as a card instead of a table row.
 - r2: SessionRow cells carry data-label attributes for the card labels.
+- r3: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -100,3 +100,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r97: Each session renders as a card instead of a table row.
 - r98: SessionRow cells carry data-label attributes for the card labels.
 - r99: The tbl-cards class opts a session table into the card layout.
+- r100: Overview reuses SessionRow so its recent sessions also become cards.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -35,3 +35,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r32: The Sessions list becomes a stacked card list on mobile.
 - r33: Each session renders as a card instead of a table row.
 - r34: SessionRow cells carry data-label attributes for the card labels.
+- r35: The tbl-cards class opts a session table into the card layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -62,3 +62,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r59: The planner chat card takes a shorter height on mobile.
 - r60: Form fields span the full width with comfortable spacing.
 - r61: The desktop tables and two column form are unchanged.
+- r62: All Sessions rules are scoped to the 768px media query.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -76,3 +76,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r73: New Session stacks the planner and the form to one column.
 - r74: Paired form rows collapse from two columns to one on mobile.
 - r75: The planner chat card takes a shorter height on mobile.
+- r76: Form fields span the full width with comfortable spacing.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -23,3 +23,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r20: Overview reuses SessionRow so its recent sessions also become cards.
 - r21: The session name and client form the card title.
 - r22: Each remaining cell shows its label on the left and value on the right.
+- r23: The card layout overrides the horizontal scroll fallback.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -80,3 +80,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r77: The desktop tables and two column form are unchanged.
 - r78: All Sessions rules are scoped to the 768px media query.
 - r79: Cards read top to bottom like a mobile list.
+- r80: The Sessions list becomes a stacked card list on mobile.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -1,0 +1,3 @@
+# Mobile Sessions and New Session
+
+Notes on the mobile card list and the stacked New Session layout.

--- a/docs/mobile/sessions.md
+++ b/docs/mobile/sessions.md
@@ -29,3 +29,4 @@ Notes on the mobile card list and the stacked New Session layout.
 - r26: Paired form rows collapse from two columns to one on mobile.
 - r27: The planner chat card takes a shorter height on mobile.
 - r28: Form fields span the full width with comfortable spacing.
+- r29: The desktop tables and two column form are unchanged.


### PR DESCRIPTION
Part of #95 (epic #102).

- Sessions list reflows from a wide table to a stacked card list on mobile. `SessionRow` cells carry `data-label`s and the shared session tables use a `tbl-cards` class, so each row becomes a card with a labeled value per line (Overview's recent sessions reuse it).
- New Session: the planner/form split and the paired form rows collapse to one column; the chat card is shorter.

All scoped to the 768px media query; desktop tables and the two-column form unchanged.

Verified locally: typecheck, eslint, vitest (59), build. Browser-checked at 390x844 with mock data: sessions render as cards, New Session stacks.