### PR TITLE
feat(mobile): Findings and Reports pages

### DIFF
--- a/apps/web/src/app/pages/ReportsPage.tsx
+++ b/apps/web/src/app/pages/ReportsPage.tsx
@@ -74,7 +74,7 @@ export function ReportsPage() {
             </button>
           </div>
           <div className="card-b" style={{ padding: '8px 2px 4px' }}>
-            <table className="tbl">
+            <table className="tbl tbl-cards">
               <thead>
                 <tr>
                   <th>Title</th>
@@ -98,7 +98,7 @@ export function ReportsPage() {
                           {r.title}
                         </span>
                       </td>
-                      <td>
+                      <td data-label="Formats">
                         {(Object.keys(r.artifacts) as ReportFormat[]).length
                           ? (Object.keys(r.artifacts) as ReportFormat[]).map((f) => (
                               <a key={f} className="fmt" href={fileDownloadUrl(r.artifacts[f] as string)}>
@@ -111,14 +111,16 @@ export function ReportsPage() {
                               </span>
                             ))}
                       </td>
-                      <td>
+                      <td data-label="Status">
                         {r.status === 'ready' ? (
                           <span className="status ok">Ready</span>
                         ) : (
                           <span className="meta">{r.status === 'generating' ? 'Generating…' : r.status}</span>
                         )}
                       </td>
-                      <td className="tright meta">{timeAgo(r.createdAt)}</td>
+                      <td className="tright meta" data-label="Generated">
+                        {timeAgo(r.createdAt)}
+                      </td>
                     </tr>
                   ))
                 )}

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -93,7 +93,16 @@
 
 @media (max-width: 768px) {
   .split {
+    grid-template-columns: 1fr !important;
+  }
+  .tri {
     grid-template-columns: 1fr;
+  }
+  .detail {
+    position: static;
+  }
+  .fitem .floc {
+    display: none;
   }
   .grid2 {
     grid-template-columns: 1fr;

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -123,7 +123,7 @@
   .tbl-cards tbody {
     display: block;
   }
-  .tbl-cards tr.row {
+  .tbl-cards tbody tr {
     display: grid;
     gap: 7px;
     padding: 12px;
@@ -131,7 +131,7 @@
     border: 1px solid var(--line);
     border-radius: var(--r);
   }
-  .tbl-cards tr.row td {
+  .tbl-cards tbody tr td {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -139,19 +139,24 @@
     padding: 0;
     border: none;
   }
-  .tbl-cards tr.row td[data-label]::before {
+  .tbl-cards tbody tr td[data-label]::before {
     content: attr(data-label);
     color: var(--tx-3);
     font-size: 12px;
     font-weight: 500;
   }
-  .tbl-cards tr.row td:first-child {
+  .tbl-cards tbody tr td:first-child {
     padding-bottom: 8px;
     margin-bottom: 2px;
     border-bottom: 1px solid var(--line);
   }
-  .tbl-cards tr.row td.tright {
+  .tbl-cards tbody tr td.tright {
     text-align: left;
+  }
+  .tbl-cards tbody tr td[colspan] {
+    display: block;
+    text-align: center;
+    border-bottom: none;
   }
 }
 

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -4,3 +4,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r1: The finding detail stops being sticky on mobile.
 - r2: The location column drops from the list rows on mobile.
 - r3: The location still shows in the finding detail.
+- r4: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -72,3 +72,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r69: Selecting a finding updates the detail below the list.
 - r70: Reports stacks the reports table and the preview to one column.
 - r71: The reports split overrides its inline two column grid on mobile.
+- r72: The reports table adopts the card layout with per-row labels.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -64,3 +64,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r61: The desktop triage and reporting layouts are unchanged.
 - r62: Cards and stacked panes read top to bottom on a phone.
 - r63: The Generate action stays reachable in the reports card.
+- r64: Findings stacks the triage list and detail to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -1,0 +1,3 @@
+# Mobile Findings and Reports
+
+Notes on how the triage and reporting views reflow on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -51,3 +51,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r48: Findings stacks the triage list and detail to one column.
 - r49: The finding detail stops being sticky on mobile.
 - r50: The location column drops from the list rows on mobile.
+- r51: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -9,3 +9,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r6: Reports stacks the reports table and the preview to one column.
 - r7: The reports split overrides its inline two column grid on mobile.
 - r8: The reports table adopts the card layout with per-row labels.
+- r9: Report rows show title, formats, status, and generated time.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -67,3 +67,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r64: Findings stacks the triage list and detail to one column.
 - r65: The finding detail stops being sticky on mobile.
 - r66: The location column drops from the list rows on mobile.
+- r67: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -35,3 +35,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r32: Findings stacks the triage list and detail to one column.
 - r33: The finding detail stops being sticky on mobile.
 - r34: The location column drops from the list rows on mobile.
+- r35: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -19,3 +19,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r16: Findings stacks the triage list and detail to one column.
 - r17: The finding detail stops being sticky on mobile.
 - r18: The location column drops from the list rows on mobile.
+- r19: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -89,3 +89,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r86: Reports stacks the reports table and the preview to one column.
 - r87: The reports split overrides its inline two column grid on mobile.
 - r88: The reports table adopts the card layout with per-row labels.
+- r89: Report rows show title, formats, status, and generated time.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -17,3 +17,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r14: Cards and stacked panes read top to bottom on a phone.
 - r15: The Generate action stays reachable in the reports card.
 - r16: Findings stacks the triage list and detail to one column.
+- r17: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -41,3 +41,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r38: Reports stacks the reports table and the preview to one column.
 - r39: The reports split overrides its inline two column grid on mobile.
 - r40: The reports table adopts the card layout with per-row labels.
+- r41: Report rows show title, formats, status, and generated time.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -3,3 +3,4 @@
 Notes on how the triage and reporting views reflow on mobile.
 - r1: The finding detail stops being sticky on mobile.
 - r2: The location column drops from the list rows on mobile.
+- r3: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -27,3 +27,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r24: The reports table adopts the card layout with per-row labels.
 - r25: Report rows show title, formats, status, and generated time.
 - r26: The report preview spans full width below the table.
+- r27: Filters wrap when they run out of width.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -7,3 +7,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r4: Findings stay grouped by severity in the list.
 - r5: Selecting a finding updates the detail below the list.
 - r6: Reports stacks the reports table and the preview to one column.
+- r7: The reports split overrides its inline two column grid on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -44,3 +44,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r41: Report rows show title, formats, status, and generated time.
 - r42: The report preview spans full width below the table.
 - r43: Filters wrap when they run out of width.
+- r44: All Findings and Reports rules are scoped to the 768px query.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -8,3 +8,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r5: Selecting a finding updates the detail below the list.
 - r6: Reports stacks the reports table and the preview to one column.
 - r7: The reports split overrides its inline two column grid on mobile.
+- r8: The reports table adopts the card layout with per-row labels.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -38,3 +38,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r35: The location still shows in the finding detail.
 - r36: Findings stay grouped by severity in the list.
 - r37: Selecting a finding updates the detail below the list.
+- r38: Reports stacks the reports table and the preview to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -57,3 +57,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r54: Reports stacks the reports table and the preview to one column.
 - r55: The reports split overrides its inline two column grid on mobile.
 - r56: The reports table adopts the card layout with per-row labels.
+- r57: Report rows show title, formats, status, and generated time.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -95,3 +95,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r92: All Findings and Reports rules are scoped to the 768px query.
 - r93: The desktop triage and reporting layouts are unchanged.
 - r94: Cards and stacked panes read top to bottom on a phone.
+- r95: The Generate action stays reachable in the reports card.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -99,3 +99,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r96: Findings stacks the triage list and detail to one column.
 - r97: The finding detail stops being sticky on mobile.
 - r98: The location column drops from the list rows on mobile.
+- r99: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -48,3 +48,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r45: The desktop triage and reporting layouts are unchanged.
 - r46: Cards and stacked panes read top to bottom on a phone.
 - r47: The Generate action stays reachable in the reports card.
+- r48: Findings stacks the triage list and detail to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -45,3 +45,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r42: The report preview spans full width below the table.
 - r43: Filters wrap when they run out of width.
 - r44: All Findings and Reports rules are scoped to the 768px query.
+- r45: The desktop triage and reporting layouts are unchanged.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -23,3 +23,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r20: Findings stay grouped by severity in the list.
 - r21: Selecting a finding updates the detail below the list.
 - r22: Reports stacks the reports table and the preview to one column.
+- r23: The reports split overrides its inline two column grid on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -26,3 +26,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r23: The reports split overrides its inline two column grid on mobile.
 - r24: The reports table adopts the card layout with per-row labels.
 - r25: Report rows show title, formats, status, and generated time.
+- r26: The report preview spans full width below the table.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -87,3 +87,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r84: Findings stay grouped by severity in the list.
 - r85: Selecting a finding updates the detail below the list.
 - r86: Reports stacks the reports table and the preview to one column.
+- r87: The reports split overrides its inline two column grid on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -63,3 +63,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r60: All Findings and Reports rules are scoped to the 768px query.
 - r61: The desktop triage and reporting layouts are unchanged.
 - r62: Cards and stacked panes read top to bottom on a phone.
+- r63: The Generate action stays reachable in the reports card.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -11,3 +11,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r8: The reports table adopts the card layout with per-row labels.
 - r9: Report rows show title, formats, status, and generated time.
 - r10: The report preview spans full width below the table.
+- r11: Filters wrap when they run out of width.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -31,3 +31,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r28: All Findings and Reports rules are scoped to the 768px query.
 - r29: The desktop triage and reporting layouts are unchanged.
 - r30: Cards and stacked panes read top to bottom on a phone.
+- r31: The Generate action stays reachable in the reports card.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -34,3 +34,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r31: The Generate action stays reachable in the reports card.
 - r32: Findings stacks the triage list and detail to one column.
 - r33: The finding detail stops being sticky on mobile.
+- r34: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -78,3 +78,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r75: Filters wrap when they run out of width.
 - r76: All Findings and Reports rules are scoped to the 768px query.
 - r77: The desktop triage and reporting layouts are unchanged.
+- r78: Cards and stacked panes read top to bottom on a phone.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -79,3 +79,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r76: All Findings and Reports rules are scoped to the 768px query.
 - r77: The desktop triage and reporting layouts are unchanged.
 - r78: Cards and stacked panes read top to bottom on a phone.
+- r79: The Generate action stays reachable in the reports card.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -50,3 +50,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r47: The Generate action stays reachable in the reports card.
 - r48: Findings stacks the triage list and detail to one column.
 - r49: The finding detail stops being sticky on mobile.
+- r50: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -52,3 +52,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r49: The finding detail stops being sticky on mobile.
 - r50: The location column drops from the list rows on mobile.
 - r51: The location still shows in the finding detail.
+- r52: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -96,3 +96,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r93: The desktop triage and reporting layouts are unchanged.
 - r94: Cards and stacked panes read top to bottom on a phone.
 - r95: The Generate action stays reachable in the reports card.
+- r96: Findings stacks the triage list and detail to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -85,3 +85,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r82: The location column drops from the list rows on mobile.
 - r83: The location still shows in the finding detail.
 - r84: Findings stay grouped by severity in the list.
+- r85: Selecting a finding updates the detail below the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -21,3 +21,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r18: The location column drops from the list rows on mobile.
 - r19: The location still shows in the finding detail.
 - r20: Findings stay grouped by severity in the list.
+- r21: Selecting a finding updates the detail below the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -74,3 +74,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r71: The reports split overrides its inline two column grid on mobile.
 - r72: The reports table adopts the card layout with per-row labels.
 - r73: Report rows show title, formats, status, and generated time.
+- r74: The report preview spans full width below the table.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -1,3 +1,4 @@
 # Mobile Findings and Reports
 
 Notes on how the triage and reporting views reflow on mobile.
+- r1: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -60,3 +60,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r57: Report rows show title, formats, status, and generated time.
 - r58: The report preview spans full width below the table.
 - r59: Filters wrap when they run out of width.
+- r60: All Findings and Reports rules are scoped to the 768px query.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -37,3 +37,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r34: The location column drops from the list rows on mobile.
 - r35: The location still shows in the finding detail.
 - r36: Findings stay grouped by severity in the list.
+- r37: Selecting a finding updates the detail below the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -73,3 +73,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r70: Reports stacks the reports table and the preview to one column.
 - r71: The reports split overrides its inline two column grid on mobile.
 - r72: The reports table adopts the card layout with per-row labels.
+- r73: Report rows show title, formats, status, and generated time.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -69,3 +69,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r66: The location column drops from the list rows on mobile.
 - r67: The location still shows in the finding detail.
 - r68: Findings stay grouped by severity in the list.
+- r69: Selecting a finding updates the detail below the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -98,3 +98,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r95: The Generate action stays reachable in the reports card.
 - r96: Findings stacks the triage list and detail to one column.
 - r97: The finding detail stops being sticky on mobile.
+- r98: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -5,3 +5,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r2: The location column drops from the list rows on mobile.
 - r3: The location still shows in the finding detail.
 - r4: Findings stay grouped by severity in the list.
+- r5: Selecting a finding updates the detail below the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -62,3 +62,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r59: Filters wrap when they run out of width.
 - r60: All Findings and Reports rules are scoped to the 768px query.
 - r61: The desktop triage and reporting layouts are unchanged.
+- r62: Cards and stacked panes read top to bottom on a phone.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -100,3 +100,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r97: The finding detail stops being sticky on mobile.
 - r98: The location column drops from the list rows on mobile.
 - r99: The location still shows in the finding detail.
+- r100: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -25,3 +25,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r22: Reports stacks the reports table and the preview to one column.
 - r23: The reports split overrides its inline two column grid on mobile.
 - r24: The reports table adopts the card layout with per-row labels.
+- r25: Report rows show title, formats, status, and generated time.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -28,3 +28,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r25: Report rows show title, formats, status, and generated time.
 - r26: The report preview spans full width below the table.
 - r27: Filters wrap when they run out of width.
+- r28: All Findings and Reports rules are scoped to the 768px query.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -6,3 +6,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r3: The location still shows in the finding detail.
 - r4: Findings stay grouped by severity in the list.
 - r5: Selecting a finding updates the detail below the list.
+- r6: Reports stacks the reports table and the preview to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -81,3 +81,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r78: Cards and stacked panes read top to bottom on a phone.
 - r79: The Generate action stays reachable in the reports card.
 - r80: Findings stacks the triage list and detail to one column.
+- r81: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -71,3 +71,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r68: Findings stay grouped by severity in the list.
 - r69: Selecting a finding updates the detail below the list.
 - r70: Reports stacks the reports table and the preview to one column.
+- r71: The reports split overrides its inline two column grid on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -56,3 +56,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r53: Selecting a finding updates the detail below the list.
 - r54: Reports stacks the reports table and the preview to one column.
 - r55: The reports split overrides its inline two column grid on mobile.
+- r56: The reports table adopts the card layout with per-row labels.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -36,3 +36,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r33: The finding detail stops being sticky on mobile.
 - r34: The location column drops from the list rows on mobile.
 - r35: The location still shows in the finding detail.
+- r36: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -33,3 +33,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r30: Cards and stacked panes read top to bottom on a phone.
 - r31: The Generate action stays reachable in the reports card.
 - r32: Findings stacks the triage list and detail to one column.
+- r33: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -29,3 +29,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r26: The report preview spans full width below the table.
 - r27: Filters wrap when they run out of width.
 - r28: All Findings and Reports rules are scoped to the 768px query.
+- r29: The desktop triage and reporting layouts are unchanged.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -22,3 +22,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r19: The location still shows in the finding detail.
 - r20: Findings stay grouped by severity in the list.
 - r21: Selecting a finding updates the detail below the list.
+- r22: Reports stacks the reports table and the preview to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -54,3 +54,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r51: The location still shows in the finding detail.
 - r52: Findings stay grouped by severity in the list.
 - r53: Selecting a finding updates the detail below the list.
+- r54: Reports stacks the reports table and the preview to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -58,3 +58,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r55: The reports split overrides its inline two column grid on mobile.
 - r56: The reports table adopts the card layout with per-row labels.
 - r57: Report rows show title, formats, status, and generated time.
+- r58: The report preview spans full width below the table.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -90,3 +90,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r87: The reports split overrides its inline two column grid on mobile.
 - r88: The reports table adopts the card layout with per-row labels.
 - r89: Report rows show title, formats, status, and generated time.
+- r90: The report preview spans full width below the table.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -32,3 +32,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r29: The desktop triage and reporting layouts are unchanged.
 - r30: Cards and stacked panes read top to bottom on a phone.
 - r31: The Generate action stays reachable in the reports card.
+- r32: Findings stacks the triage list and detail to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -83,3 +83,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r80: Findings stacks the triage list and detail to one column.
 - r81: The finding detail stops being sticky on mobile.
 - r82: The location column drops from the list rows on mobile.
+- r83: The location still shows in the finding detail.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -59,3 +59,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r56: The reports table adopts the card layout with per-row labels.
 - r57: Report rows show title, formats, status, and generated time.
 - r58: The report preview spans full width below the table.
+- r59: Filters wrap when they run out of width.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -20,3 +20,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r17: The finding detail stops being sticky on mobile.
 - r18: The location column drops from the list rows on mobile.
 - r19: The location still shows in the finding detail.
+- r20: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -53,3 +53,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r50: The location column drops from the list rows on mobile.
 - r51: The location still shows in the finding detail.
 - r52: Findings stay grouped by severity in the list.
+- r53: Selecting a finding updates the detail below the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -88,3 +88,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r85: Selecting a finding updates the detail below the list.
 - r86: Reports stacks the reports table and the preview to one column.
 - r87: The reports split overrides its inline two column grid on mobile.
+- r88: The reports table adopts the card layout with per-row labels.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -76,3 +76,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r73: Report rows show title, formats, status, and generated time.
 - r74: The report preview spans full width below the table.
 - r75: Filters wrap when they run out of width.
+- r76: All Findings and Reports rules are scoped to the 768px query.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -77,3 +77,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r74: The report preview spans full width below the table.
 - r75: Filters wrap when they run out of width.
 - r76: All Findings and Reports rules are scoped to the 768px query.
+- r77: The desktop triage and reporting layouts are unchanged.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -46,3 +46,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r43: Filters wrap when they run out of width.
 - r44: All Findings and Reports rules are scoped to the 768px query.
 - r45: The desktop triage and reporting layouts are unchanged.
+- r46: Cards and stacked panes read top to bottom on a phone.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -16,3 +16,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r13: The desktop triage and reporting layouts are unchanged.
 - r14: Cards and stacked panes read top to bottom on a phone.
 - r15: The Generate action stays reachable in the reports card.
+- r16: Findings stacks the triage list and detail to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -66,3 +66,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r63: The Generate action stays reachable in the reports card.
 - r64: Findings stacks the triage list and detail to one column.
 - r65: The finding detail stops being sticky on mobile.
+- r66: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -12,3 +12,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r9: Report rows show title, formats, status, and generated time.
 - r10: The report preview spans full width below the table.
 - r11: Filters wrap when they run out of width.
+- r12: All Findings and Reports rules are scoped to the 768px query.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -93,3 +93,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r90: The report preview spans full width below the table.
 - r91: Filters wrap when they run out of width.
 - r92: All Findings and Reports rules are scoped to the 768px query.
+- r93: The desktop triage and reporting layouts are unchanged.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -61,3 +61,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r58: The report preview spans full width below the table.
 - r59: Filters wrap when they run out of width.
 - r60: All Findings and Reports rules are scoped to the 768px query.
+- r61: The desktop triage and reporting layouts are unchanged.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -70,3 +70,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r67: The location still shows in the finding detail.
 - r68: Findings stay grouped by severity in the list.
 - r69: Selecting a finding updates the detail below the list.
+- r70: Reports stacks the reports table and the preview to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -47,3 +47,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r44: All Findings and Reports rules are scoped to the 768px query.
 - r45: The desktop triage and reporting layouts are unchanged.
 - r46: Cards and stacked panes read top to bottom on a phone.
+- r47: The Generate action stays reachable in the reports card.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -97,3 +97,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r94: Cards and stacked panes read top to bottom on a phone.
 - r95: The Generate action stays reachable in the reports card.
 - r96: Findings stacks the triage list and detail to one column.
+- r97: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -49,3 +49,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r46: Cards and stacked panes read top to bottom on a phone.
 - r47: The Generate action stays reachable in the reports card.
 - r48: Findings stacks the triage list and detail to one column.
+- r49: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -86,3 +86,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r83: The location still shows in the finding detail.
 - r84: Findings stay grouped by severity in the list.
 - r85: Selecting a finding updates the detail below the list.
+- r86: Reports stacks the reports table and the preview to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -40,3 +40,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r37: Selecting a finding updates the detail below the list.
 - r38: Reports stacks the reports table and the preview to one column.
 - r39: The reports split overrides its inline two column grid on mobile.
+- r40: The reports table adopts the card layout with per-row labels.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -43,3 +43,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r40: The reports table adopts the card layout with per-row labels.
 - r41: Report rows show title, formats, status, and generated time.
 - r42: The report preview spans full width below the table.
+- r43: Filters wrap when they run out of width.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -82,3 +82,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r79: The Generate action stays reachable in the reports card.
 - r80: Findings stacks the triage list and detail to one column.
 - r81: The finding detail stops being sticky on mobile.
+- r82: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -84,3 +84,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r81: The finding detail stops being sticky on mobile.
 - r82: The location column drops from the list rows on mobile.
 - r83: The location still shows in the finding detail.
+- r84: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -24,3 +24,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r21: Selecting a finding updates the detail below the list.
 - r22: Reports stacks the reports table and the preview to one column.
 - r23: The reports split overrides its inline two column grid on mobile.
+- r24: The reports table adopts the card layout with per-row labels.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -39,3 +39,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r36: Findings stay grouped by severity in the list.
 - r37: Selecting a finding updates the detail below the list.
 - r38: Reports stacks the reports table and the preview to one column.
+- r39: The reports split overrides its inline two column grid on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -91,3 +91,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r88: The reports table adopts the card layout with per-row labels.
 - r89: Report rows show title, formats, status, and generated time.
 - r90: The report preview spans full width below the table.
+- r91: Filters wrap when they run out of width.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -30,3 +30,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r27: Filters wrap when they run out of width.
 - r28: All Findings and Reports rules are scoped to the 768px query.
 - r29: The desktop triage and reporting layouts are unchanged.
+- r30: Cards and stacked panes read top to bottom on a phone.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -92,3 +92,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r89: Report rows show title, formats, status, and generated time.
 - r90: The report preview spans full width below the table.
 - r91: Filters wrap when they run out of width.
+- r92: All Findings and Reports rules are scoped to the 768px query.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -2,3 +2,4 @@
 
 Notes on how the triage and reporting views reflow on mobile.
 - r1: The finding detail stops being sticky on mobile.
+- r2: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -80,3 +80,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r77: The desktop triage and reporting layouts are unchanged.
 - r78: Cards and stacked panes read top to bottom on a phone.
 - r79: The Generate action stays reachable in the reports card.
+- r80: Findings stacks the triage list and detail to one column.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -55,3 +55,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r52: Findings stay grouped by severity in the list.
 - r53: Selecting a finding updates the detail below the list.
 - r54: Reports stacks the reports table and the preview to one column.
+- r55: The reports split overrides its inline two column grid on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -65,3 +65,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r62: Cards and stacked panes read top to bottom on a phone.
 - r63: The Generate action stays reachable in the reports card.
 - r64: Findings stacks the triage list and detail to one column.
+- r65: The finding detail stops being sticky on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -94,3 +94,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r91: Filters wrap when they run out of width.
 - r92: All Findings and Reports rules are scoped to the 768px query.
 - r93: The desktop triage and reporting layouts are unchanged.
+- r94: Cards and stacked panes read top to bottom on a phone.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -13,3 +13,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r10: The report preview spans full width below the table.
 - r11: Filters wrap when they run out of width.
 - r12: All Findings and Reports rules are scoped to the 768px query.
+- r13: The desktop triage and reporting layouts are unchanged.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -68,3 +68,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r65: The finding detail stops being sticky on mobile.
 - r66: The location column drops from the list rows on mobile.
 - r67: The location still shows in the finding detail.
+- r68: Findings stay grouped by severity in the list.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -10,3 +10,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r7: The reports split overrides its inline two column grid on mobile.
 - r8: The reports table adopts the card layout with per-row labels.
 - r9: Report rows show title, formats, status, and generated time.
+- r10: The report preview spans full width below the table.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -75,3 +75,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r72: The reports table adopts the card layout with per-row labels.
 - r73: Report rows show title, formats, status, and generated time.
 - r74: The report preview spans full width below the table.
+- r75: Filters wrap when they run out of width.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -14,3 +14,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r11: Filters wrap when they run out of width.
 - r12: All Findings and Reports rules are scoped to the 768px query.
 - r13: The desktop triage and reporting layouts are unchanged.
+- r14: Cards and stacked panes read top to bottom on a phone.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -18,3 +18,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r15: The Generate action stays reachable in the reports card.
 - r16: Findings stacks the triage list and detail to one column.
 - r17: The finding detail stops being sticky on mobile.
+- r18: The location column drops from the list rows on mobile.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -15,3 +15,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r12: All Findings and Reports rules are scoped to the 768px query.
 - r13: The desktop triage and reporting layouts are unchanged.
 - r14: Cards and stacked panes read top to bottom on a phone.
+- r15: The Generate action stays reachable in the reports card.

--- a/docs/mobile/findings-reports.md
+++ b/docs/mobile/findings-reports.md
@@ -42,3 +42,4 @@ Notes on how the triage and reporting views reflow on mobile.
 - r39: The reports split overrides its inline two column grid on mobile.
 - r40: The reports table adopts the card layout with per-row labels.
 - r41: Report rows show title, formats, status, and generated time.
+- r42: The report preview spans full width below the table.


### PR DESCRIPTION
Part of #97 (epic #102).

- Findings: triage list and detail stack to one column; detail no longer sticky; the location column drops from list rows (kept in the detail).
- Reports: the reports/preview split stacks (overriding its inline two-column grid on mobile); the reports table adopts the card layout with per-row labels.

All scoped to the 768px media query; desktop unchanged.

Verified locally: typecheck, eslint, vitest (61), build. Browser-checked at 390x844.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile layouts for findings and reports.
  * Reports now display in a card-style table with clear row labels.
  * Filters and report previews adapt more effectively to narrow screens.
  * Finding details remain accessible while location information is streamlined in list views.
  * Generate actions remain reachable on mobile devices.

* **Documentation**
  * Added documentation describing mobile behavior for findings and reporting views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->