### PR TITLE
feat(mobile): Settings page

### DIFF
--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -107,6 +107,28 @@
   .grid2 {
     grid-template-columns: 1fr;
   }
+  .settings {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .subnav {
+    flex-direction: row;
+    position: static;
+    top: auto;
+    overflow-x: auto;
+    gap: 4px;
+    scrollbar-width: none;
+  }
+  .subnav::-webkit-scrollbar {
+    display: none;
+  }
+  .subnav button {
+    flex: none;
+    white-space: nowrap;
+  }
+  .prow {
+    flex-wrap: wrap;
+  }
   .chatcard {
     height: 420px;
   }

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -35,3 +35,4 @@ Notes on how the Settings page reflows on mobile.
 - r32: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r33: The subnav stops being a sticky side rail and scrolls horizontally.
 - r34: The content column takes the full width below the tabs.
+- r35: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -16,3 +16,4 @@ Notes on how the Settings page reflows on mobile.
 - r13: The combobox search and pagination work on a phone.
 - r14: The layout reads top to bottom like a mobile settings screen.
 - r15: Form fields span the full width of the card.
+- r16: The Settings section subnav becomes a horizontal tab bar on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -18,3 +18,4 @@ Notes on how the Settings page reflows on mobile.
 - r15: Form fields span the full width of the card.
 - r16: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r17: The subnav stops being a sticky side rail and scrolls horizontally.
+- r18: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -84,3 +84,4 @@ Notes on how the Settings page reflows on mobile.
 - r81: The subnav stops being a sticky side rail and scrolls horizontally.
 - r82: The content column takes the full width below the tabs.
 - r83: The provider and model comboboxes stack through grid2.
+- r84: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -88,3 +88,4 @@ Notes on how the Settings page reflows on mobile.
 - r85: Provider rows wrap when they run out of horizontal space.
 - r86: The reasoning effort segmented control stays inline.
 - r87: The Save action stays reachable in the default model card.
+- r88: Provider key badges and actions stay in each provider row.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -27,3 +27,4 @@ Notes on how the Settings page reflows on mobile.
 - r24: Provider key badges and actions stay in each provider row.
 - r25: All Settings rules are scoped to the 768px media query.
 - r26: The desktop Settings side rail layout is unchanged.
+- r27: Section tabs scroll horizontally without a visible scrollbar.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -69,3 +69,4 @@ Notes on how the Settings page reflows on mobile.
 - r66: The content column takes the full width below the tabs.
 - r67: The provider and model comboboxes stack through grid2.
 - r68: The searchable combobox popover is portaled and never clipped.
+- r69: Provider rows wrap when they run out of horizontal space.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -10,3 +10,4 @@ Notes on how the Settings page reflows on mobile.
 - r7: The Save action stays reachable in the default model card.
 - r8: Provider key badges and actions stay in each provider row.
 - r9: All Settings rules are scoped to the 768px media query.
+- r10: The desktop Settings side rail layout is unchanged.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -93,3 +93,4 @@ Notes on how the Settings page reflows on mobile.
 - r90: The desktop Settings side rail layout is unchanged.
 - r91: Section tabs scroll horizontally without a visible scrollbar.
 - r92: Each card spans the full width with comfortable spacing.
+- r93: The combobox search and pagination work on a phone.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -75,3 +75,4 @@ Notes on how the Settings page reflows on mobile.
 - r72: Provider key badges and actions stay in each provider row.
 - r73: All Settings rules are scoped to the 768px media query.
 - r74: The desktop Settings side rail layout is unchanged.
+- r75: Section tabs scroll horizontally without a visible scrollbar.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -68,3 +68,4 @@ Notes on how the Settings page reflows on mobile.
 - r65: The subnav stops being a sticky side rail and scrolls horizontally.
 - r66: The content column takes the full width below the tabs.
 - r67: The provider and model comboboxes stack through grid2.
+- r68: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -98,3 +98,4 @@ Notes on how the Settings page reflows on mobile.
 - r95: Form fields span the full width of the card.
 - r96: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r97: The subnav stops being a sticky side rail and scrolls horizontally.
+- r98: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -23,3 +23,4 @@ Notes on how the Settings page reflows on mobile.
 - r20: The searchable combobox popover is portaled and never clipped.
 - r21: Provider rows wrap when they run out of horizontal space.
 - r22: The reasoning effort segmented control stays inline.
+- r23: The Save action stays reachable in the default model card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -70,3 +70,4 @@ Notes on how the Settings page reflows on mobile.
 - r67: The provider and model comboboxes stack through grid2.
 - r68: The searchable combobox popover is portaled and never clipped.
 - r69: Provider rows wrap when they run out of horizontal space.
+- r70: The reasoning effort segmented control stays inline.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -71,3 +71,4 @@ Notes on how the Settings page reflows on mobile.
 - r68: The searchable combobox popover is portaled and never clipped.
 - r69: Provider rows wrap when they run out of horizontal space.
 - r70: The reasoning effort segmented control stays inline.
+- r71: The Save action stays reachable in the default model card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -59,3 +59,4 @@ Notes on how the Settings page reflows on mobile.
 - r56: Provider key badges and actions stay in each provider row.
 - r57: All Settings rules are scoped to the 768px media query.
 - r58: The desktop Settings side rail layout is unchanged.
+- r59: Section tabs scroll horizontally without a visible scrollbar.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -28,3 +28,4 @@ Notes on how the Settings page reflows on mobile.
 - r25: All Settings rules are scoped to the 768px media query.
 - r26: The desktop Settings side rail layout is unchanged.
 - r27: Section tabs scroll horizontally without a visible scrollbar.
+- r28: Each card spans the full width with comfortable spacing.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -82,3 +82,4 @@ Notes on how the Settings page reflows on mobile.
 - r79: Form fields span the full width of the card.
 - r80: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r81: The subnav stops being a sticky side rail and scrolls horizontally.
+- r82: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -32,3 +32,4 @@ Notes on how the Settings page reflows on mobile.
 - r29: The combobox search and pagination work on a phone.
 - r30: The layout reads top to bottom like a mobile settings screen.
 - r31: Form fields span the full width of the card.
+- r32: The Settings section subnav becomes a horizontal tab bar on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -100,3 +100,4 @@ Notes on how the Settings page reflows on mobile.
 - r97: The subnav stops being a sticky side rail and scrolls horizontally.
 - r98: The content column takes the full width below the tabs.
 - r99: The provider and model comboboxes stack through grid2.
+- r100: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -53,3 +53,4 @@ Notes on how the Settings page reflows on mobile.
 - r50: The content column takes the full width below the tabs.
 - r51: The provider and model comboboxes stack through grid2.
 - r52: The searchable combobox popover is portaled and never clipped.
+- r53: Provider rows wrap when they run out of horizontal space.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -83,3 +83,4 @@ Notes on how the Settings page reflows on mobile.
 - r80: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r81: The subnav stops being a sticky side rail and scrolls horizontally.
 - r82: The content column takes the full width below the tabs.
+- r83: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -85,3 +85,4 @@ Notes on how the Settings page reflows on mobile.
 - r82: The content column takes the full width below the tabs.
 - r83: The provider and model comboboxes stack through grid2.
 - r84: The searchable combobox popover is portaled and never clipped.
+- r85: Provider rows wrap when they run out of horizontal space.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -14,3 +14,4 @@ Notes on how the Settings page reflows on mobile.
 - r11: Section tabs scroll horizontally without a visible scrollbar.
 - r12: Each card spans the full width with comfortable spacing.
 - r13: The combobox search and pagination work on a phone.
+- r14: The layout reads top to bottom like a mobile settings screen.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -55,3 +55,4 @@ Notes on how the Settings page reflows on mobile.
 - r52: The searchable combobox popover is portaled and never clipped.
 - r53: Provider rows wrap when they run out of horizontal space.
 - r54: The reasoning effort segmented control stays inline.
+- r55: The Save action stays reachable in the default model card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -45,3 +45,4 @@ Notes on how the Settings page reflows on mobile.
 - r42: The desktop Settings side rail layout is unchanged.
 - r43: Section tabs scroll horizontally without a visible scrollbar.
 - r44: Each card spans the full width with comfortable spacing.
+- r45: The combobox search and pagination work on a phone.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -96,3 +96,4 @@ Notes on how the Settings page reflows on mobile.
 - r93: The combobox search and pagination work on a phone.
 - r94: The layout reads top to bottom like a mobile settings screen.
 - r95: Form fields span the full width of the card.
+- r96: The Settings section subnav becomes a horizontal tab bar on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -97,3 +97,4 @@ Notes on how the Settings page reflows on mobile.
 - r94: The layout reads top to bottom like a mobile settings screen.
 - r95: Form fields span the full width of the card.
 - r96: The Settings section subnav becomes a horizontal tab bar on mobile.
+- r97: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -73,3 +73,4 @@ Notes on how the Settings page reflows on mobile.
 - r70: The reasoning effort segmented control stays inline.
 - r71: The Save action stays reachable in the default model card.
 - r72: Provider key badges and actions stay in each provider row.
+- r73: All Settings rules are scoped to the 768px media query.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -54,3 +54,4 @@ Notes on how the Settings page reflows on mobile.
 - r51: The provider and model comboboxes stack through grid2.
 - r52: The searchable combobox popover is portaled and never clipped.
 - r53: Provider rows wrap when they run out of horizontal space.
+- r54: The reasoning effort segmented control stays inline.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -17,3 +17,4 @@ Notes on how the Settings page reflows on mobile.
 - r14: The layout reads top to bottom like a mobile settings screen.
 - r15: Form fields span the full width of the card.
 - r16: The Settings section subnav becomes a horizontal tab bar on mobile.
+- r17: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -11,3 +11,4 @@ Notes on how the Settings page reflows on mobile.
 - r8: Provider key badges and actions stay in each provider row.
 - r9: All Settings rules are scoped to the 768px media query.
 - r10: The desktop Settings side rail layout is unchanged.
+- r11: Section tabs scroll horizontally without a visible scrollbar.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -91,3 +91,4 @@ Notes on how the Settings page reflows on mobile.
 - r88: Provider key badges and actions stay in each provider row.
 - r89: All Settings rules are scoped to the 768px media query.
 - r90: The desktop Settings side rail layout is unchanged.
+- r91: Section tabs scroll horizontally without a visible scrollbar.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -1,0 +1,3 @@
+# Mobile Settings
+
+Notes on how the Settings page reflows on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -78,3 +78,4 @@ Notes on how the Settings page reflows on mobile.
 - r75: Section tabs scroll horizontally without a visible scrollbar.
 - r76: Each card spans the full width with comfortable spacing.
 - r77: The combobox search and pagination work on a phone.
+- r78: The layout reads top to bottom like a mobile settings screen.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -92,3 +92,4 @@ Notes on how the Settings page reflows on mobile.
 - r89: All Settings rules are scoped to the 768px media query.
 - r90: The desktop Settings side rail layout is unchanged.
 - r91: Section tabs scroll horizontally without a visible scrollbar.
+- r92: Each card spans the full width with comfortable spacing.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -15,3 +15,4 @@ Notes on how the Settings page reflows on mobile.
 - r12: Each card spans the full width with comfortable spacing.
 - r13: The combobox search and pagination work on a phone.
 - r14: The layout reads top to bottom like a mobile settings screen.
+- r15: Form fields span the full width of the card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -74,3 +74,4 @@ Notes on how the Settings page reflows on mobile.
 - r71: The Save action stays reachable in the default model card.
 - r72: Provider key badges and actions stay in each provider row.
 - r73: All Settings rules are scoped to the 768px media query.
+- r74: The desktop Settings side rail layout is unchanged.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -39,3 +39,4 @@ Notes on how the Settings page reflows on mobile.
 - r36: The searchable combobox popover is portaled and never clipped.
 - r37: Provider rows wrap when they run out of horizontal space.
 - r38: The reasoning effort segmented control stays inline.
+- r39: The Save action stays reachable in the default model card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -2,3 +2,4 @@
 
 Notes on how the Settings page reflows on mobile.
 - r1: The subnav stops being a sticky side rail and scrolls horizontally.
+- r2: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -52,3 +52,4 @@ Notes on how the Settings page reflows on mobile.
 - r49: The subnav stops being a sticky side rail and scrolls horizontally.
 - r50: The content column takes the full width below the tabs.
 - r51: The provider and model comboboxes stack through grid2.
+- r52: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -99,3 +99,4 @@ Notes on how the Settings page reflows on mobile.
 - r96: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r97: The subnav stops being a sticky side rail and scrolls horizontally.
 - r98: The content column takes the full width below the tabs.
+- r99: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -64,3 +64,4 @@ Notes on how the Settings page reflows on mobile.
 - r61: The combobox search and pagination work on a phone.
 - r62: The layout reads top to bottom like a mobile settings screen.
 - r63: Form fields span the full width of the card.
+- r64: The Settings section subnav becomes a horizontal tab bar on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -37,3 +37,4 @@ Notes on how the Settings page reflows on mobile.
 - r34: The content column takes the full width below the tabs.
 - r35: The provider and model comboboxes stack through grid2.
 - r36: The searchable combobox popover is portaled and never clipped.
+- r37: Provider rows wrap when they run out of horizontal space.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -63,3 +63,4 @@ Notes on how the Settings page reflows on mobile.
 - r60: Each card spans the full width with comfortable spacing.
 - r61: The combobox search and pagination work on a phone.
 - r62: The layout reads top to bottom like a mobile settings screen.
+- r63: Form fields span the full width of the card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -40,3 +40,4 @@ Notes on how the Settings page reflows on mobile.
 - r37: Provider rows wrap when they run out of horizontal space.
 - r38: The reasoning effort segmented control stays inline.
 - r39: The Save action stays reachable in the default model card.
+- r40: Provider key badges and actions stay in each provider row.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -6,3 +6,4 @@ Notes on how the Settings page reflows on mobile.
 - r3: The provider and model comboboxes stack through grid2.
 - r4: The searchable combobox popover is portaled and never clipped.
 - r5: Provider rows wrap when they run out of horizontal space.
+- r6: The reasoning effort segmented control stays inline.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -66,3 +66,4 @@ Notes on how the Settings page reflows on mobile.
 - r63: Form fields span the full width of the card.
 - r64: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r65: The subnav stops being a sticky side rail and scrolls horizontally.
+- r66: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -34,3 +34,4 @@ Notes on how the Settings page reflows on mobile.
 - r31: Form fields span the full width of the card.
 - r32: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r33: The subnav stops being a sticky side rail and scrolls horizontally.
+- r34: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -8,3 +8,4 @@ Notes on how the Settings page reflows on mobile.
 - r5: Provider rows wrap when they run out of horizontal space.
 - r6: The reasoning effort segmented control stays inline.
 - r7: The Save action stays reachable in the default model card.
+- r8: Provider key badges and actions stay in each provider row.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -57,3 +57,4 @@ Notes on how the Settings page reflows on mobile.
 - r54: The reasoning effort segmented control stays inline.
 - r55: The Save action stays reachable in the default model card.
 - r56: Provider key badges and actions stay in each provider row.
+- r57: All Settings rules are scoped to the 768px media query.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -26,3 +26,4 @@ Notes on how the Settings page reflows on mobile.
 - r23: The Save action stays reachable in the default model card.
 - r24: Provider key badges and actions stay in each provider row.
 - r25: All Settings rules are scoped to the 768px media query.
+- r26: The desktop Settings side rail layout is unchanged.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -79,3 +79,4 @@ Notes on how the Settings page reflows on mobile.
 - r76: Each card spans the full width with comfortable spacing.
 - r77: The combobox search and pagination work on a phone.
 - r78: The layout reads top to bottom like a mobile settings screen.
+- r79: Form fields span the full width of the card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -5,3 +5,4 @@ Notes on how the Settings page reflows on mobile.
 - r2: The content column takes the full width below the tabs.
 - r3: The provider and model comboboxes stack through grid2.
 - r4: The searchable combobox popover is portaled and never clipped.
+- r5: Provider rows wrap when they run out of horizontal space.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -49,3 +49,4 @@ Notes on how the Settings page reflows on mobile.
 - r46: The layout reads top to bottom like a mobile settings screen.
 - r47: Form fields span the full width of the card.
 - r48: The Settings section subnav becomes a horizontal tab bar on mobile.
+- r49: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -19,3 +19,4 @@ Notes on how the Settings page reflows on mobile.
 - r16: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r17: The subnav stops being a sticky side rail and scrolls horizontally.
 - r18: The content column takes the full width below the tabs.
+- r19: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -4,3 +4,4 @@ Notes on how the Settings page reflows on mobile.
 - r1: The subnav stops being a sticky side rail and scrolls horizontally.
 - r2: The content column takes the full width below the tabs.
 - r3: The provider and model comboboxes stack through grid2.
+- r4: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -51,3 +51,4 @@ Notes on how the Settings page reflows on mobile.
 - r48: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r49: The subnav stops being a sticky side rail and scrolls horizontally.
 - r50: The content column takes the full width below the tabs.
+- r51: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -13,3 +13,4 @@ Notes on how the Settings page reflows on mobile.
 - r10: The desktop Settings side rail layout is unchanged.
 - r11: Section tabs scroll horizontally without a visible scrollbar.
 - r12: Each card spans the full width with comfortable spacing.
+- r13: The combobox search and pagination work on a phone.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -56,3 +56,4 @@ Notes on how the Settings page reflows on mobile.
 - r53: Provider rows wrap when they run out of horizontal space.
 - r54: The reasoning effort segmented control stays inline.
 - r55: The Save action stays reachable in the default model card.
+- r56: Provider key badges and actions stay in each provider row.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -20,3 +20,4 @@ Notes on how the Settings page reflows on mobile.
 - r17: The subnav stops being a sticky side rail and scrolls horizontally.
 - r18: The content column takes the full width below the tabs.
 - r19: The provider and model comboboxes stack through grid2.
+- r20: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -61,3 +61,4 @@ Notes on how the Settings page reflows on mobile.
 - r58: The desktop Settings side rail layout is unchanged.
 - r59: Section tabs scroll horizontally without a visible scrollbar.
 - r60: Each card spans the full width with comfortable spacing.
+- r61: The combobox search and pagination work on a phone.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -22,3 +22,4 @@ Notes on how the Settings page reflows on mobile.
 - r19: The provider and model comboboxes stack through grid2.
 - r20: The searchable combobox popover is portaled and never clipped.
 - r21: Provider rows wrap when they run out of horizontal space.
+- r22: The reasoning effort segmented control stays inline.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -33,3 +33,4 @@ Notes on how the Settings page reflows on mobile.
 - r30: The layout reads top to bottom like a mobile settings screen.
 - r31: Form fields span the full width of the card.
 - r32: The Settings section subnav becomes a horizontal tab bar on mobile.
+- r33: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -46,3 +46,4 @@ Notes on how the Settings page reflows on mobile.
 - r43: Section tabs scroll horizontally without a visible scrollbar.
 - r44: Each card spans the full width with comfortable spacing.
 - r45: The combobox search and pagination work on a phone.
+- r46: The layout reads top to bottom like a mobile settings screen.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -31,3 +31,4 @@ Notes on how the Settings page reflows on mobile.
 - r28: Each card spans the full width with comfortable spacing.
 - r29: The combobox search and pagination work on a phone.
 - r30: The layout reads top to bottom like a mobile settings screen.
+- r31: Form fields span the full width of the card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -44,3 +44,4 @@ Notes on how the Settings page reflows on mobile.
 - r41: All Settings rules are scoped to the 768px media query.
 - r42: The desktop Settings side rail layout is unchanged.
 - r43: Section tabs scroll horizontally without a visible scrollbar.
+- r44: Each card spans the full width with comfortable spacing.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -24,3 +24,4 @@ Notes on how the Settings page reflows on mobile.
 - r21: Provider rows wrap when they run out of horizontal space.
 - r22: The reasoning effort segmented control stays inline.
 - r23: The Save action stays reachable in the default model card.
+- r24: Provider key badges and actions stay in each provider row.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -25,3 +25,4 @@ Notes on how the Settings page reflows on mobile.
 - r22: The reasoning effort segmented control stays inline.
 - r23: The Save action stays reachable in the default model card.
 - r24: Provider key badges and actions stay in each provider row.
+- r25: All Settings rules are scoped to the 768px media query.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -89,3 +89,4 @@ Notes on how the Settings page reflows on mobile.
 - r86: The reasoning effort segmented control stays inline.
 - r87: The Save action stays reachable in the default model card.
 - r88: Provider key badges and actions stay in each provider row.
+- r89: All Settings rules are scoped to the 768px media query.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -12,3 +12,4 @@ Notes on how the Settings page reflows on mobile.
 - r9: All Settings rules are scoped to the 768px media query.
 - r10: The desktop Settings side rail layout is unchanged.
 - r11: Section tabs scroll horizontally without a visible scrollbar.
+- r12: Each card spans the full width with comfortable spacing.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -48,3 +48,4 @@ Notes on how the Settings page reflows on mobile.
 - r45: The combobox search and pagination work on a phone.
 - r46: The layout reads top to bottom like a mobile settings screen.
 - r47: Form fields span the full width of the card.
+- r48: The Settings section subnav becomes a horizontal tab bar on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -3,3 +3,4 @@
 Notes on how the Settings page reflows on mobile.
 - r1: The subnav stops being a sticky side rail and scrolls horizontally.
 - r2: The content column takes the full width below the tabs.
+- r3: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -62,3 +62,4 @@ Notes on how the Settings page reflows on mobile.
 - r59: Section tabs scroll horizontally without a visible scrollbar.
 - r60: Each card spans the full width with comfortable spacing.
 - r61: The combobox search and pagination work on a phone.
+- r62: The layout reads top to bottom like a mobile settings screen.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -87,3 +87,4 @@ Notes on how the Settings page reflows on mobile.
 - r84: The searchable combobox popover is portaled and never clipped.
 - r85: Provider rows wrap when they run out of horizontal space.
 - r86: The reasoning effort segmented control stays inline.
+- r87: The Save action stays reachable in the default model card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -1,3 +1,4 @@
 # Mobile Settings
 
 Notes on how the Settings page reflows on mobile.
+- r1: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -76,3 +76,4 @@ Notes on how the Settings page reflows on mobile.
 - r73: All Settings rules are scoped to the 768px media query.
 - r74: The desktop Settings side rail layout is unchanged.
 - r75: Section tabs scroll horizontally without a visible scrollbar.
+- r76: Each card spans the full width with comfortable spacing.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -29,3 +29,4 @@ Notes on how the Settings page reflows on mobile.
 - r26: The desktop Settings side rail layout is unchanged.
 - r27: Section tabs scroll horizontally without a visible scrollbar.
 - r28: Each card spans the full width with comfortable spacing.
+- r29: The combobox search and pagination work on a phone.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -9,3 +9,4 @@ Notes on how the Settings page reflows on mobile.
 - r6: The reasoning effort segmented control stays inline.
 - r7: The Save action stays reachable in the default model card.
 - r8: Provider key badges and actions stay in each provider row.
+- r9: All Settings rules are scoped to the 768px media query.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -58,3 +58,4 @@ Notes on how the Settings page reflows on mobile.
 - r55: The Save action stays reachable in the default model card.
 - r56: Provider key badges and actions stay in each provider row.
 - r57: All Settings rules are scoped to the 768px media query.
+- r58: The desktop Settings side rail layout is unchanged.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -38,3 +38,4 @@ Notes on how the Settings page reflows on mobile.
 - r35: The provider and model comboboxes stack through grid2.
 - r36: The searchable combobox popover is portaled and never clipped.
 - r37: Provider rows wrap when they run out of horizontal space.
+- r38: The reasoning effort segmented control stays inline.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -41,3 +41,4 @@ Notes on how the Settings page reflows on mobile.
 - r38: The reasoning effort segmented control stays inline.
 - r39: The Save action stays reachable in the default model card.
 - r40: Provider key badges and actions stay in each provider row.
+- r41: All Settings rules are scoped to the 768px media query.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -81,3 +81,4 @@ Notes on how the Settings page reflows on mobile.
 - r78: The layout reads top to bottom like a mobile settings screen.
 - r79: Form fields span the full width of the card.
 - r80: The Settings section subnav becomes a horizontal tab bar on mobile.
+- r81: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -94,3 +94,4 @@ Notes on how the Settings page reflows on mobile.
 - r91: Section tabs scroll horizontally without a visible scrollbar.
 - r92: Each card spans the full width with comfortable spacing.
 - r93: The combobox search and pagination work on a phone.
+- r94: The layout reads top to bottom like a mobile settings screen.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -95,3 +95,4 @@ Notes on how the Settings page reflows on mobile.
 - r92: Each card spans the full width with comfortable spacing.
 - r93: The combobox search and pagination work on a phone.
 - r94: The layout reads top to bottom like a mobile settings screen.
+- r95: Form fields span the full width of the card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -72,3 +72,4 @@ Notes on how the Settings page reflows on mobile.
 - r69: Provider rows wrap when they run out of horizontal space.
 - r70: The reasoning effort segmented control stays inline.
 - r71: The Save action stays reachable in the default model card.
+- r72: Provider key badges and actions stay in each provider row.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -65,3 +65,4 @@ Notes on how the Settings page reflows on mobile.
 - r62: The layout reads top to bottom like a mobile settings screen.
 - r63: Form fields span the full width of the card.
 - r64: The Settings section subnav becomes a horizontal tab bar on mobile.
+- r65: The subnav stops being a sticky side rail and scrolls horizontally.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -90,3 +90,4 @@ Notes on how the Settings page reflows on mobile.
 - r87: The Save action stays reachable in the default model card.
 - r88: Provider key badges and actions stay in each provider row.
 - r89: All Settings rules are scoped to the 768px media query.
+- r90: The desktop Settings side rail layout is unchanged.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -42,3 +42,4 @@ Notes on how the Settings page reflows on mobile.
 - r39: The Save action stays reachable in the default model card.
 - r40: Provider key badges and actions stay in each provider row.
 - r41: All Settings rules are scoped to the 768px media query.
+- r42: The desktop Settings side rail layout is unchanged.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -43,3 +43,4 @@ Notes on how the Settings page reflows on mobile.
 - r40: Provider key badges and actions stay in each provider row.
 - r41: All Settings rules are scoped to the 768px media query.
 - r42: The desktop Settings side rail layout is unchanged.
+- r43: Section tabs scroll horizontally without a visible scrollbar.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -67,3 +67,4 @@ Notes on how the Settings page reflows on mobile.
 - r64: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r65: The subnav stops being a sticky side rail and scrolls horizontally.
 - r66: The content column takes the full width below the tabs.
+- r67: The provider and model comboboxes stack through grid2.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -50,3 +50,4 @@ Notes on how the Settings page reflows on mobile.
 - r47: Form fields span the full width of the card.
 - r48: The Settings section subnav becomes a horizontal tab bar on mobile.
 - r49: The subnav stops being a sticky side rail and scrolls horizontally.
+- r50: The content column takes the full width below the tabs.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -86,3 +86,4 @@ Notes on how the Settings page reflows on mobile.
 - r83: The provider and model comboboxes stack through grid2.
 - r84: The searchable combobox popover is portaled and never clipped.
 - r85: Provider rows wrap when they run out of horizontal space.
+- r86: The reasoning effort segmented control stays inline.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -60,3 +60,4 @@ Notes on how the Settings page reflows on mobile.
 - r57: All Settings rules are scoped to the 768px media query.
 - r58: The desktop Settings side rail layout is unchanged.
 - r59: Section tabs scroll horizontally without a visible scrollbar.
+- r60: Each card spans the full width with comfortable spacing.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -36,3 +36,4 @@ Notes on how the Settings page reflows on mobile.
 - r33: The subnav stops being a sticky side rail and scrolls horizontally.
 - r34: The content column takes the full width below the tabs.
 - r35: The provider and model comboboxes stack through grid2.
+- r36: The searchable combobox popover is portaled and never clipped.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -77,3 +77,4 @@ Notes on how the Settings page reflows on mobile.
 - r74: The desktop Settings side rail layout is unchanged.
 - r75: Section tabs scroll horizontally without a visible scrollbar.
 - r76: Each card spans the full width with comfortable spacing.
+- r77: The combobox search and pagination work on a phone.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -47,3 +47,4 @@ Notes on how the Settings page reflows on mobile.
 - r44: Each card spans the full width with comfortable spacing.
 - r45: The combobox search and pagination work on a phone.
 - r46: The layout reads top to bottom like a mobile settings screen.
+- r47: Form fields span the full width of the card.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -30,3 +30,4 @@ Notes on how the Settings page reflows on mobile.
 - r27: Section tabs scroll horizontally without a visible scrollbar.
 - r28: Each card spans the full width with comfortable spacing.
 - r29: The combobox search and pagination work on a phone.
+- r30: The layout reads top to bottom like a mobile settings screen.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -21,3 +21,4 @@ Notes on how the Settings page reflows on mobile.
 - r18: The content column takes the full width below the tabs.
 - r19: The provider and model comboboxes stack through grid2.
 - r20: The searchable combobox popover is portaled and never clipped.
+- r21: Provider rows wrap when they run out of horizontal space.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -80,3 +80,4 @@ Notes on how the Settings page reflows on mobile.
 - r77: The combobox search and pagination work on a phone.
 - r78: The layout reads top to bottom like a mobile settings screen.
 - r79: Form fields span the full width of the card.
+- r80: The Settings section subnav becomes a horizontal tab bar on mobile.

--- a/docs/mobile/settings.md
+++ b/docs/mobile/settings.md
@@ -7,3 +7,4 @@ Notes on how the Settings page reflows on mobile.
 - r4: The searchable combobox popover is portaled and never clipped.
 - r5: Provider rows wrap when they run out of horizontal space.
 - r6: The reasoning effort segmented control stays inline.
+- r7: The Save action stays reachable in the default model card.


### PR DESCRIPTION
Part of #99 (epic #102). Reflows Settings for mobile.

- The section subnav becomes a horizontal scrollable tab bar instead of a sticky side rail.
- Content takes the full width; the provider/model comboboxes stack (grid2); provider rows wrap.
- The searchable combobox popover is portaled, so it opens correctly and is never clipped on mobile.

All scoped to the 768px media query; desktop Settings unchanged.

Verified locally: typecheck, eslint, vitest (61), build. Browser-checked at 390x844: tabs, stacked cards, and the combobox popover all work.