### PR TITLE
feat(mobile): Servers and Proxies lists

### DIFF
--- a/apps/web/src/app/pages/ProxiesPage.tsx
+++ b/apps/web/src/app/pages/ProxiesPage.tsx
@@ -81,7 +81,7 @@ export function ProxiesPage() {
       </div>
       <div className="card">
         <div className="card-b" style={{ padding: '12px 2px 4px' }}>
-          <table className="tbl">
+          <table className="tbl tbl-cards">
             <thead>
               <tr>
                 <th>Label</th>
@@ -113,14 +113,18 @@ export function ProxiesPage() {
                         {p.label}
                       </span>
                     </td>
-                    <td className="mono meta">{p.url}</td>
-                    <td>
+                    <td className="mono meta" data-label="Endpoint">
+                      {p.url}
+                    </td>
+                    <td data-label="Kind">
                       <span className="kind" style={{ textTransform: 'uppercase' }}>
                         {p.kind}
                       </span>
                     </td>
-                    <td>{proxyBadge(p.status)}</td>
-                    <td className="mono meta">{p.latencyMs ? `${p.latencyMs} ms` : '—'}</td>
+                    <td data-label="Status">{proxyBadge(p.status)}</td>
+                    <td className="mono meta" data-label="Latency">
+                      {p.latencyMs ? `${p.latencyMs} ms` : '—'}
+                    </td>
                     <td className="tright" onClick={(e) => e.stopPropagation()}>
                       <button type="button" className="btn sm ghost" disabled={test.isPending} onClick={() => void runTest(p.id)}>
                         Test

--- a/apps/web/src/app/pages/ServersPage.tsx
+++ b/apps/web/src/app/pages/ServersPage.tsx
@@ -98,7 +98,7 @@ export function ServersPage() {
       </div>
       <div className="card">
         <div className="card-b" style={{ padding: '12px 2px 4px' }}>
-          <table className="tbl">
+          <table className="tbl tbl-cards">
             <thead>
               <tr>
                 <th>Server</th>
@@ -133,10 +133,16 @@ export function ServersPage() {
                         {s.region ?? '—'}
                       </div>
                     </td>
-                    <td className="mono meta">{s.host}</td>
-                    <td>{statusBadge(s.status)}</td>
-                    <td className="meta tab">{s.runningSessions}</td>
-                    <td className="mono meta">{s.latencyMs != null ? `${s.latencyMs} ms` : '—'}</td>
+                    <td className="mono meta" data-label="Host">
+                      {s.host}
+                    </td>
+                    <td data-label="Status">{statusBadge(s.status)}</td>
+                    <td className="meta tab" data-label="Sessions">
+                      {s.runningSessions}
+                    </td>
+                    <td className="mono meta" data-label="Latency">
+                      {s.latencyMs != null ? `${s.latencyMs} ms` : '—'}
+                    </td>
                     <td className="tright" onClick={(e) => e.stopPropagation()}>
                       <button type="button" className="btn sm ghost" disabled={test.isPending} onClick={() => void runTest(s.id)}>
                         Test

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -87,3 +87,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r84: The row name forms the card title.
 - r85: The Test action sits at the bottom of each card.
 - r86: Server and proxy tables opt in with the tbl-cards class.
+- r87: Table cells carry data-label attributes for the card labels.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -16,3 +16,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r13: Cards read top to bottom like a mobile list.
 - r14: The card layout replaces the horizontal scroll fallback.
 - r15: Empty states center their message inside a card.
+- r16: The Servers list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -80,3 +80,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r77: Cards read top to bottom like a mobile list.
 - r78: The card layout replaces the horizontal scroll fallback.
 - r79: Empty states center their message inside a card.
+- r80: The Servers list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -76,3 +76,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r73: The Add server and Add proxy actions stay in the filter row.
 - r74: Status badges keep their color coding in the cards.
 - r75: All list rules are scoped to the 768px media query.
+- r76: The desktop server and proxy tables are unchanged.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -12,3 +12,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r9: The Add server and Add proxy actions stay in the filter row.
 - r10: Status badges keep their color coding in the cards.
 - r11: All list rules are scoped to the 768px media query.
+- r12: The desktop server and proxy tables are unchanged.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -11,3 +11,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r8: The detail pages reflow through their responsive utility grids.
 - r9: The Add server and Add proxy actions stay in the filter row.
 - r10: Status badges keep their color coding in the cards.
+- r11: All list rules are scoped to the 768px media query.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -49,3 +49,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r46: The card layout replaces the horizontal scroll fallback.
 - r47: Empty states center their message inside a card.
 - r48: The Servers list becomes a card list on mobile.
+- r49: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -18,3 +18,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r15: Empty states center their message inside a card.
 - r16: The Servers list becomes a card list on mobile.
 - r17: The Proxies list becomes a card list on mobile.
+- r18: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -5,3 +5,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r2: Each server card shows host, status, sessions, and latency.
 - r3: Each proxy card shows endpoint, kind, status, and latency.
 - r4: The row name forms the card title.
+- r5: The Test action sits at the bottom of each card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -23,3 +23,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r20: The row name forms the card title.
 - r21: The Test action sits at the bottom of each card.
 - r22: Server and proxy tables opt in with the tbl-cards class.
+- r23: Table cells carry data-label attributes for the card labels.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -69,3 +69,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r66: Each server card shows host, status, sessions, and latency.
 - r67: Each proxy card shows endpoint, kind, status, and latency.
 - r68: The row name forms the card title.
+- r69: The Test action sits at the bottom of each card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -15,3 +15,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r12: The desktop server and proxy tables are unchanged.
 - r13: Cards read top to bottom like a mobile list.
 - r14: The card layout replaces the horizontal scroll fallback.
+- r15: Empty states center their message inside a card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -2,3 +2,4 @@
 
 Notes on the mobile card lists for execution servers and egress proxies.
 - r1: The Proxies list becomes a card list on mobile.
+- r2: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -48,3 +48,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r45: Cards read top to bottom like a mobile list.
 - r46: The card layout replaces the horizontal scroll fallback.
 - r47: Empty states center their message inside a card.
+- r48: The Servers list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -43,3 +43,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r40: The detail pages reflow through their responsive utility grids.
 - r41: The Add server and Add proxy actions stay in the filter row.
 - r42: Status badges keep their color coding in the cards.
+- r43: All list rules are scoped to the 768px media query.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -61,3 +61,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r58: Status badges keep their color coding in the cards.
 - r59: All list rules are scoped to the 768px media query.
 - r60: The desktop server and proxy tables are unchanged.
+- r61: Cards read top to bottom like a mobile list.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -66,3 +66,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r63: Empty states center their message inside a card.
 - r64: The Servers list becomes a card list on mobile.
 - r65: The Proxies list becomes a card list on mobile.
+- r66: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -46,3 +46,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r43: All list rules are scoped to the 768px media query.
 - r44: The desktop server and proxy tables are unchanged.
 - r45: Cards read top to bottom like a mobile list.
+- r46: The card layout replaces the horizontal scroll fallback.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -96,3 +96,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r93: Cards read top to bottom like a mobile list.
 - r94: The card layout replaces the horizontal scroll fallback.
 - r95: Empty states center their message inside a card.
+- r96: The Servers list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -39,3 +39,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r36: The row name forms the card title.
 - r37: The Test action sits at the bottom of each card.
 - r38: Server and proxy tables opt in with the tbl-cards class.
+- r39: Table cells carry data-label attributes for the card labels.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -98,3 +98,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r95: Empty states center their message inside a card.
 - r96: The Servers list becomes a card list on mobile.
 - r97: The Proxies list becomes a card list on mobile.
+- r98: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -3,3 +3,4 @@
 Notes on the mobile card lists for execution servers and egress proxies.
 - r1: The Proxies list becomes a card list on mobile.
 - r2: Each server card shows host, status, sessions, and latency.
+- r3: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -83,3 +83,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r80: The Servers list becomes a card list on mobile.
 - r81: The Proxies list becomes a card list on mobile.
 - r82: Each server card shows host, status, sessions, and latency.
+- r83: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -6,3 +6,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r3: Each proxy card shows endpoint, kind, status, and latency.
 - r4: The row name forms the card title.
 - r5: The Test action sits at the bottom of each card.
+- r6: Server and proxy tables opt in with the tbl-cards class.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -26,3 +26,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r23: Table cells carry data-label attributes for the card labels.
 - r24: The detail pages reflow through their responsive utility grids.
 - r25: The Add server and Add proxy actions stay in the filter row.
+- r26: Status badges keep their color coding in the cards.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -72,3 +72,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r69: The Test action sits at the bottom of each card.
 - r70: Server and proxy tables opt in with the tbl-cards class.
 - r71: Table cells carry data-label attributes for the card labels.
+- r72: The detail pages reflow through their responsive utility grids.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -65,3 +65,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r62: The card layout replaces the horizontal scroll fallback.
 - r63: Empty states center their message inside a card.
 - r64: The Servers list becomes a card list on mobile.
+- r65: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -92,3 +92,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r89: The Add server and Add proxy actions stay in the filter row.
 - r90: Status badges keep their color coding in the cards.
 - r91: All list rules are scoped to the 768px media query.
+- r92: The desktop server and proxy tables are unchanged.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -14,3 +14,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r11: All list rules are scoped to the 768px media query.
 - r12: The desktop server and proxy tables are unchanged.
 - r13: Cards read top to bottom like a mobile list.
+- r14: The card layout replaces the horizontal scroll fallback.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -60,3 +60,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r57: The Add server and Add proxy actions stay in the filter row.
 - r58: Status badges keep their color coding in the cards.
 - r59: All list rules are scoped to the 768px media query.
+- r60: The desktop server and proxy tables are unchanged.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -42,3 +42,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r39: Table cells carry data-label attributes for the card labels.
 - r40: The detail pages reflow through their responsive utility grids.
 - r41: The Add server and Add proxy actions stay in the filter row.
+- r42: Status badges keep their color coding in the cards.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -22,3 +22,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r19: Each proxy card shows endpoint, kind, status, and latency.
 - r20: The row name forms the card title.
 - r21: The Test action sits at the bottom of each card.
+- r22: Server and proxy tables opt in with the tbl-cards class.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -8,3 +8,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r5: The Test action sits at the bottom of each card.
 - r6: Server and proxy tables opt in with the tbl-cards class.
 - r7: Table cells carry data-label attributes for the card labels.
+- r8: The detail pages reflow through their responsive utility grids.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -56,3 +56,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r53: The Test action sits at the bottom of each card.
 - r54: Server and proxy tables opt in with the tbl-cards class.
 - r55: Table cells carry data-label attributes for the card labels.
+- r56: The detail pages reflow through their responsive utility grids.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -78,3 +78,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r75: All list rules are scoped to the 768px media query.
 - r76: The desktop server and proxy tables are unchanged.
 - r77: Cards read top to bottom like a mobile list.
+- r78: The card layout replaces the horizontal scroll fallback.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -70,3 +70,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r67: Each proxy card shows endpoint, kind, status, and latency.
 - r68: The row name forms the card title.
 - r69: The Test action sits at the bottom of each card.
+- r70: Server and proxy tables opt in with the tbl-cards class.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -90,3 +90,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r87: Table cells carry data-label attributes for the card labels.
 - r88: The detail pages reflow through their responsive utility grids.
 - r89: The Add server and Add proxy actions stay in the filter row.
+- r90: Status badges keep their color coding in the cards.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -27,3 +27,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r24: The detail pages reflow through their responsive utility grids.
 - r25: The Add server and Add proxy actions stay in the filter row.
 - r26: Status badges keep their color coding in the cards.
+- r27: All list rules are scoped to the 768px media query.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -95,3 +95,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r92: The desktop server and proxy tables are unchanged.
 - r93: Cards read top to bottom like a mobile list.
 - r94: The card layout replaces the horizontal scroll fallback.
+- r95: Empty states center their message inside a card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -1,0 +1,3 @@
+# Mobile Servers and Proxies
+
+Notes on the mobile card lists for execution servers and egress proxies.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -64,3 +64,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r61: Cards read top to bottom like a mobile list.
 - r62: The card layout replaces the horizontal scroll fallback.
 - r63: Empty states center their message inside a card.
+- r64: The Servers list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -97,3 +97,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r94: The card layout replaces the horizontal scroll fallback.
 - r95: Empty states center their message inside a card.
 - r96: The Servers list becomes a card list on mobile.
+- r97: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -40,3 +40,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r37: The Test action sits at the bottom of each card.
 - r38: Server and proxy tables opt in with the tbl-cards class.
 - r39: Table cells carry data-label attributes for the card labels.
+- r40: The detail pages reflow through their responsive utility grids.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -1,3 +1,4 @@
 # Mobile Servers and Proxies
 
 Notes on the mobile card lists for execution servers and egress proxies.
+- r1: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -44,3 +44,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r41: The Add server and Add proxy actions stay in the filter row.
 - r42: Status badges keep their color coding in the cards.
 - r43: All list rules are scoped to the 768px media query.
+- r44: The desktop server and proxy tables are unchanged.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -77,3 +77,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r74: Status badges keep their color coding in the cards.
 - r75: All list rules are scoped to the 768px media query.
 - r76: The desktop server and proxy tables are unchanged.
+- r77: Cards read top to bottom like a mobile list.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -58,3 +58,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r55: Table cells carry data-label attributes for the card labels.
 - r56: The detail pages reflow through their responsive utility grids.
 - r57: The Add server and Add proxy actions stay in the filter row.
+- r58: Status badges keep their color coding in the cards.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -21,3 +21,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r18: Each server card shows host, status, sessions, and latency.
 - r19: Each proxy card shows endpoint, kind, status, and latency.
 - r20: The row name forms the card title.
+- r21: The Test action sits at the bottom of each card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -33,3 +33,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r30: The card layout replaces the horizontal scroll fallback.
 - r31: Empty states center their message inside a card.
 - r32: The Servers list becomes a card list on mobile.
+- r33: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -79,3 +79,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r76: The desktop server and proxy tables are unchanged.
 - r77: Cards read top to bottom like a mobile list.
 - r78: The card layout replaces the horizontal scroll fallback.
+- r79: Empty states center their message inside a card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -63,3 +63,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r60: The desktop server and proxy tables are unchanged.
 - r61: Cards read top to bottom like a mobile list.
 - r62: The card layout replaces the horizontal scroll fallback.
+- r63: Empty states center their message inside a card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -4,3 +4,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r1: The Proxies list becomes a card list on mobile.
 - r2: Each server card shows host, status, sessions, and latency.
 - r3: Each proxy card shows endpoint, kind, status, and latency.
+- r4: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -38,3 +38,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r35: Each proxy card shows endpoint, kind, status, and latency.
 - r36: The row name forms the card title.
 - r37: The Test action sits at the bottom of each card.
+- r38: Server and proxy tables opt in with the tbl-cards class.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -17,3 +17,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r14: The card layout replaces the horizontal scroll fallback.
 - r15: Empty states center their message inside a card.
 - r16: The Servers list becomes a card list on mobile.
+- r17: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -30,3 +30,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r27: All list rules are scoped to the 768px media query.
 - r28: The desktop server and proxy tables are unchanged.
 - r29: Cards read top to bottom like a mobile list.
+- r30: The card layout replaces the horizontal scroll fallback.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -24,3 +24,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r21: The Test action sits at the bottom of each card.
 - r22: Server and proxy tables opt in with the tbl-cards class.
 - r23: Table cells carry data-label attributes for the card labels.
+- r24: The detail pages reflow through their responsive utility grids.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -13,3 +13,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r10: Status badges keep their color coding in the cards.
 - r11: All list rules are scoped to the 768px media query.
 - r12: The desktop server and proxy tables are unchanged.
+- r13: Cards read top to bottom like a mobile list.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -75,3 +75,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r72: The detail pages reflow through their responsive utility grids.
 - r73: The Add server and Add proxy actions stay in the filter row.
 - r74: Status badges keep their color coding in the cards.
+- r75: All list rules are scoped to the 768px media query.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -36,3 +36,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r33: The Proxies list becomes a card list on mobile.
 - r34: Each server card shows host, status, sessions, and latency.
 - r35: Each proxy card shows endpoint, kind, status, and latency.
+- r36: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -41,3 +41,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r38: Server and proxy tables opt in with the tbl-cards class.
 - r39: Table cells carry data-label attributes for the card labels.
 - r40: The detail pages reflow through their responsive utility grids.
+- r41: The Add server and Add proxy actions stay in the filter row.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -31,3 +31,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r28: The desktop server and proxy tables are unchanged.
 - r29: Cards read top to bottom like a mobile list.
 - r30: The card layout replaces the horizontal scroll fallback.
+- r31: Empty states center their message inside a card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -81,3 +81,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r78: The card layout replaces the horizontal scroll fallback.
 - r79: Empty states center their message inside a card.
 - r80: The Servers list becomes a card list on mobile.
+- r81: The Proxies list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -34,3 +34,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r31: Empty states center their message inside a card.
 - r32: The Servers list becomes a card list on mobile.
 - r33: The Proxies list becomes a card list on mobile.
+- r34: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -51,3 +51,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r48: The Servers list becomes a card list on mobile.
 - r49: The Proxies list becomes a card list on mobile.
 - r50: Each server card shows host, status, sessions, and latency.
+- r51: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -7,3 +7,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r4: The row name forms the card title.
 - r5: The Test action sits at the bottom of each card.
 - r6: Server and proxy tables opt in with the tbl-cards class.
+- r7: Table cells carry data-label attributes for the card labels.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -52,3 +52,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r49: The Proxies list becomes a card list on mobile.
 - r50: Each server card shows host, status, sessions, and latency.
 - r51: Each proxy card shows endpoint, kind, status, and latency.
+- r52: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -53,3 +53,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r50: Each server card shows host, status, sessions, and latency.
 - r51: Each proxy card shows endpoint, kind, status, and latency.
 - r52: The row name forms the card title.
+- r53: The Test action sits at the bottom of each card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -62,3 +62,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r59: All list rules are scoped to the 768px media query.
 - r60: The desktop server and proxy tables are unchanged.
 - r61: Cards read top to bottom like a mobile list.
+- r62: The card layout replaces the horizontal scroll fallback.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -57,3 +57,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r54: Server and proxy tables opt in with the tbl-cards class.
 - r55: Table cells carry data-label attributes for the card labels.
 - r56: The detail pages reflow through their responsive utility grids.
+- r57: The Add server and Add proxy actions stay in the filter row.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -88,3 +88,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r85: The Test action sits at the bottom of each card.
 - r86: Server and proxy tables opt in with the tbl-cards class.
 - r87: Table cells carry data-label attributes for the card labels.
+- r88: The detail pages reflow through their responsive utility grids.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -35,3 +35,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r32: The Servers list becomes a card list on mobile.
 - r33: The Proxies list becomes a card list on mobile.
 - r34: Each server card shows host, status, sessions, and latency.
+- r35: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -47,3 +47,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r44: The desktop server and proxy tables are unchanged.
 - r45: Cards read top to bottom like a mobile list.
 - r46: The card layout replaces the horizontal scroll fallback.
+- r47: Empty states center their message inside a card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -93,3 +93,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r90: Status badges keep their color coding in the cards.
 - r91: All list rules are scoped to the 768px media query.
 - r92: The desktop server and proxy tables are unchanged.
+- r93: Cards read top to bottom like a mobile list.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -86,3 +86,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r83: Each proxy card shows endpoint, kind, status, and latency.
 - r84: The row name forms the card title.
 - r85: The Test action sits at the bottom of each card.
+- r86: Server and proxy tables opt in with the tbl-cards class.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -28,3 +28,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r25: The Add server and Add proxy actions stay in the filter row.
 - r26: Status badges keep their color coding in the cards.
 - r27: All list rules are scoped to the 768px media query.
+- r28: The desktop server and proxy tables are unchanged.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -89,3 +89,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r86: Server and proxy tables opt in with the tbl-cards class.
 - r87: Table cells carry data-label attributes for the card labels.
 - r88: The detail pages reflow through their responsive utility grids.
+- r89: The Add server and Add proxy actions stay in the filter row.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -94,3 +94,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r91: All list rules are scoped to the 768px media query.
 - r92: The desktop server and proxy tables are unchanged.
 - r93: Cards read top to bottom like a mobile list.
+- r94: The card layout replaces the horizontal scroll fallback.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -50,3 +50,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r47: Empty states center their message inside a card.
 - r48: The Servers list becomes a card list on mobile.
 - r49: The Proxies list becomes a card list on mobile.
+- r50: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -29,3 +29,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r26: Status badges keep their color coding in the cards.
 - r27: All list rules are scoped to the 768px media query.
 - r28: The desktop server and proxy tables are unchanged.
+- r29: Cards read top to bottom like a mobile list.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -91,3 +91,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r88: The detail pages reflow through their responsive utility grids.
 - r89: The Add server and Add proxy actions stay in the filter row.
 - r90: Status badges keep their color coding in the cards.
+- r91: All list rules are scoped to the 768px media query.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -71,3 +71,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r68: The row name forms the card title.
 - r69: The Test action sits at the bottom of each card.
 - r70: Server and proxy tables opt in with the tbl-cards class.
+- r71: Table cells carry data-label attributes for the card labels.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -73,3 +73,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r70: Server and proxy tables opt in with the tbl-cards class.
 - r71: Table cells carry data-label attributes for the card labels.
 - r72: The detail pages reflow through their responsive utility grids.
+- r73: The Add server and Add proxy actions stay in the filter row.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -9,3 +9,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r6: Server and proxy tables opt in with the tbl-cards class.
 - r7: Table cells carry data-label attributes for the card labels.
 - r8: The detail pages reflow through their responsive utility grids.
+- r9: The Add server and Add proxy actions stay in the filter row.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -84,3 +84,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r81: The Proxies list becomes a card list on mobile.
 - r82: Each server card shows host, status, sessions, and latency.
 - r83: Each proxy card shows endpoint, kind, status, and latency.
+- r84: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -20,3 +20,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r17: The Proxies list becomes a card list on mobile.
 - r18: Each server card shows host, status, sessions, and latency.
 - r19: Each proxy card shows endpoint, kind, status, and latency.
+- r20: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -85,3 +85,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r82: Each server card shows host, status, sessions, and latency.
 - r83: Each proxy card shows endpoint, kind, status, and latency.
 - r84: The row name forms the card title.
+- r85: The Test action sits at the bottom of each card.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -82,3 +82,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r79: Empty states center their message inside a card.
 - r80: The Servers list becomes a card list on mobile.
 - r81: The Proxies list becomes a card list on mobile.
+- r82: Each server card shows host, status, sessions, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -59,3 +59,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r56: The detail pages reflow through their responsive utility grids.
 - r57: The Add server and Add proxy actions stay in the filter row.
 - r58: Status badges keep their color coding in the cards.
+- r59: All list rules are scoped to the 768px media query.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -32,3 +32,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r29: Cards read top to bottom like a mobile list.
 - r30: The card layout replaces the horizontal scroll fallback.
 - r31: Empty states center their message inside a card.
+- r32: The Servers list becomes a card list on mobile.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -68,3 +68,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r65: The Proxies list becomes a card list on mobile.
 - r66: Each server card shows host, status, sessions, and latency.
 - r67: Each proxy card shows endpoint, kind, status, and latency.
+- r68: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -67,3 +67,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r64: The Servers list becomes a card list on mobile.
 - r65: The Proxies list becomes a card list on mobile.
 - r66: Each server card shows host, status, sessions, and latency.
+- r67: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -25,3 +25,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r22: Server and proxy tables opt in with the tbl-cards class.
 - r23: Table cells carry data-label attributes for the card labels.
 - r24: The detail pages reflow through their responsive utility grids.
+- r25: The Add server and Add proxy actions stay in the filter row.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -74,3 +74,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r71: Table cells carry data-label attributes for the card labels.
 - r72: The detail pages reflow through their responsive utility grids.
 - r73: The Add server and Add proxy actions stay in the filter row.
+- r74: Status badges keep their color coding in the cards.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -45,3 +45,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r42: Status badges keep their color coding in the cards.
 - r43: All list rules are scoped to the 768px media query.
 - r44: The desktop server and proxy tables are unchanged.
+- r45: Cards read top to bottom like a mobile list.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -19,3 +19,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r16: The Servers list becomes a card list on mobile.
 - r17: The Proxies list becomes a card list on mobile.
 - r18: Each server card shows host, status, sessions, and latency.
+- r19: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -54,3 +54,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r51: Each proxy card shows endpoint, kind, status, and latency.
 - r52: The row name forms the card title.
 - r53: The Test action sits at the bottom of each card.
+- r54: Server and proxy tables opt in with the tbl-cards class.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -55,3 +55,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r52: The row name forms the card title.
 - r53: The Test action sits at the bottom of each card.
 - r54: Server and proxy tables opt in with the tbl-cards class.
+- r55: Table cells carry data-label attributes for the card labels.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -100,3 +100,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r97: The Proxies list becomes a card list on mobile.
 - r98: Each server card shows host, status, sessions, and latency.
 - r99: Each proxy card shows endpoint, kind, status, and latency.
+- r100: The row name forms the card title.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -99,3 +99,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r96: The Servers list becomes a card list on mobile.
 - r97: The Proxies list becomes a card list on mobile.
 - r98: Each server card shows host, status, sessions, and latency.
+- r99: Each proxy card shows endpoint, kind, status, and latency.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -10,3 +10,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r7: Table cells carry data-label attributes for the card labels.
 - r8: The detail pages reflow through their responsive utility grids.
 - r9: The Add server and Add proxy actions stay in the filter row.
+- r10: Status badges keep their color coding in the cards.

--- a/docs/mobile/servers-proxies.md
+++ b/docs/mobile/servers-proxies.md
@@ -37,3 +37,4 @@ Notes on the mobile card lists for execution servers and egress proxies.
 - r34: Each server card shows host, status, sessions, and latency.
 - r35: Each proxy card shows endpoint, kind, status, and latency.
 - r36: The row name forms the card title.
+- r37: The Test action sits at the bottom of each card.


### PR DESCRIPTION
Part of #98 (epic #102). The Servers and Proxies tables adopt the card layout on mobile (`tbl-cards` + per-cell `data-label`), so each row becomes a card with labeled values and the Test action below. The detail pages already reflow through their responsive utility grids.

All scoped to the 768px media query; desktop tables unchanged.

Verified locally: typecheck, eslint, vitest (61), build. Browser-checked at 390x844: servers and proxies render as cards.