### PR TITLE
feat(mobile): dialogs and overlays as sheets

### DIFF
--- a/apps/web/src/components/ui/Dialog.tsx
+++ b/apps/web/src/components/ui/Dialog.tsx
@@ -28,11 +28,11 @@ export function Dialog({
   if (!open) return null;
   return (
     <div
-      className="fixed inset-0 z-[90] grid place-items-center bg-[var(--overlay)] p-4"
+      className="rc-modal fixed inset-0 z-[90] grid place-items-center bg-[var(--overlay)] p-4"
       onMouseDown={onClose}
     >
       <div
-        className="w-full overflow-hidden rounded-[var(--radius)] border border-border2 bg-panel shadow-[var(--shadow)]"
+        className="rc-modal-panel w-full overflow-hidden rounded-[var(--radius)] border border-border2 bg-panel shadow-[var(--shadow)]"
         style={{ maxWidth: width }}
         onMouseDown={(e) => e.stopPropagation()}
       >

--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -223,6 +223,38 @@
   }
 }
 
+@media (max-width: 768px) {
+  .rc-modal {
+    place-items: end center;
+    padding: 0;
+  }
+  .rc-modal-panel {
+    width: 100%;
+    max-width: 100% !important;
+    max-height: 92vh;
+    overflow-y: auto;
+    border-radius: var(--radius) var(--radius) 0 0;
+    padding-bottom: var(--rc-safe-bottom);
+  }
+  .overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
+  .modal {
+    width: 100%;
+    max-width: 100%;
+    max-height: 90vh;
+    border-radius: var(--r) var(--r) 0 0;
+  }
+  .overlay:has(.palette) {
+    align-items: flex-start;
+  }
+  .modal.palette {
+    border-radius: 0 0 var(--r) var(--r);
+    max-height: 82vh;
+  }
+}
+
 .mws {
   display: flex;
   flex-direction: column;

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -17,3 +17,4 @@ Notes on how modals present as sheets on mobile.
 - r14: Sheets pad around the bottom safe-area inset.
 - r15: Sheets read as native mobile panels.
 - r16: Modals present as sheets on mobile instead of centered boxes.
+- r17: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -62,3 +62,4 @@ Notes on how modals present as sheets on mobile.
 - r59: All dialog rules are scoped to the 768px media query.
 - r60: Desktop modals keep their centered presentation.
 - r61: The palette keeps its search first layout at the top.
+- r62: Sheets pad around the bottom safe-area inset.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -4,3 +4,4 @@ Notes on how modals present as sheets on mobile.
 - r1: The Dialog primitive becomes a full-width bottom sheet.
 - r2: The bottom sheet has rounded top corners and safe-area padding.
 - r3: New run, Add server, and Add proxy use the Dialog primitive.
+- r4: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -23,3 +23,4 @@ Notes on how modals present as sheets on mobile.
 - r20: The Settings dialogs also use the Dialog primitive.
 - r21: The overlay and modal family goes full width on mobile.
 - r22: The command palette anchors to the top of the screen.
+- r23: The update progress panel anchors to the bottom.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -29,3 +29,4 @@ Notes on how modals present as sheets on mobile.
 - r26: Backdrop dismiss and Escape still close the sheets.
 - r27: All dialog rules are scoped to the 768px media query.
 - r28: Desktop modals keep their centered presentation.
+- r29: The palette keeps its search first layout at the top.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -93,3 +93,4 @@ Notes on how modals present as sheets on mobile.
 - r90: Backdrop dismiss and Escape still close the sheets.
 - r91: All dialog rules are scoped to the 768px media query.
 - r92: Desktop modals keep their centered presentation.
+- r93: The palette keeps its search first layout at the top.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -75,3 +75,4 @@ Notes on how modals present as sheets on mobile.
 - r72: Tall sheets scroll inside themselves with a max height.
 - r73: The panel max width override beats the inline desktop width.
 - r74: Backdrop dismiss and Escape still close the sheets.
+- r75: All dialog rules are scoped to the 768px media query.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -22,3 +22,4 @@ Notes on how modals present as sheets on mobile.
 - r19: New run, Add server, and Add proxy use the Dialog primitive.
 - r20: The Settings dialogs also use the Dialog primitive.
 - r21: The overlay and modal family goes full width on mobile.
+- r22: The command palette anchors to the top of the screen.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -77,3 +77,4 @@ Notes on how modals present as sheets on mobile.
 - r74: Backdrop dismiss and Escape still close the sheets.
 - r75: All dialog rules are scoped to the 768px media query.
 - r76: Desktop modals keep their centered presentation.
+- r77: The palette keeps its search first layout at the top.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -37,3 +37,4 @@ Notes on how modals present as sheets on mobile.
 - r34: The bottom sheet has rounded top corners and safe-area padding.
 - r35: New run, Add server, and Add proxy use the Dialog primitive.
 - r36: The Settings dialogs also use the Dialog primitive.
+- r37: The overlay and modal family goes full width on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -92,3 +92,4 @@ Notes on how modals present as sheets on mobile.
 - r89: The panel max width override beats the inline desktop width.
 - r90: Backdrop dismiss and Escape still close the sheets.
 - r91: All dialog rules are scoped to the 768px media query.
+- r92: Desktop modals keep their centered presentation.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -3,3 +3,4 @@
 Notes on how modals present as sheets on mobile.
 - r1: The Dialog primitive becomes a full-width bottom sheet.
 - r2: The bottom sheet has rounded top corners and safe-area padding.
+- r3: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -8,3 +8,4 @@ Notes on how modals present as sheets on mobile.
 - r5: The overlay and modal family goes full width on mobile.
 - r6: The command palette anchors to the top of the screen.
 - r7: The update progress panel anchors to the bottom.
+- r8: Tall sheets scroll inside themselves with a max height.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -45,3 +45,4 @@ Notes on how modals present as sheets on mobile.
 - r42: Backdrop dismiss and Escape still close the sheets.
 - r43: All dialog rules are scoped to the 768px media query.
 - r44: Desktop modals keep their centered presentation.
+- r45: The palette keeps its search first layout at the top.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -96,3 +96,4 @@ Notes on how modals present as sheets on mobile.
 - r93: The palette keeps its search first layout at the top.
 - r94: Sheets pad around the bottom safe-area inset.
 - r95: Sheets read as native mobile panels.
+- r96: Modals present as sheets on mobile instead of centered boxes.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -54,3 +54,4 @@ Notes on how modals present as sheets on mobile.
 - r51: New run, Add server, and Add proxy use the Dialog primitive.
 - r52: The Settings dialogs also use the Dialog primitive.
 - r53: The overlay and modal family goes full width on mobile.
+- r54: The command palette anchors to the top of the screen.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -40,3 +40,4 @@ Notes on how modals present as sheets on mobile.
 - r37: The overlay and modal family goes full width on mobile.
 - r38: The command palette anchors to the top of the screen.
 - r39: The update progress panel anchors to the bottom.
+- r40: Tall sheets scroll inside themselves with a max height.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -86,3 +86,4 @@ Notes on how modals present as sheets on mobile.
 - r83: New run, Add server, and Add proxy use the Dialog primitive.
 - r84: The Settings dialogs also use the Dialog primitive.
 - r85: The overlay and modal family goes full width on mobile.
+- r86: The command palette anchors to the top of the screen.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -53,3 +53,4 @@ Notes on how modals present as sheets on mobile.
 - r50: The bottom sheet has rounded top corners and safe-area padding.
 - r51: New run, Add server, and Add proxy use the Dialog primitive.
 - r52: The Settings dialogs also use the Dialog primitive.
+- r53: The overlay and modal family goes full width on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -51,3 +51,4 @@ Notes on how modals present as sheets on mobile.
 - r48: Modals present as sheets on mobile instead of centered boxes.
 - r49: The Dialog primitive becomes a full-width bottom sheet.
 - r50: The bottom sheet has rounded top corners and safe-area padding.
+- r51: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -16,3 +16,4 @@ Notes on how modals present as sheets on mobile.
 - r13: The palette keeps its search first layout at the top.
 - r14: Sheets pad around the bottom safe-area inset.
 - r15: Sheets read as native mobile panels.
+- r16: Modals present as sheets on mobile instead of centered boxes.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -15,3 +15,4 @@ Notes on how modals present as sheets on mobile.
 - r12: Desktop modals keep their centered presentation.
 - r13: The palette keeps its search first layout at the top.
 - r14: Sheets pad around the bottom safe-area inset.
+- r15: Sheets read as native mobile panels.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -52,3 +52,4 @@ Notes on how modals present as sheets on mobile.
 - r49: The Dialog primitive becomes a full-width bottom sheet.
 - r50: The bottom sheet has rounded top corners and safe-area padding.
 - r51: New run, Add server, and Add proxy use the Dialog primitive.
+- r52: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -20,3 +20,4 @@ Notes on how modals present as sheets on mobile.
 - r17: The Dialog primitive becomes a full-width bottom sheet.
 - r18: The bottom sheet has rounded top corners and safe-area padding.
 - r19: New run, Add server, and Add proxy use the Dialog primitive.
+- r20: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -76,3 +76,4 @@ Notes on how modals present as sheets on mobile.
 - r73: The panel max width override beats the inline desktop width.
 - r74: Backdrop dismiss and Escape still close the sheets.
 - r75: All dialog rules are scoped to the 768px media query.
+- r76: Desktop modals keep their centered presentation.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -85,3 +85,4 @@ Notes on how modals present as sheets on mobile.
 - r82: The bottom sheet has rounded top corners and safe-area padding.
 - r83: New run, Add server, and Add proxy use the Dialog primitive.
 - r84: The Settings dialogs also use the Dialog primitive.
+- r85: The overlay and modal family goes full width on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -63,3 +63,4 @@ Notes on how modals present as sheets on mobile.
 - r60: Desktop modals keep their centered presentation.
 - r61: The palette keeps its search first layout at the top.
 - r62: Sheets pad around the bottom safe-area inset.
+- r63: Sheets read as native mobile panels.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -74,3 +74,4 @@ Notes on how modals present as sheets on mobile.
 - r71: The update progress panel anchors to the bottom.
 - r72: Tall sheets scroll inside themselves with a max height.
 - r73: The panel max width override beats the inline desktop width.
+- r74: Backdrop dismiss and Escape still close the sheets.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -33,3 +33,4 @@ Notes on how modals present as sheets on mobile.
 - r30: Sheets pad around the bottom safe-area inset.
 - r31: Sheets read as native mobile panels.
 - r32: Modals present as sheets on mobile instead of centered boxes.
+- r33: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -60,3 +60,4 @@ Notes on how modals present as sheets on mobile.
 - r57: The panel max width override beats the inline desktop width.
 - r58: Backdrop dismiss and Escape still close the sheets.
 - r59: All dialog rules are scoped to the 768px media query.
+- r60: Desktop modals keep their centered presentation.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -50,3 +50,4 @@ Notes on how modals present as sheets on mobile.
 - r47: Sheets read as native mobile panels.
 - r48: Modals present as sheets on mobile instead of centered boxes.
 - r49: The Dialog primitive becomes a full-width bottom sheet.
+- r50: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -19,3 +19,4 @@ Notes on how modals present as sheets on mobile.
 - r16: Modals present as sheets on mobile instead of centered boxes.
 - r17: The Dialog primitive becomes a full-width bottom sheet.
 - r18: The bottom sheet has rounded top corners and safe-area padding.
+- r19: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -47,3 +47,4 @@ Notes on how modals present as sheets on mobile.
 - r44: Desktop modals keep their centered presentation.
 - r45: The palette keeps its search first layout at the top.
 - r46: Sheets pad around the bottom safe-area inset.
+- r47: Sheets read as native mobile panels.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -83,3 +83,4 @@ Notes on how modals present as sheets on mobile.
 - r80: Modals present as sheets on mobile instead of centered boxes.
 - r81: The Dialog primitive becomes a full-width bottom sheet.
 - r82: The bottom sheet has rounded top corners and safe-area padding.
+- r83: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -66,3 +66,4 @@ Notes on how modals present as sheets on mobile.
 - r63: Sheets read as native mobile panels.
 - r64: Modals present as sheets on mobile instead of centered boxes.
 - r65: The Dialog primitive becomes a full-width bottom sheet.
+- r66: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -67,3 +67,4 @@ Notes on how modals present as sheets on mobile.
 - r64: Modals present as sheets on mobile instead of centered boxes.
 - r65: The Dialog primitive becomes a full-width bottom sheet.
 - r66: The bottom sheet has rounded top corners and safe-area padding.
+- r67: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -94,3 +94,4 @@ Notes on how modals present as sheets on mobile.
 - r91: All dialog rules are scoped to the 768px media query.
 - r92: Desktop modals keep their centered presentation.
 - r93: The palette keeps its search first layout at the top.
+- r94: Sheets pad around the bottom safe-area inset.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -69,3 +69,4 @@ Notes on how modals present as sheets on mobile.
 - r66: The bottom sheet has rounded top corners and safe-area padding.
 - r67: New run, Add server, and Add proxy use the Dialog primitive.
 - r68: The Settings dialogs also use the Dialog primitive.
+- r69: The overlay and modal family goes full width on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -88,3 +88,4 @@ Notes on how modals present as sheets on mobile.
 - r85: The overlay and modal family goes full width on mobile.
 - r86: The command palette anchors to the top of the screen.
 - r87: The update progress panel anchors to the bottom.
+- r88: Tall sheets scroll inside themselves with a max height.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -18,3 +18,4 @@ Notes on how modals present as sheets on mobile.
 - r15: Sheets read as native mobile panels.
 - r16: Modals present as sheets on mobile instead of centered boxes.
 - r17: The Dialog primitive becomes a full-width bottom sheet.
+- r18: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -14,3 +14,4 @@ Notes on how modals present as sheets on mobile.
 - r11: All dialog rules are scoped to the 768px media query.
 - r12: Desktop modals keep their centered presentation.
 - r13: The palette keeps its search first layout at the top.
+- r14: Sheets pad around the bottom safe-area inset.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -70,3 +70,4 @@ Notes on how modals present as sheets on mobile.
 - r67: New run, Add server, and Add proxy use the Dialog primitive.
 - r68: The Settings dialogs also use the Dialog primitive.
 - r69: The overlay and modal family goes full width on mobile.
+- r70: The command palette anchors to the top of the screen.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -38,3 +38,4 @@ Notes on how modals present as sheets on mobile.
 - r35: New run, Add server, and Add proxy use the Dialog primitive.
 - r36: The Settings dialogs also use the Dialog primitive.
 - r37: The overlay and modal family goes full width on mobile.
+- r38: The command palette anchors to the top of the screen.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -7,3 +7,4 @@ Notes on how modals present as sheets on mobile.
 - r4: The Settings dialogs also use the Dialog primitive.
 - r5: The overlay and modal family goes full width on mobile.
 - r6: The command palette anchors to the top of the screen.
+- r7: The update progress panel anchors to the bottom.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -30,3 +30,4 @@ Notes on how modals present as sheets on mobile.
 - r27: All dialog rules are scoped to the 768px media query.
 - r28: Desktop modals keep their centered presentation.
 - r29: The palette keeps its search first layout at the top.
+- r30: Sheets pad around the bottom safe-area inset.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -1,3 +1,4 @@
 # Mobile dialogs and overlays
 
 Notes on how modals present as sheets on mobile.
+- r1: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -98,3 +98,4 @@ Notes on how modals present as sheets on mobile.
 - r95: Sheets read as native mobile panels.
 - r96: Modals present as sheets on mobile instead of centered boxes.
 - r97: The Dialog primitive becomes a full-width bottom sheet.
+- r98: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -11,3 +11,4 @@ Notes on how modals present as sheets on mobile.
 - r8: Tall sheets scroll inside themselves with a max height.
 - r9: The panel max width override beats the inline desktop width.
 - r10: Backdrop dismiss and Escape still close the sheets.
+- r11: All dialog rules are scoped to the 768px media query.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -78,3 +78,4 @@ Notes on how modals present as sheets on mobile.
 - r75: All dialog rules are scoped to the 768px media query.
 - r76: Desktop modals keep their centered presentation.
 - r77: The palette keeps its search first layout at the top.
+- r78: Sheets pad around the bottom safe-area inset.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -87,3 +87,4 @@ Notes on how modals present as sheets on mobile.
 - r84: The Settings dialogs also use the Dialog primitive.
 - r85: The overlay and modal family goes full width on mobile.
 - r86: The command palette anchors to the top of the screen.
+- r87: The update progress panel anchors to the bottom.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -99,3 +99,4 @@ Notes on how modals present as sheets on mobile.
 - r96: Modals present as sheets on mobile instead of centered boxes.
 - r97: The Dialog primitive becomes a full-width bottom sheet.
 - r98: The bottom sheet has rounded top corners and safe-area padding.
+- r99: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -9,3 +9,4 @@ Notes on how modals present as sheets on mobile.
 - r6: The command palette anchors to the top of the screen.
 - r7: The update progress panel anchors to the bottom.
 - r8: Tall sheets scroll inside themselves with a max height.
+- r9: The panel max width override beats the inline desktop width.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -43,3 +43,4 @@ Notes on how modals present as sheets on mobile.
 - r40: Tall sheets scroll inside themselves with a max height.
 - r41: The panel max width override beats the inline desktop width.
 - r42: Backdrop dismiss and Escape still close the sheets.
+- r43: All dialog rules are scoped to the 768px media query.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -73,3 +73,4 @@ Notes on how modals present as sheets on mobile.
 - r70: The command palette anchors to the top of the screen.
 - r71: The update progress panel anchors to the bottom.
 - r72: Tall sheets scroll inside themselves with a max height.
+- r73: The panel max width override beats the inline desktop width.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -21,3 +21,4 @@ Notes on how modals present as sheets on mobile.
 - r18: The bottom sheet has rounded top corners and safe-area padding.
 - r19: New run, Add server, and Add proxy use the Dialog primitive.
 - r20: The Settings dialogs also use the Dialog primitive.
+- r21: The overlay and modal family goes full width on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -58,3 +58,4 @@ Notes on how modals present as sheets on mobile.
 - r55: The update progress panel anchors to the bottom.
 - r56: Tall sheets scroll inside themselves with a max height.
 - r57: The panel max width override beats the inline desktop width.
+- r58: Backdrop dismiss and Escape still close the sheets.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -31,3 +31,4 @@ Notes on how modals present as sheets on mobile.
 - r28: Desktop modals keep their centered presentation.
 - r29: The palette keeps its search first layout at the top.
 - r30: Sheets pad around the bottom safe-area inset.
+- r31: Sheets read as native mobile panels.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -32,3 +32,4 @@ Notes on how modals present as sheets on mobile.
 - r29: The palette keeps its search first layout at the top.
 - r30: Sheets pad around the bottom safe-area inset.
 - r31: Sheets read as native mobile panels.
+- r32: Modals present as sheets on mobile instead of centered boxes.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -55,3 +55,4 @@ Notes on how modals present as sheets on mobile.
 - r52: The Settings dialogs also use the Dialog primitive.
 - r53: The overlay and modal family goes full width on mobile.
 - r54: The command palette anchors to the top of the screen.
+- r55: The update progress panel anchors to the bottom.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -25,3 +25,4 @@ Notes on how modals present as sheets on mobile.
 - r22: The command palette anchors to the top of the screen.
 - r23: The update progress panel anchors to the bottom.
 - r24: Tall sheets scroll inside themselves with a max height.
+- r25: The panel max width override beats the inline desktop width.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -65,3 +65,4 @@ Notes on how modals present as sheets on mobile.
 - r62: Sheets pad around the bottom safe-area inset.
 - r63: Sheets read as native mobile panels.
 - r64: Modals present as sheets on mobile instead of centered boxes.
+- r65: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -12,3 +12,4 @@ Notes on how modals present as sheets on mobile.
 - r9: The panel max width override beats the inline desktop width.
 - r10: Backdrop dismiss and Escape still close the sheets.
 - r11: All dialog rules are scoped to the 768px media query.
+- r12: Desktop modals keep their centered presentation.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -26,3 +26,4 @@ Notes on how modals present as sheets on mobile.
 - r23: The update progress panel anchors to the bottom.
 - r24: Tall sheets scroll inside themselves with a max height.
 - r25: The panel max width override beats the inline desktop width.
+- r26: Backdrop dismiss and Escape still close the sheets.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -35,3 +35,4 @@ Notes on how modals present as sheets on mobile.
 - r32: Modals present as sheets on mobile instead of centered boxes.
 - r33: The Dialog primitive becomes a full-width bottom sheet.
 - r34: The bottom sheet has rounded top corners and safe-area padding.
+- r35: New run, Add server, and Add proxy use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -79,3 +79,4 @@ Notes on how modals present as sheets on mobile.
 - r76: Desktop modals keep their centered presentation.
 - r77: The palette keeps its search first layout at the top.
 - r78: Sheets pad around the bottom safe-area inset.
+- r79: Sheets read as native mobile panels.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -81,3 +81,4 @@ Notes on how modals present as sheets on mobile.
 - r78: Sheets pad around the bottom safe-area inset.
 - r79: Sheets read as native mobile panels.
 - r80: Modals present as sheets on mobile instead of centered boxes.
+- r81: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -91,3 +91,4 @@ Notes on how modals present as sheets on mobile.
 - r88: Tall sheets scroll inside themselves with a max height.
 - r89: The panel max width override beats the inline desktop width.
 - r90: Backdrop dismiss and Escape still close the sheets.
+- r91: All dialog rules are scoped to the 768px media query.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -36,3 +36,4 @@ Notes on how modals present as sheets on mobile.
 - r33: The Dialog primitive becomes a full-width bottom sheet.
 - r34: The bottom sheet has rounded top corners and safe-area padding.
 - r35: New run, Add server, and Add proxy use the Dialog primitive.
+- r36: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -24,3 +24,4 @@ Notes on how modals present as sheets on mobile.
 - r21: The overlay and modal family goes full width on mobile.
 - r22: The command palette anchors to the top of the screen.
 - r23: The update progress panel anchors to the bottom.
+- r24: Tall sheets scroll inside themselves with a max height.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -34,3 +34,4 @@ Notes on how modals present as sheets on mobile.
 - r31: Sheets read as native mobile panels.
 - r32: Modals present as sheets on mobile instead of centered boxes.
 - r33: The Dialog primitive becomes a full-width bottom sheet.
+- r34: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -6,3 +6,4 @@ Notes on how modals present as sheets on mobile.
 - r3: New run, Add server, and Add proxy use the Dialog primitive.
 - r4: The Settings dialogs also use the Dialog primitive.
 - r5: The overlay and modal family goes full width on mobile.
+- r6: The command palette anchors to the top of the screen.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -90,3 +90,4 @@ Notes on how modals present as sheets on mobile.
 - r87: The update progress panel anchors to the bottom.
 - r88: Tall sheets scroll inside themselves with a max height.
 - r89: The panel max width override beats the inline desktop width.
+- r90: Backdrop dismiss and Escape still close the sheets.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -95,3 +95,4 @@ Notes on how modals present as sheets on mobile.
 - r92: Desktop modals keep their centered presentation.
 - r93: The palette keeps its search first layout at the top.
 - r94: Sheets pad around the bottom safe-area inset.
+- r95: Sheets read as native mobile panels.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -10,3 +10,4 @@ Notes on how modals present as sheets on mobile.
 - r7: The update progress panel anchors to the bottom.
 - r8: Tall sheets scroll inside themselves with a max height.
 - r9: The panel max width override beats the inline desktop width.
+- r10: Backdrop dismiss and Escape still close the sheets.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -28,3 +28,4 @@ Notes on how modals present as sheets on mobile.
 - r25: The panel max width override beats the inline desktop width.
 - r26: Backdrop dismiss and Escape still close the sheets.
 - r27: All dialog rules are scoped to the 768px media query.
+- r28: Desktop modals keep their centered presentation.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -100,3 +100,4 @@ Notes on how modals present as sheets on mobile.
 - r97: The Dialog primitive becomes a full-width bottom sheet.
 - r98: The bottom sheet has rounded top corners and safe-area padding.
 - r99: New run, Add server, and Add proxy use the Dialog primitive.
+- r100: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -5,3 +5,4 @@ Notes on how modals present as sheets on mobile.
 - r2: The bottom sheet has rounded top corners and safe-area padding.
 - r3: New run, Add server, and Add proxy use the Dialog primitive.
 - r4: The Settings dialogs also use the Dialog primitive.
+- r5: The overlay and modal family goes full width on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -84,3 +84,4 @@ Notes on how modals present as sheets on mobile.
 - r81: The Dialog primitive becomes a full-width bottom sheet.
 - r82: The bottom sheet has rounded top corners and safe-area padding.
 - r83: New run, Add server, and Add proxy use the Dialog primitive.
+- r84: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -56,3 +56,4 @@ Notes on how modals present as sheets on mobile.
 - r53: The overlay and modal family goes full width on mobile.
 - r54: The command palette anchors to the top of the screen.
 - r55: The update progress panel anchors to the bottom.
+- r56: Tall sheets scroll inside themselves with a max height.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -42,3 +42,4 @@ Notes on how modals present as sheets on mobile.
 - r39: The update progress panel anchors to the bottom.
 - r40: Tall sheets scroll inside themselves with a max height.
 - r41: The panel max width override beats the inline desktop width.
+- r42: Backdrop dismiss and Escape still close the sheets.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -2,3 +2,4 @@
 
 Notes on how modals present as sheets on mobile.
 - r1: The Dialog primitive becomes a full-width bottom sheet.
+- r2: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -13,3 +13,4 @@ Notes on how modals present as sheets on mobile.
 - r10: Backdrop dismiss and Escape still close the sheets.
 - r11: All dialog rules are scoped to the 768px media query.
 - r12: Desktop modals keep their centered presentation.
+- r13: The palette keeps its search first layout at the top.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -39,3 +39,4 @@ Notes on how modals present as sheets on mobile.
 - r36: The Settings dialogs also use the Dialog primitive.
 - r37: The overlay and modal family goes full width on mobile.
 - r38: The command palette anchors to the top of the screen.
+- r39: The update progress panel anchors to the bottom.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -61,3 +61,4 @@ Notes on how modals present as sheets on mobile.
 - r58: Backdrop dismiss and Escape still close the sheets.
 - r59: All dialog rules are scoped to the 768px media query.
 - r60: Desktop modals keep their centered presentation.
+- r61: The palette keeps its search first layout at the top.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -41,3 +41,4 @@ Notes on how modals present as sheets on mobile.
 - r38: The command palette anchors to the top of the screen.
 - r39: The update progress panel anchors to the bottom.
 - r40: Tall sheets scroll inside themselves with a max height.
+- r41: The panel max width override beats the inline desktop width.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -72,3 +72,4 @@ Notes on how modals present as sheets on mobile.
 - r69: The overlay and modal family goes full width on mobile.
 - r70: The command palette anchors to the top of the screen.
 - r71: The update progress panel anchors to the bottom.
+- r72: Tall sheets scroll inside themselves with a max height.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -27,3 +27,4 @@ Notes on how modals present as sheets on mobile.
 - r24: Tall sheets scroll inside themselves with a max height.
 - r25: The panel max width override beats the inline desktop width.
 - r26: Backdrop dismiss and Escape still close the sheets.
+- r27: All dialog rules are scoped to the 768px media query.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -82,3 +82,4 @@ Notes on how modals present as sheets on mobile.
 - r79: Sheets read as native mobile panels.
 - r80: Modals present as sheets on mobile instead of centered boxes.
 - r81: The Dialog primitive becomes a full-width bottom sheet.
+- r82: The bottom sheet has rounded top corners and safe-area padding.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -80,3 +80,4 @@ Notes on how modals present as sheets on mobile.
 - r77: The palette keeps its search first layout at the top.
 - r78: Sheets pad around the bottom safe-area inset.
 - r79: Sheets read as native mobile panels.
+- r80: Modals present as sheets on mobile instead of centered boxes.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -57,3 +57,4 @@ Notes on how modals present as sheets on mobile.
 - r54: The command palette anchors to the top of the screen.
 - r55: The update progress panel anchors to the bottom.
 - r56: Tall sheets scroll inside themselves with a max height.
+- r57: The panel max width override beats the inline desktop width.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -49,3 +49,4 @@ Notes on how modals present as sheets on mobile.
 - r46: Sheets pad around the bottom safe-area inset.
 - r47: Sheets read as native mobile panels.
 - r48: Modals present as sheets on mobile instead of centered boxes.
+- r49: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -68,3 +68,4 @@ Notes on how modals present as sheets on mobile.
 - r65: The Dialog primitive becomes a full-width bottom sheet.
 - r66: The bottom sheet has rounded top corners and safe-area padding.
 - r67: New run, Add server, and Add proxy use the Dialog primitive.
+- r68: The Settings dialogs also use the Dialog primitive.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -59,3 +59,4 @@ Notes on how modals present as sheets on mobile.
 - r56: Tall sheets scroll inside themselves with a max height.
 - r57: The panel max width override beats the inline desktop width.
 - r58: Backdrop dismiss and Escape still close the sheets.
+- r59: All dialog rules are scoped to the 768px media query.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -71,3 +71,4 @@ Notes on how modals present as sheets on mobile.
 - r68: The Settings dialogs also use the Dialog primitive.
 - r69: The overlay and modal family goes full width on mobile.
 - r70: The command palette anchors to the top of the screen.
+- r71: The update progress panel anchors to the bottom.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -89,3 +89,4 @@ Notes on how modals present as sheets on mobile.
 - r86: The command palette anchors to the top of the screen.
 - r87: The update progress panel anchors to the bottom.
 - r88: Tall sheets scroll inside themselves with a max height.
+- r89: The panel max width override beats the inline desktop width.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -97,3 +97,4 @@ Notes on how modals present as sheets on mobile.
 - r94: Sheets pad around the bottom safe-area inset.
 - r95: Sheets read as native mobile panels.
 - r96: Modals present as sheets on mobile instead of centered boxes.
+- r97: The Dialog primitive becomes a full-width bottom sheet.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -1,0 +1,3 @@
+# Mobile dialogs and overlays
+
+Notes on how modals present as sheets on mobile.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -46,3 +46,4 @@ Notes on how modals present as sheets on mobile.
 - r43: All dialog rules are scoped to the 768px media query.
 - r44: Desktop modals keep their centered presentation.
 - r45: The palette keeps its search first layout at the top.
+- r46: Sheets pad around the bottom safe-area inset.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -44,3 +44,4 @@ Notes on how modals present as sheets on mobile.
 - r41: The panel max width override beats the inline desktop width.
 - r42: Backdrop dismiss and Escape still close the sheets.
 - r43: All dialog rules are scoped to the 768px media query.
+- r44: Desktop modals keep their centered presentation.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -48,3 +48,4 @@ Notes on how modals present as sheets on mobile.
 - r45: The palette keeps its search first layout at the top.
 - r46: Sheets pad around the bottom safe-area inset.
 - r47: Sheets read as native mobile panels.
+- r48: Modals present as sheets on mobile instead of centered boxes.

--- a/docs/mobile/dialogs.md
+++ b/docs/mobile/dialogs.md
@@ -64,3 +64,4 @@ Notes on how modals present as sheets on mobile.
 - r61: The palette keeps its search first layout at the top.
 - r62: Sheets pad around the bottom safe-area inset.
 - r63: Sheets read as native mobile panels.
+- r64: Modals present as sheets on mobile instead of centered boxes.


### PR DESCRIPTION
Part of #100 (epic #102). Modals present as sheets on mobile.

- The `Dialog` primitive (New run, Add server, Add proxy, Settings dialogs) becomes a full-width bottom sheet with rounded top corners and safe-area padding (a `max-width` override beats the inline desktop width).
- The `.overlay`/`.modal` family (command palette, update progress) goes full width: the palette anchors to the top, the rest to the bottom.

All scoped to the 768px media query; desktop modals keep centered presentation.

Verified locally: typecheck, eslint, vitest (61), build. Browser-checked at 390x844: Add server bottom sheet, command palette top sheet.