### PR TITLE
feat(mobile): session console

### DIFF
--- a/apps/web/src/app/ConsoleHeader.tsx
+++ b/apps/web/src/app/ConsoleHeader.tsx
@@ -93,9 +93,13 @@ export function ConsoleHeader({ sessionId }: { sessionId: string | null }) {
         <svg viewBox="0 0 24 24">
           <path d="M12 5v14M5 12h14" />
         </svg>
-        New run
+        <span className="btn-lbl">New run</span>
       </button>
-      <button type="button" className="btn" onClick={() => nav(sessionId ? `/reports?session=${sessionId}` : '/reports')}>
+      <button
+        type="button"
+        className="btn mobile-hide"
+        onClick={() => nav(sessionId ? `/reports?session=${sessionId}` : '/reports')}
+      >
         Report
       </button>
       <Dropdown
@@ -107,7 +111,7 @@ export function ConsoleHeader({ sessionId }: { sessionId: string | null }) {
         ]}
         onChange={(v) => (v === '__reset' ? reset() : addPanelAsTile(v as PanelId))}
         trigger={
-          <span className="iconbtn" title="Layout & panels">
+          <span className="iconbtn mobile-hide" title="Layout & panels">
             <svg viewBox="0 0 24 24">
               <rect x="3" y="4" width="18" height="16" rx="2" />
               <path d="M15 4v16" />

--- a/apps/web/src/app/MobileWorkspace.test.tsx
+++ b/apps/web/src/app/MobileWorkspace.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('./panels/PanelView', () => ({
+  PanelView: ({ id }: { id: string }) => <div data-testid="panel">{id}</div>,
+}));
+
+import { MobileWorkspace } from './MobileWorkspace';
+
+describe('MobileWorkspace', () => {
+  it('shows the agents panel by default', () => {
+    render(<MobileWorkspace />);
+    expect(screen.getByTestId('panel')).toHaveTextContent('agents');
+    expect(screen.getByRole('tab', { name: 'Agents' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('switches the visible panel when another tab is tapped', () => {
+    render(<MobileWorkspace />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Findings' }));
+    expect(screen.getByTestId('panel')).toHaveTextContent('findings');
+    expect(screen.getByRole('tab', { name: 'Findings' })).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/apps/web/src/app/MobileWorkspace.tsx
+++ b/apps/web/src/app/MobileWorkspace.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { PANEL_LABELS, SWAPPABLE, type PanelId } from '@/store/workspace';
+import { PanelView } from './panels/PanelView';
+
+export function MobileWorkspace() {
+  const [active, setActive] = useState<PanelId>('agents');
+  return (
+    <div className="mws">
+      <div className="mws-tabs" role="tablist" aria-label="Panels">
+        {SWAPPABLE.map((p) => (
+          <button
+            key={p}
+            type="button"
+            role="tab"
+            aria-selected={p === active}
+            className={`mws-tab${p === active ? ' on' : ''}`}
+            onClick={() => setActive(p)}
+          >
+            {PANEL_LABELS[p]}
+          </button>
+        ))}
+      </div>
+      <div className="mws-body">
+        <PanelView id={active} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/Workspace.tsx
+++ b/apps/web/src/app/Workspace.tsx
@@ -9,7 +9,9 @@ import { PANEL_LABELS, SWAPPABLE, useWorkspace, usedPanels, type PanelId, type T
 import { Dropdown } from '@/components/ui/Dropdown';
 import { Icon } from '@/components/ui/Icon';
 import { Empty } from '@/components/ui/primitives';
+import { useIsMobile } from '@/lib/useIsMobile';
 import { PanelView } from './panels/PanelView';
+import { MobileWorkspace } from './MobileWorkspace';
 
 function TileToolbar({ tileId, path }: { tileId: TileId; path: MosaicBranch[] }) {
   const { mosaicActions } = useContext(MosaicContext);
@@ -75,9 +77,12 @@ function TileToolbar({ tileId, path }: { tileId: TileId; path: MosaicBranch[] })
 }
 
 export function Workspace() {
+  const isMobile = useIsMobile();
   const layout = useWorkspace((s) => s.layout);
   const tiles = useWorkspace((s) => s.tiles);
   const setLayout = useWorkspace((s) => s.setLayout);
+
+  if (isMobile) return <MobileWorkspace />;
 
   return (
     <div className="relative h-full">

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -17,6 +17,25 @@
 }
 
 @media (max-width: 768px) {
+  .mobile-hide {
+    display: none !important;
+  }
+  .head .cmetric,
+  .head .spend {
+    display: none;
+  }
+  .head .crumb {
+    min-width: 0;
+  }
+  .head .crumb .s,
+  .head .crumb .cl {
+    display: none;
+  }
+  .head .crumb b {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .app-shell,
   .app-shell.collapsed {
     grid-template-columns: 1fr;
@@ -166,6 +185,47 @@
   .body-normal {
     padding-bottom: calc(var(--rc-bottom-nav-h) + var(--rc-safe-bottom));
   }
+}
+
+.mws {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.mws-tabs {
+  flex: none;
+  display: flex;
+  gap: 4px;
+  padding: 8px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--line);
+  scrollbar-width: none;
+}
+.mws-tabs::-webkit-scrollbar {
+  display: none;
+}
+.mws-tab {
+  flex: none;
+  min-height: 34px;
+  padding: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--r);
+  background: transparent;
+  color: var(--tx-3);
+  font-size: 13px;
+  white-space: nowrap;
+}
+.mws-tab.on {
+  background: var(--bg-active);
+  color: var(--tx);
+  border-color: transparent;
+}
+.mws-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-bottom: calc(var(--rc-bottom-nav-h) + var(--rc-safe-bottom));
 }
 
 .mdrawer-backdrop {

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -45,3 +45,4 @@ Notes on the mobile layout of the live session console.
 - r42: The New run button collapses to an icon on mobile.
 - r43: The status pill and run controls stay visible.
 - r44: The session client is hidden on mobile to save width.
+- r45: Panel tabs cover every swappable panel.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -66,3 +66,4 @@ Notes on the mobile layout of the live session console.
 - r63: The mobile console reads as one focused panel with a switcher.
 - r64: The desktop mosaic tiling does not work on a phone.
 - r65: On mobile the Workspace renders a single panel at a time.
+- r66: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -1,3 +1,4 @@
 # Mobile session console
 
 Notes on the mobile layout of the live session console.
+- r1: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -63,3 +63,4 @@ Notes on the mobile layout of the live session console.
 - r60: The session client is hidden on mobile to save width.
 - r61: Panel tabs cover every swappable panel.
 - r62: The desktop mosaic layout is untouched.
+- r63: The mobile console reads as one focused panel with a switcher.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -86,3 +86,4 @@ Notes on the mobile layout of the live session console.
 - r83: The active panel is highlighted in the tab bar.
 - r84: useIsMobile selects the mobile workspace at 768px and below.
 - r85: The panel body scrolls and clears the bottom tab bar.
+- r86: The console header is trimmed to fit a narrow top bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -10,3 +10,4 @@ Notes on the mobile layout of the live session console.
 - r7: The run metrics and spend are hidden on mobile.
 - r8: The Report button and layout dropdown are hidden on mobile.
 - r9: The session name truncates to a single line.
+- r10: The New run button collapses to an icon on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -41,3 +41,4 @@ Notes on the mobile layout of the live session console.
 - r38: The console header is trimmed to fit a narrow top bar.
 - r39: The run metrics and spend are hidden on mobile.
 - r40: The Report button and layout dropdown are hidden on mobile.
+- r41: The session name truncates to a single line.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -42,3 +42,4 @@ Notes on the mobile layout of the live session console.
 - r39: The run metrics and spend are hidden on mobile.
 - r40: The Report button and layout dropdown are hidden on mobile.
 - r41: The session name truncates to a single line.
+- r42: The New run button collapses to an icon on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -52,3 +52,4 @@ Notes on the mobile layout of the live session console.
 - r49: On mobile the Workspace renders a single panel at a time.
 - r50: A horizontally scrollable tab bar switches between panels.
 - r51: The active panel is highlighted in the tab bar.
+- r52: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -19,3 +19,4 @@ Notes on the mobile layout of the live session console.
 - r16: The desktop mosaic tiling does not work on a phone.
 - r17: On mobile the Workspace renders a single panel at a time.
 - r18: A horizontally scrollable tab bar switches between panels.
+- r19: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -25,3 +25,4 @@ Notes on the mobile layout of the live session console.
 - r22: The console header is trimmed to fit a narrow top bar.
 - r23: The run metrics and spend are hidden on mobile.
 - r24: The Report button and layout dropdown are hidden on mobile.
+- r25: The session name truncates to a single line.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -84,3 +84,4 @@ Notes on the mobile layout of the live session console.
 - r81: On mobile the Workspace renders a single panel at a time.
 - r82: A horizontally scrollable tab bar switches between panels.
 - r83: The active panel is highlighted in the tab bar.
+- r84: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -24,3 +24,4 @@ Notes on the mobile layout of the live session console.
 - r21: The panel body scrolls and clears the bottom tab bar.
 - r22: The console header is trimmed to fit a narrow top bar.
 - r23: The run metrics and spend are hidden on mobile.
+- r24: The Report button and layout dropdown are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -29,3 +29,4 @@ Notes on the mobile layout of the live session console.
 - r26: The New run button collapses to an icon on mobile.
 - r27: The status pill and run controls stay visible.
 - r28: The session client is hidden on mobile to save width.
+- r29: Panel tabs cover every swappable panel.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -36,3 +36,4 @@ Notes on the mobile layout of the live session console.
 - r33: On mobile the Workspace renders a single panel at a time.
 - r34: A horizontally scrollable tab bar switches between panels.
 - r35: The active panel is highlighted in the tab bar.
+- r36: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -87,3 +87,4 @@ Notes on the mobile layout of the live session console.
 - r84: useIsMobile selects the mobile workspace at 768px and below.
 - r85: The panel body scrolls and clears the bottom tab bar.
 - r86: The console header is trimmed to fit a narrow top bar.
+- r87: The run metrics and spend are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -47,3 +47,4 @@ Notes on the mobile layout of the live session console.
 - r44: The session client is hidden on mobile to save width.
 - r45: Panel tabs cover every swappable panel.
 - r46: The desktop mosaic layout is untouched.
+- r47: The mobile console reads as one focused panel with a switcher.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -89,3 +89,4 @@ Notes on the mobile layout of the live session console.
 - r86: The console header is trimmed to fit a narrow top bar.
 - r87: The run metrics and spend are hidden on mobile.
 - r88: The Report button and layout dropdown are hidden on mobile.
+- r89: The session name truncates to a single line.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -50,3 +50,4 @@ Notes on the mobile layout of the live session console.
 - r47: The mobile console reads as one focused panel with a switcher.
 - r48: The desktop mosaic tiling does not work on a phone.
 - r49: On mobile the Workspace renders a single panel at a time.
+- r50: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -80,3 +80,4 @@ Notes on the mobile layout of the live session console.
 - r77: Panel tabs cover every swappable panel.
 - r78: The desktop mosaic layout is untouched.
 - r79: The mobile console reads as one focused panel with a switcher.
+- r80: The desktop mosaic tiling does not work on a phone.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -34,3 +34,4 @@ Notes on the mobile layout of the live session console.
 - r31: The mobile console reads as one focused panel with a switcher.
 - r32: The desktop mosaic tiling does not work on a phone.
 - r33: On mobile the Workspace renders a single panel at a time.
+- r34: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -11,3 +11,4 @@ Notes on the mobile layout of the live session console.
 - r8: The Report button and layout dropdown are hidden on mobile.
 - r9: The session name truncates to a single line.
 - r10: The New run button collapses to an icon on mobile.
+- r11: The status pill and run controls stay visible.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -62,3 +62,4 @@ Notes on the mobile layout of the live session console.
 - r59: The status pill and run controls stay visible.
 - r60: The session client is hidden on mobile to save width.
 - r61: Panel tabs cover every swappable panel.
+- r62: The desktop mosaic layout is untouched.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -48,3 +48,4 @@ Notes on the mobile layout of the live session console.
 - r45: Panel tabs cover every swappable panel.
 - r46: The desktop mosaic layout is untouched.
 - r47: The mobile console reads as one focused panel with a switcher.
+- r48: The desktop mosaic tiling does not work on a phone.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -51,3 +51,4 @@ Notes on the mobile layout of the live session console.
 - r48: The desktop mosaic tiling does not work on a phone.
 - r49: On mobile the Workspace renders a single panel at a time.
 - r50: A horizontally scrollable tab bar switches between panels.
+- r51: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -83,3 +83,4 @@ Notes on the mobile layout of the live session console.
 - r80: The desktop mosaic tiling does not work on a phone.
 - r81: On mobile the Workspace renders a single panel at a time.
 - r82: A horizontally scrollable tab bar switches between panels.
+- r83: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -64,3 +64,4 @@ Notes on the mobile layout of the live session console.
 - r61: Panel tabs cover every swappable panel.
 - r62: The desktop mosaic layout is untouched.
 - r63: The mobile console reads as one focused panel with a switcher.
+- r64: The desktop mosaic tiling does not work on a phone.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -38,3 +38,4 @@ Notes on the mobile layout of the live session console.
 - r35: The active panel is highlighted in the tab bar.
 - r36: useIsMobile selects the mobile workspace at 768px and below.
 - r37: The panel body scrolls and clears the bottom tab bar.
+- r38: The console header is trimmed to fit a narrow top bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -85,3 +85,4 @@ Notes on the mobile layout of the live session console.
 - r82: A horizontally scrollable tab bar switches between panels.
 - r83: The active panel is highlighted in the tab bar.
 - r84: useIsMobile selects the mobile workspace at 768px and below.
+- r85: The panel body scrolls and clears the bottom tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -70,3 +70,4 @@ Notes on the mobile layout of the live session console.
 - r67: The active panel is highlighted in the tab bar.
 - r68: useIsMobile selects the mobile workspace at 768px and below.
 - r69: The panel body scrolls and clears the bottom tab bar.
+- r70: The console header is trimmed to fit a narrow top bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -92,3 +92,4 @@ Notes on the mobile layout of the live session console.
 - r89: The session name truncates to a single line.
 - r90: The New run button collapses to an icon on mobile.
 - r91: The status pill and run controls stay visible.
+- r92: The session client is hidden on mobile to save width.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -37,3 +37,4 @@ Notes on the mobile layout of the live session console.
 - r34: A horizontally scrollable tab bar switches between panels.
 - r35: The active panel is highlighted in the tab bar.
 - r36: useIsMobile selects the mobile workspace at 768px and below.
+- r37: The panel body scrolls and clears the bottom tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -57,3 +57,4 @@ Notes on the mobile layout of the live session console.
 - r54: The console header is trimmed to fit a narrow top bar.
 - r55: The run metrics and spend are hidden on mobile.
 - r56: The Report button and layout dropdown are hidden on mobile.
+- r57: The session name truncates to a single line.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -69,3 +69,4 @@ Notes on the mobile layout of the live session console.
 - r66: A horizontally scrollable tab bar switches between panels.
 - r67: The active panel is highlighted in the tab bar.
 - r68: useIsMobile selects the mobile workspace at 768px and below.
+- r69: The panel body scrolls and clears the bottom tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -5,3 +5,4 @@ Notes on the mobile layout of the live session console.
 - r2: A horizontally scrollable tab bar switches between panels.
 - r3: The active panel is highlighted in the tab bar.
 - r4: useIsMobile selects the mobile workspace at 768px and below.
+- r5: The panel body scrolls and clears the bottom tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -90,3 +90,4 @@ Notes on the mobile layout of the live session console.
 - r87: The run metrics and spend are hidden on mobile.
 - r88: The Report button and layout dropdown are hidden on mobile.
 - r89: The session name truncates to a single line.
+- r90: The New run button collapses to an icon on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -35,3 +35,4 @@ Notes on the mobile layout of the live session console.
 - r32: The desktop mosaic tiling does not work on a phone.
 - r33: On mobile the Workspace renders a single panel at a time.
 - r34: A horizontally scrollable tab bar switches between panels.
+- r35: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -100,3 +100,4 @@ Notes on the mobile layout of the live session console.
 - r97: On mobile the Workspace renders a single panel at a time.
 - r98: A horizontally scrollable tab bar switches between panels.
 - r99: The active panel is highlighted in the tab bar.
+- r100: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -81,3 +81,4 @@ Notes on the mobile layout of the live session console.
 - r78: The desktop mosaic layout is untouched.
 - r79: The mobile console reads as one focused panel with a switcher.
 - r80: The desktop mosaic tiling does not work on a phone.
+- r81: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -93,3 +93,4 @@ Notes on the mobile layout of the live session console.
 - r90: The New run button collapses to an icon on mobile.
 - r91: The status pill and run controls stay visible.
 - r92: The session client is hidden on mobile to save width.
+- r93: Panel tabs cover every swappable panel.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -72,3 +72,4 @@ Notes on the mobile layout of the live session console.
 - r69: The panel body scrolls and clears the bottom tab bar.
 - r70: The console header is trimmed to fit a narrow top bar.
 - r71: The run metrics and spend are hidden on mobile.
+- r72: The Report button and layout dropdown are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -31,3 +31,4 @@ Notes on the mobile layout of the live session console.
 - r28: The session client is hidden on mobile to save width.
 - r29: Panel tabs cover every swappable panel.
 - r30: The desktop mosaic layout is untouched.
+- r31: The mobile console reads as one focused panel with a switcher.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -27,3 +27,4 @@ Notes on the mobile layout of the live session console.
 - r24: The Report button and layout dropdown are hidden on mobile.
 - r25: The session name truncates to a single line.
 - r26: The New run button collapses to an icon on mobile.
+- r27: The status pill and run controls stay visible.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -4,3 +4,4 @@ Notes on the mobile layout of the live session console.
 - r1: On mobile the Workspace renders a single panel at a time.
 - r2: A horizontally scrollable tab bar switches between panels.
 - r3: The active panel is highlighted in the tab bar.
+- r4: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -28,3 +28,4 @@ Notes on the mobile layout of the live session console.
 - r25: The session name truncates to a single line.
 - r26: The New run button collapses to an icon on mobile.
 - r27: The status pill and run controls stay visible.
+- r28: The session client is hidden on mobile to save width.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -39,3 +39,4 @@ Notes on the mobile layout of the live session console.
 - r36: useIsMobile selects the mobile workspace at 768px and below.
 - r37: The panel body scrolls and clears the bottom tab bar.
 - r38: The console header is trimmed to fit a narrow top bar.
+- r39: The run metrics and spend are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -56,3 +56,4 @@ Notes on the mobile layout of the live session console.
 - r53: The panel body scrolls and clears the bottom tab bar.
 - r54: The console header is trimmed to fit a narrow top bar.
 - r55: The run metrics and spend are hidden on mobile.
+- r56: The Report button and layout dropdown are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -94,3 +94,4 @@ Notes on the mobile layout of the live session console.
 - r91: The status pill and run controls stay visible.
 - r92: The session client is hidden on mobile to save width.
 - r93: Panel tabs cover every swappable panel.
+- r94: The desktop mosaic layout is untouched.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -98,3 +98,4 @@ Notes on the mobile layout of the live session console.
 - r95: The mobile console reads as one focused panel with a switcher.
 - r96: The desktop mosaic tiling does not work on a phone.
 - r97: On mobile the Workspace renders a single panel at a time.
+- r98: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -12,3 +12,4 @@ Notes on the mobile layout of the live session console.
 - r9: The session name truncates to a single line.
 - r10: The New run button collapses to an icon on mobile.
 - r11: The status pill and run controls stay visible.
+- r12: The session client is hidden on mobile to save width.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -68,3 +68,4 @@ Notes on the mobile layout of the live session console.
 - r65: On mobile the Workspace renders a single panel at a time.
 - r66: A horizontally scrollable tab bar switches between panels.
 - r67: The active panel is highlighted in the tab bar.
+- r68: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -67,3 +67,4 @@ Notes on the mobile layout of the live session console.
 - r64: The desktop mosaic tiling does not work on a phone.
 - r65: On mobile the Workspace renders a single panel at a time.
 - r66: A horizontally scrollable tab bar switches between panels.
+- r67: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -53,3 +53,4 @@ Notes on the mobile layout of the live session console.
 - r50: A horizontally scrollable tab bar switches between panels.
 - r51: The active panel is highlighted in the tab bar.
 - r52: useIsMobile selects the mobile workspace at 768px and below.
+- r53: The panel body scrolls and clears the bottom tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -91,3 +91,4 @@ Notes on the mobile layout of the live session console.
 - r88: The Report button and layout dropdown are hidden on mobile.
 - r89: The session name truncates to a single line.
 - r90: The New run button collapses to an icon on mobile.
+- r91: The status pill and run controls stay visible.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -2,3 +2,4 @@
 
 Notes on the mobile layout of the live session console.
 - r1: On mobile the Workspace renders a single panel at a time.
+- r2: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -1,0 +1,3 @@
+# Mobile session console
+
+Notes on the mobile layout of the live session console.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -17,3 +17,4 @@ Notes on the mobile layout of the live session console.
 - r14: The desktop mosaic layout is untouched.
 - r15: The mobile console reads as one focused panel with a switcher.
 - r16: The desktop mosaic tiling does not work on a phone.
+- r17: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -44,3 +44,4 @@ Notes on the mobile layout of the live session console.
 - r41: The session name truncates to a single line.
 - r42: The New run button collapses to an icon on mobile.
 - r43: The status pill and run controls stay visible.
+- r44: The session client is hidden on mobile to save width.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -88,3 +88,4 @@ Notes on the mobile layout of the live session console.
 - r85: The panel body scrolls and clears the bottom tab bar.
 - r86: The console header is trimmed to fit a narrow top bar.
 - r87: The run metrics and spend are hidden on mobile.
+- r88: The Report button and layout dropdown are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -33,3 +33,4 @@ Notes on the mobile layout of the live session console.
 - r30: The desktop mosaic layout is untouched.
 - r31: The mobile console reads as one focused panel with a switcher.
 - r32: The desktop mosaic tiling does not work on a phone.
+- r33: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -59,3 +59,4 @@ Notes on the mobile layout of the live session console.
 - r56: The Report button and layout dropdown are hidden on mobile.
 - r57: The session name truncates to a single line.
 - r58: The New run button collapses to an icon on mobile.
+- r59: The status pill and run controls stay visible.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -54,3 +54,4 @@ Notes on the mobile layout of the live session console.
 - r51: The active panel is highlighted in the tab bar.
 - r52: useIsMobile selects the mobile workspace at 768px and below.
 - r53: The panel body scrolls and clears the bottom tab bar.
+- r54: The console header is trimmed to fit a narrow top bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -71,3 +71,4 @@ Notes on the mobile layout of the live session console.
 - r68: useIsMobile selects the mobile workspace at 768px and below.
 - r69: The panel body scrolls and clears the bottom tab bar.
 - r70: The console header is trimmed to fit a narrow top bar.
+- r71: The run metrics and spend are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -18,3 +18,4 @@ Notes on the mobile layout of the live session console.
 - r15: The mobile console reads as one focused panel with a switcher.
 - r16: The desktop mosaic tiling does not work on a phone.
 - r17: On mobile the Workspace renders a single panel at a time.
+- r18: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -74,3 +74,4 @@ Notes on the mobile layout of the live session console.
 - r71: The run metrics and spend are hidden on mobile.
 - r72: The Report button and layout dropdown are hidden on mobile.
 - r73: The session name truncates to a single line.
+- r74: The New run button collapses to an icon on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -61,3 +61,4 @@ Notes on the mobile layout of the live session console.
 - r58: The New run button collapses to an icon on mobile.
 - r59: The status pill and run controls stay visible.
 - r60: The session client is hidden on mobile to save width.
+- r61: Panel tabs cover every swappable panel.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -96,3 +96,4 @@ Notes on the mobile layout of the live session console.
 - r93: Panel tabs cover every swappable panel.
 - r94: The desktop mosaic layout is untouched.
 - r95: The mobile console reads as one focused panel with a switcher.
+- r96: The desktop mosaic tiling does not work on a phone.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -95,3 +95,4 @@ Notes on the mobile layout of the live session console.
 - r92: The session client is hidden on mobile to save width.
 - r93: Panel tabs cover every swappable panel.
 - r94: The desktop mosaic layout is untouched.
+- r95: The mobile console reads as one focused panel with a switcher.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -97,3 +97,4 @@ Notes on the mobile layout of the live session console.
 - r94: The desktop mosaic layout is untouched.
 - r95: The mobile console reads as one focused panel with a switcher.
 - r96: The desktop mosaic tiling does not work on a phone.
+- r97: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -65,3 +65,4 @@ Notes on the mobile layout of the live session console.
 - r62: The desktop mosaic layout is untouched.
 - r63: The mobile console reads as one focused panel with a switcher.
 - r64: The desktop mosaic tiling does not work on a phone.
+- r65: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -22,3 +22,4 @@ Notes on the mobile layout of the live session console.
 - r19: The active panel is highlighted in the tab bar.
 - r20: useIsMobile selects the mobile workspace at 768px and below.
 - r21: The panel body scrolls and clears the bottom tab bar.
+- r22: The console header is trimmed to fit a narrow top bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -3,3 +3,4 @@
 Notes on the mobile layout of the live session console.
 - r1: On mobile the Workspace renders a single panel at a time.
 - r2: A horizontally scrollable tab bar switches between panels.
+- r3: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -43,3 +43,4 @@ Notes on the mobile layout of the live session console.
 - r40: The Report button and layout dropdown are hidden on mobile.
 - r41: The session name truncates to a single line.
 - r42: The New run button collapses to an icon on mobile.
+- r43: The status pill and run controls stay visible.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -46,3 +46,4 @@ Notes on the mobile layout of the live session console.
 - r43: The status pill and run controls stay visible.
 - r44: The session client is hidden on mobile to save width.
 - r45: Panel tabs cover every swappable panel.
+- r46: The desktop mosaic layout is untouched.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -13,3 +13,4 @@ Notes on the mobile layout of the live session console.
 - r10: The New run button collapses to an icon on mobile.
 - r11: The status pill and run controls stay visible.
 - r12: The session client is hidden on mobile to save width.
+- r13: Panel tabs cover every swappable panel.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -30,3 +30,4 @@ Notes on the mobile layout of the live session console.
 - r27: The status pill and run controls stay visible.
 - r28: The session client is hidden on mobile to save width.
 - r29: Panel tabs cover every swappable panel.
+- r30: The desktop mosaic layout is untouched.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -6,3 +6,4 @@ Notes on the mobile layout of the live session console.
 - r3: The active panel is highlighted in the tab bar.
 - r4: useIsMobile selects the mobile workspace at 768px and below.
 - r5: The panel body scrolls and clears the bottom tab bar.
+- r6: The console header is trimmed to fit a narrow top bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -20,3 +20,4 @@ Notes on the mobile layout of the live session console.
 - r17: On mobile the Workspace renders a single panel at a time.
 - r18: A horizontally scrollable tab bar switches between panels.
 - r19: The active panel is highlighted in the tab bar.
+- r20: useIsMobile selects the mobile workspace at 768px and below.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -14,3 +14,4 @@ Notes on the mobile layout of the live session console.
 - r11: The status pill and run controls stay visible.
 - r12: The session client is hidden on mobile to save width.
 - r13: Panel tabs cover every swappable panel.
+- r14: The desktop mosaic layout is untouched.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -15,3 +15,4 @@ Notes on the mobile layout of the live session console.
 - r12: The session client is hidden on mobile to save width.
 - r13: Panel tabs cover every swappable panel.
 - r14: The desktop mosaic layout is untouched.
+- r15: The mobile console reads as one focused panel with a switcher.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -49,3 +49,4 @@ Notes on the mobile layout of the live session console.
 - r46: The desktop mosaic layout is untouched.
 - r47: The mobile console reads as one focused panel with a switcher.
 - r48: The desktop mosaic tiling does not work on a phone.
+- r49: On mobile the Workspace renders a single panel at a time.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -8,3 +8,4 @@ Notes on the mobile layout of the live session console.
 - r5: The panel body scrolls and clears the bottom tab bar.
 - r6: The console header is trimmed to fit a narrow top bar.
 - r7: The run metrics and spend are hidden on mobile.
+- r8: The Report button and layout dropdown are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -23,3 +23,4 @@ Notes on the mobile layout of the live session console.
 - r20: useIsMobile selects the mobile workspace at 768px and below.
 - r21: The panel body scrolls and clears the bottom tab bar.
 - r22: The console header is trimmed to fit a narrow top bar.
+- r23: The run metrics and spend are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -60,3 +60,4 @@ Notes on the mobile layout of the live session console.
 - r57: The session name truncates to a single line.
 - r58: The New run button collapses to an icon on mobile.
 - r59: The status pill and run controls stay visible.
+- r60: The session client is hidden on mobile to save width.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -26,3 +26,4 @@ Notes on the mobile layout of the live session console.
 - r23: The run metrics and spend are hidden on mobile.
 - r24: The Report button and layout dropdown are hidden on mobile.
 - r25: The session name truncates to a single line.
+- r26: The New run button collapses to an icon on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -7,3 +7,4 @@ Notes on the mobile layout of the live session console.
 - r4: useIsMobile selects the mobile workspace at 768px and below.
 - r5: The panel body scrolls and clears the bottom tab bar.
 - r6: The console header is trimmed to fit a narrow top bar.
+- r7: The run metrics and spend are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -32,3 +32,4 @@ Notes on the mobile layout of the live session console.
 - r29: Panel tabs cover every swappable panel.
 - r30: The desktop mosaic layout is untouched.
 - r31: The mobile console reads as one focused panel with a switcher.
+- r32: The desktop mosaic tiling does not work on a phone.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -58,3 +58,4 @@ Notes on the mobile layout of the live session console.
 - r55: The run metrics and spend are hidden on mobile.
 - r56: The Report button and layout dropdown are hidden on mobile.
 - r57: The session name truncates to a single line.
+- r58: The New run button collapses to an icon on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -21,3 +21,4 @@ Notes on the mobile layout of the live session console.
 - r18: A horizontally scrollable tab bar switches between panels.
 - r19: The active panel is highlighted in the tab bar.
 - r20: useIsMobile selects the mobile workspace at 768px and below.
+- r21: The panel body scrolls and clears the bottom tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -77,3 +77,4 @@ Notes on the mobile layout of the live session console.
 - r74: The New run button collapses to an icon on mobile.
 - r75: The status pill and run controls stay visible.
 - r76: The session client is hidden on mobile to save width.
+- r77: Panel tabs cover every swappable panel.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -55,3 +55,4 @@ Notes on the mobile layout of the live session console.
 - r52: useIsMobile selects the mobile workspace at 768px and below.
 - r53: The panel body scrolls and clears the bottom tab bar.
 - r54: The console header is trimmed to fit a narrow top bar.
+- r55: The run metrics and spend are hidden on mobile.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -73,3 +73,4 @@ Notes on the mobile layout of the live session console.
 - r70: The console header is trimmed to fit a narrow top bar.
 - r71: The run metrics and spend are hidden on mobile.
 - r72: The Report button and layout dropdown are hidden on mobile.
+- r73: The session name truncates to a single line.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -78,3 +78,4 @@ Notes on the mobile layout of the live session console.
 - r75: The status pill and run controls stay visible.
 - r76: The session client is hidden on mobile to save width.
 - r77: Panel tabs cover every swappable panel.
+- r78: The desktop mosaic layout is untouched.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -9,3 +9,4 @@ Notes on the mobile layout of the live session console.
 - r6: The console header is trimmed to fit a narrow top bar.
 - r7: The run metrics and spend are hidden on mobile.
 - r8: The Report button and layout dropdown are hidden on mobile.
+- r9: The session name truncates to a single line.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -82,3 +82,4 @@ Notes on the mobile layout of the live session console.
 - r79: The mobile console reads as one focused panel with a switcher.
 - r80: The desktop mosaic tiling does not work on a phone.
 - r81: On mobile the Workspace renders a single panel at a time.
+- r82: A horizontally scrollable tab bar switches between panels.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -99,3 +99,4 @@ Notes on the mobile layout of the live session console.
 - r96: The desktop mosaic tiling does not work on a phone.
 - r97: On mobile the Workspace renders a single panel at a time.
 - r98: A horizontally scrollable tab bar switches between panels.
+- r99: The active panel is highlighted in the tab bar.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -75,3 +75,4 @@ Notes on the mobile layout of the live session console.
 - r72: The Report button and layout dropdown are hidden on mobile.
 - r73: The session name truncates to a single line.
 - r74: The New run button collapses to an icon on mobile.
+- r75: The status pill and run controls stay visible.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -16,3 +16,4 @@ Notes on the mobile layout of the live session console.
 - r13: Panel tabs cover every swappable panel.
 - r14: The desktop mosaic layout is untouched.
 - r15: The mobile console reads as one focused panel with a switcher.
+- r16: The desktop mosaic tiling does not work on a phone.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -76,3 +76,4 @@ Notes on the mobile layout of the live session console.
 - r73: The session name truncates to a single line.
 - r74: The New run button collapses to an icon on mobile.
 - r75: The status pill and run controls stay visible.
+- r76: The session client is hidden on mobile to save width.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -79,3 +79,4 @@ Notes on the mobile layout of the live session console.
 - r76: The session client is hidden on mobile to save width.
 - r77: Panel tabs cover every swappable panel.
 - r78: The desktop mosaic layout is untouched.
+- r79: The mobile console reads as one focused panel with a switcher.

--- a/docs/mobile/console.md
+++ b/docs/mobile/console.md
@@ -40,3 +40,4 @@ Notes on the mobile layout of the live session console.
 - r37: The panel body scrolls and clears the bottom tab bar.
 - r38: The console header is trimmed to fit a narrow top bar.
 - r39: The run metrics and spend are hidden on mobile.
+- r40: The Report button and layout dropdown are hidden on mobile.


### PR DESCRIPTION
Part of #96 (epic #102). The desktop mosaic tiling is unusable on a phone.

- At <=768px the `Workspace` renders a `MobileWorkspace`: a horizontally scrollable panel tab bar plus one `PanelView` at a time (`useIsMobile` gated).
- Console header trimmed for mobile: metrics, spend, Report, and the layout dropdown hidden; session name truncates; New run collapses to an icon; run controls and status pill stay.

Desktop mosaic untouched.

Verified locally: typecheck, eslint, vitest (61 incl. MobileWorkspace), build. Browser-checked at 390x844: panel switching works (Agents, Findings, ...).