### PR TITLE
feat(mobile): polish and QA pass

### DIFF
--- a/apps/web/src/styles/mobile.css
+++ b/apps/web/src/styles/mobile.css
@@ -255,6 +255,30 @@
   }
 }
 
+@media (max-width: 768px) {
+  .head {
+    height: auto;
+    min-height: var(--rc-mobile-top-h);
+    padding-top: var(--rc-safe-top);
+  }
+  .iconbtn {
+    width: 38px;
+    height: 38px;
+  }
+  .btn {
+    min-height: 38px;
+  }
+  .chip {
+    min-height: 36px;
+  }
+  .fitem {
+    height: auto;
+    min-height: var(--rc-tap-min);
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
 .mws {
   display: flex;
   flex-direction: column;

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -31,3 +31,4 @@ Notes on the final mobile polish pass.
 - r28: Touch targets follow the mobile minimum where it matters.
 - r29: The bottom bar and top bar respect the safe areas.
 - r30: Typography stays legible at mobile widths.
+- r31: The console reads as a coherent mobile app.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -13,3 +13,4 @@ Notes on the final mobile polish pass.
 - r10: The desktop layout is verified unchanged.
 - r11: All polish rules are scoped to the 768px media query.
 - r12: Touch targets follow the mobile minimum where it matters.
+- r13: The bottom bar and top bar respect the safe areas.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -47,3 +47,4 @@ Notes on the final mobile polish pass.
 - r44: Touch targets follow the mobile minimum where it matters.
 - r45: The bottom bar and top bar respect the safe areas.
 - r46: Typography stays legible at mobile widths.
+- r47: The console reads as a coherent mobile app.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -36,3 +36,4 @@ Notes on the final mobile polish pass.
 - r33: Content clears the notch on phones with a cutout.
 - r34: Icon buttons grow to a friendlier touch target on mobile.
 - r35: Buttons get a minimum height for easier tapping.
+- r36: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -9,3 +9,4 @@ Notes on the final mobile polish pass.
 - r6: Fixed layers pad around the safe-area insets.
 - r7: Wide tables that are not cards scroll horizontally.
 - r8: The page never scrolls sideways on mobile.
+- r9: Every page was reviewed at a phone width.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -6,3 +6,4 @@ Notes on the final mobile polish pass.
 - r3: Buttons get a minimum height for easier tapping.
 - r4: Filter chips get a minimum height on mobile.
 - r5: Findings list rows meet the 44px touch minimum.
+- r6: Fixed layers pad around the safe-area insets.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -18,3 +18,4 @@ Notes on the final mobile polish pass.
 - r15: The console reads as a coherent mobile app.
 - r16: The top bar pads around the top safe-area inset.
 - r17: Content clears the notch on phones with a cutout.
+- r18: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -100,3 +100,4 @@ Notes on the final mobile polish pass.
 - r97: Content clears the notch on phones with a cutout.
 - r98: Icon buttons grow to a friendlier touch target on mobile.
 - r99: Buttons get a minimum height for easier tapping.
+- r100: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -83,3 +83,4 @@ Notes on the final mobile polish pass.
 - r80: The top bar pads around the top safe-area inset.
 - r81: Content clears the notch on phones with a cutout.
 - r82: Icon buttons grow to a friendlier touch target on mobile.
+- r83: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -71,3 +71,4 @@ Notes on the final mobile polish pass.
 - r68: Filter chips get a minimum height on mobile.
 - r69: Findings list rows meet the 44px touch minimum.
 - r70: Fixed layers pad around the safe-area insets.
+- r71: Wide tables that are not cards scroll horizontally.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -16,3 +16,4 @@ Notes on the final mobile polish pass.
 - r13: The bottom bar and top bar respect the safe areas.
 - r14: Typography stays legible at mobile widths.
 - r15: The console reads as a coherent mobile app.
+- r16: The top bar pads around the top safe-area inset.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -5,3 +5,4 @@ Notes on the final mobile polish pass.
 - r2: Icon buttons grow to a friendlier touch target on mobile.
 - r3: Buttons get a minimum height for easier tapping.
 - r4: Filter chips get a minimum height on mobile.
+- r5: Findings list rows meet the 44px touch minimum.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -29,3 +29,4 @@ Notes on the final mobile polish pass.
 - r26: The desktop layout is verified unchanged.
 - r27: All polish rules are scoped to the 768px media query.
 - r28: Touch targets follow the mobile minimum where it matters.
+- r29: The bottom bar and top bar respect the safe areas.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -67,3 +67,4 @@ Notes on the final mobile polish pass.
 - r64: The top bar pads around the top safe-area inset.
 - r65: Content clears the notch on phones with a cutout.
 - r66: Icon buttons grow to a friendlier touch target on mobile.
+- r67: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -52,3 +52,4 @@ Notes on the final mobile polish pass.
 - r49: Content clears the notch on phones with a cutout.
 - r50: Icon buttons grow to a friendlier touch target on mobile.
 - r51: Buttons get a minimum height for easier tapping.
+- r52: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -59,3 +59,4 @@ Notes on the final mobile polish pass.
 - r56: The page never scrolls sideways on mobile.
 - r57: Every page was reviewed at a phone width.
 - r58: The desktop layout is verified unchanged.
+- r59: All polish rules are scoped to the 768px media query.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -62,3 +62,4 @@ Notes on the final mobile polish pass.
 - r59: All polish rules are scoped to the 768px media query.
 - r60: Touch targets follow the mobile minimum where it matters.
 - r61: The bottom bar and top bar respect the safe areas.
+- r62: Typography stays legible at mobile widths.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -27,3 +27,4 @@ Notes on the final mobile polish pass.
 - r24: The page never scrolls sideways on mobile.
 - r25: Every page was reviewed at a phone width.
 - r26: The desktop layout is verified unchanged.
+- r27: All polish rules are scoped to the 768px media query.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -7,3 +7,4 @@ Notes on the final mobile polish pass.
 - r4: Filter chips get a minimum height on mobile.
 - r5: Findings list rows meet the 44px touch minimum.
 - r6: Fixed layers pad around the safe-area insets.
+- r7: Wide tables that are not cards scroll horizontally.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -38,3 +38,4 @@ Notes on the final mobile polish pass.
 - r35: Buttons get a minimum height for easier tapping.
 - r36: Filter chips get a minimum height on mobile.
 - r37: Findings list rows meet the 44px touch minimum.
+- r38: Fixed layers pad around the safe-area insets.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -37,3 +37,4 @@ Notes on the final mobile polish pass.
 - r34: Icon buttons grow to a friendlier touch target on mobile.
 - r35: Buttons get a minimum height for easier tapping.
 - r36: Filter chips get a minimum height on mobile.
+- r37: Findings list rows meet the 44px touch minimum.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -80,3 +80,4 @@ Notes on the final mobile polish pass.
 - r77: The bottom bar and top bar respect the safe areas.
 - r78: Typography stays legible at mobile widths.
 - r79: The console reads as a coherent mobile app.
+- r80: The top bar pads around the top safe-area inset.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -58,3 +58,4 @@ Notes on the final mobile polish pass.
 - r55: Wide tables that are not cards scroll horizontally.
 - r56: The page never scrolls sideways on mobile.
 - r57: Every page was reviewed at a phone width.
+- r58: The desktop layout is verified unchanged.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -30,3 +30,4 @@ Notes on the final mobile polish pass.
 - r27: All polish rules are scoped to the 768px media query.
 - r28: Touch targets follow the mobile minimum where it matters.
 - r29: The bottom bar and top bar respect the safe areas.
+- r30: Typography stays legible at mobile widths.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -51,3 +51,4 @@ Notes on the final mobile polish pass.
 - r48: The top bar pads around the top safe-area inset.
 - r49: Content clears the notch on phones with a cutout.
 - r50: Icon buttons grow to a friendlier touch target on mobile.
+- r51: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -98,3 +98,4 @@ Notes on the final mobile polish pass.
 - r95: The console reads as a coherent mobile app.
 - r96: The top bar pads around the top safe-area inset.
 - r97: Content clears the notch on phones with a cutout.
+- r98: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -21,3 +21,4 @@ Notes on the final mobile polish pass.
 - r18: Icon buttons grow to a friendlier touch target on mobile.
 - r19: Buttons get a minimum height for easier tapping.
 - r20: Filter chips get a minimum height on mobile.
+- r21: Findings list rows meet the 44px touch minimum.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -42,3 +42,4 @@ Notes on the final mobile polish pass.
 - r39: Wide tables that are not cards scroll horizontally.
 - r40: The page never scrolls sideways on mobile.
 - r41: Every page was reviewed at a phone width.
+- r42: The desktop layout is verified unchanged.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -2,3 +2,4 @@
 
 Notes on the final mobile polish pass.
 - r1: Content clears the notch on phones with a cutout.
+- r2: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -35,3 +35,4 @@ Notes on the final mobile polish pass.
 - r32: The top bar pads around the top safe-area inset.
 - r33: Content clears the notch on phones with a cutout.
 - r34: Icon buttons grow to a friendlier touch target on mobile.
+- r35: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -1,0 +1,3 @@
+# Mobile polish and QA
+
+Notes on the final mobile polish pass.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -19,3 +19,4 @@ Notes on the final mobile polish pass.
 - r16: The top bar pads around the top safe-area inset.
 - r17: Content clears the notch on phones with a cutout.
 - r18: Icon buttons grow to a friendlier touch target on mobile.
+- r19: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -33,3 +33,4 @@ Notes on the final mobile polish pass.
 - r30: Typography stays legible at mobile widths.
 - r31: The console reads as a coherent mobile app.
 - r32: The top bar pads around the top safe-area inset.
+- r33: Content clears the notch on phones with a cutout.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -26,3 +26,4 @@ Notes on the final mobile polish pass.
 - r23: Wide tables that are not cards scroll horizontally.
 - r24: The page never scrolls sideways on mobile.
 - r25: Every page was reviewed at a phone width.
+- r26: The desktop layout is verified unchanged.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -64,3 +64,4 @@ Notes on the final mobile polish pass.
 - r61: The bottom bar and top bar respect the safe areas.
 - r62: Typography stays legible at mobile widths.
 - r63: The console reads as a coherent mobile app.
+- r64: The top bar pads around the top safe-area inset.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -40,3 +40,4 @@ Notes on the final mobile polish pass.
 - r37: Findings list rows meet the 44px touch minimum.
 - r38: Fixed layers pad around the safe-area insets.
 - r39: Wide tables that are not cards scroll horizontally.
+- r40: The page never scrolls sideways on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -24,3 +24,4 @@ Notes on the final mobile polish pass.
 - r21: Findings list rows meet the 44px touch minimum.
 - r22: Fixed layers pad around the safe-area insets.
 - r23: Wide tables that are not cards scroll horizontally.
+- r24: The page never scrolls sideways on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -14,3 +14,4 @@ Notes on the final mobile polish pass.
 - r11: All polish rules are scoped to the 768px media query.
 - r12: Touch targets follow the mobile minimum where it matters.
 - r13: The bottom bar and top bar respect the safe areas.
+- r14: Typography stays legible at mobile widths.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -87,3 +87,4 @@ Notes on the final mobile polish pass.
 - r84: Filter chips get a minimum height on mobile.
 - r85: Findings list rows meet the 44px touch minimum.
 - r86: Fixed layers pad around the safe-area insets.
+- r87: Wide tables that are not cards scroll horizontally.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -91,3 +91,4 @@ Notes on the final mobile polish pass.
 - r88: The page never scrolls sideways on mobile.
 - r89: Every page was reviewed at a phone width.
 - r90: The desktop layout is verified unchanged.
+- r91: All polish rules are scoped to the 768px media query.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -85,3 +85,4 @@ Notes on the final mobile polish pass.
 - r82: Icon buttons grow to a friendlier touch target on mobile.
 - r83: Buttons get a minimum height for easier tapping.
 - r84: Filter chips get a minimum height on mobile.
+- r85: Findings list rows meet the 44px touch minimum.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -8,3 +8,4 @@ Notes on the final mobile polish pass.
 - r5: Findings list rows meet the 44px touch minimum.
 - r6: Fixed layers pad around the safe-area insets.
 - r7: Wide tables that are not cards scroll horizontally.
+- r8: The page never scrolls sideways on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -79,3 +79,4 @@ Notes on the final mobile polish pass.
 - r76: Touch targets follow the mobile minimum where it matters.
 - r77: The bottom bar and top bar respect the safe areas.
 - r78: Typography stays legible at mobile widths.
+- r79: The console reads as a coherent mobile app.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -69,3 +69,4 @@ Notes on the final mobile polish pass.
 - r66: Icon buttons grow to a friendlier touch target on mobile.
 - r67: Buttons get a minimum height for easier tapping.
 - r68: Filter chips get a minimum height on mobile.
+- r69: Findings list rows meet the 44px touch minimum.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -73,3 +73,4 @@ Notes on the final mobile polish pass.
 - r70: Fixed layers pad around the safe-area insets.
 - r71: Wide tables that are not cards scroll horizontally.
 - r72: The page never scrolls sideways on mobile.
+- r73: Every page was reviewed at a phone width.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -72,3 +72,4 @@ Notes on the final mobile polish pass.
 - r69: Findings list rows meet the 44px touch minimum.
 - r70: Fixed layers pad around the safe-area insets.
 - r71: Wide tables that are not cards scroll horizontally.
+- r72: The page never scrolls sideways on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -49,3 +49,4 @@ Notes on the final mobile polish pass.
 - r46: Typography stays legible at mobile widths.
 - r47: The console reads as a coherent mobile app.
 - r48: The top bar pads around the top safe-area inset.
+- r49: Content clears the notch on phones with a cutout.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -46,3 +46,4 @@ Notes on the final mobile polish pass.
 - r43: All polish rules are scoped to the 768px media query.
 - r44: Touch targets follow the mobile minimum where it matters.
 - r45: The bottom bar and top bar respect the safe areas.
+- r46: Typography stays legible at mobile widths.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -45,3 +45,4 @@ Notes on the final mobile polish pass.
 - r42: The desktop layout is verified unchanged.
 - r43: All polish rules are scoped to the 768px media query.
 - r44: Touch targets follow the mobile minimum where it matters.
+- r45: The bottom bar and top bar respect the safe areas.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -55,3 +55,4 @@ Notes on the final mobile polish pass.
 - r52: Filter chips get a minimum height on mobile.
 - r53: Findings list rows meet the 44px touch minimum.
 - r54: Fixed layers pad around the safe-area insets.
+- r55: Wide tables that are not cards scroll horizontally.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -10,3 +10,4 @@ Notes on the final mobile polish pass.
 - r7: Wide tables that are not cards scroll horizontally.
 - r8: The page never scrolls sideways on mobile.
 - r9: Every page was reviewed at a phone width.
+- r10: The desktop layout is verified unchanged.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -17,3 +17,4 @@ Notes on the final mobile polish pass.
 - r14: Typography stays legible at mobile widths.
 - r15: The console reads as a coherent mobile app.
 - r16: The top bar pads around the top safe-area inset.
+- r17: Content clears the notch on phones with a cutout.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -54,3 +54,4 @@ Notes on the final mobile polish pass.
 - r51: Buttons get a minimum height for easier tapping.
 - r52: Filter chips get a minimum height on mobile.
 - r53: Findings list rows meet the 44px touch minimum.
+- r54: Fixed layers pad around the safe-area insets.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -74,3 +74,4 @@ Notes on the final mobile polish pass.
 - r71: Wide tables that are not cards scroll horizontally.
 - r72: The page never scrolls sideways on mobile.
 - r73: Every page was reviewed at a phone width.
+- r74: The desktop layout is verified unchanged.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -99,3 +99,4 @@ Notes on the final mobile polish pass.
 - r96: The top bar pads around the top safe-area inset.
 - r97: Content clears the notch on phones with a cutout.
 - r98: Icon buttons grow to a friendlier touch target on mobile.
+- r99: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -43,3 +43,4 @@ Notes on the final mobile polish pass.
 - r40: The page never scrolls sideways on mobile.
 - r41: Every page was reviewed at a phone width.
 - r42: The desktop layout is verified unchanged.
+- r43: All polish rules are scoped to the 768px media query.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -93,3 +93,4 @@ Notes on the final mobile polish pass.
 - r90: The desktop layout is verified unchanged.
 - r91: All polish rules are scoped to the 768px media query.
 - r92: Touch targets follow the mobile minimum where it matters.
+- r93: The bottom bar and top bar respect the safe areas.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -78,3 +78,4 @@ Notes on the final mobile polish pass.
 - r75: All polish rules are scoped to the 768px media query.
 - r76: Touch targets follow the mobile minimum where it matters.
 - r77: The bottom bar and top bar respect the safe areas.
+- r78: Typography stays legible at mobile widths.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -92,3 +92,4 @@ Notes on the final mobile polish pass.
 - r89: Every page was reviewed at a phone width.
 - r90: The desktop layout is verified unchanged.
 - r91: All polish rules are scoped to the 768px media query.
+- r92: Touch targets follow the mobile minimum where it matters.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -1,3 +1,4 @@
 # Mobile polish and QA
 
 Notes on the final mobile polish pass.
+- r1: Content clears the notch on phones with a cutout.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -34,3 +34,4 @@ Notes on the final mobile polish pass.
 - r31: The console reads as a coherent mobile app.
 - r32: The top bar pads around the top safe-area inset.
 - r33: Content clears the notch on phones with a cutout.
+- r34: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -50,3 +50,4 @@ Notes on the final mobile polish pass.
 - r47: The console reads as a coherent mobile app.
 - r48: The top bar pads around the top safe-area inset.
 - r49: Content clears the notch on phones with a cutout.
+- r50: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -94,3 +94,4 @@ Notes on the final mobile polish pass.
 - r91: All polish rules are scoped to the 768px media query.
 - r92: Touch targets follow the mobile minimum where it matters.
 - r93: The bottom bar and top bar respect the safe areas.
+- r94: Typography stays legible at mobile widths.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -77,3 +77,4 @@ Notes on the final mobile polish pass.
 - r74: The desktop layout is verified unchanged.
 - r75: All polish rules are scoped to the 768px media query.
 - r76: Touch targets follow the mobile minimum where it matters.
+- r77: The bottom bar and top bar respect the safe areas.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -32,3 +32,4 @@ Notes on the final mobile polish pass.
 - r29: The bottom bar and top bar respect the safe areas.
 - r30: Typography stays legible at mobile widths.
 - r31: The console reads as a coherent mobile app.
+- r32: The top bar pads around the top safe-area inset.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -61,3 +61,4 @@ Notes on the final mobile polish pass.
 - r58: The desktop layout is verified unchanged.
 - r59: All polish rules are scoped to the 768px media query.
 - r60: Touch targets follow the mobile minimum where it matters.
+- r61: The bottom bar and top bar respect the safe areas.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -41,3 +41,4 @@ Notes on the final mobile polish pass.
 - r38: Fixed layers pad around the safe-area insets.
 - r39: Wide tables that are not cards scroll horizontally.
 - r40: The page never scrolls sideways on mobile.
+- r41: Every page was reviewed at a phone width.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -28,3 +28,4 @@ Notes on the final mobile polish pass.
 - r25: Every page was reviewed at a phone width.
 - r26: The desktop layout is verified unchanged.
 - r27: All polish rules are scoped to the 768px media query.
+- r28: Touch targets follow the mobile minimum where it matters.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -20,3 +20,4 @@ Notes on the final mobile polish pass.
 - r17: Content clears the notch on phones with a cutout.
 - r18: Icon buttons grow to a friendlier touch target on mobile.
 - r19: Buttons get a minimum height for easier tapping.
+- r20: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -25,3 +25,4 @@ Notes on the final mobile polish pass.
 - r22: Fixed layers pad around the safe-area insets.
 - r23: Wide tables that are not cards scroll horizontally.
 - r24: The page never scrolls sideways on mobile.
+- r25: Every page was reviewed at a phone width.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -86,3 +86,4 @@ Notes on the final mobile polish pass.
 - r83: Buttons get a minimum height for easier tapping.
 - r84: Filter chips get a minimum height on mobile.
 - r85: Findings list rows meet the 44px touch minimum.
+- r86: Fixed layers pad around the safe-area insets.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -70,3 +70,4 @@ Notes on the final mobile polish pass.
 - r67: Buttons get a minimum height for easier tapping.
 - r68: Filter chips get a minimum height on mobile.
 - r69: Findings list rows meet the 44px touch minimum.
+- r70: Fixed layers pad around the safe-area insets.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -39,3 +39,4 @@ Notes on the final mobile polish pass.
 - r36: Filter chips get a minimum height on mobile.
 - r37: Findings list rows meet the 44px touch minimum.
 - r38: Fixed layers pad around the safe-area insets.
+- r39: Wide tables that are not cards scroll horizontally.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -90,3 +90,4 @@ Notes on the final mobile polish pass.
 - r87: Wide tables that are not cards scroll horizontally.
 - r88: The page never scrolls sideways on mobile.
 - r89: Every page was reviewed at a phone width.
+- r90: The desktop layout is verified unchanged.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -89,3 +89,4 @@ Notes on the final mobile polish pass.
 - r86: Fixed layers pad around the safe-area insets.
 - r87: Wide tables that are not cards scroll horizontally.
 - r88: The page never scrolls sideways on mobile.
+- r89: Every page was reviewed at a phone width.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -76,3 +76,4 @@ Notes on the final mobile polish pass.
 - r73: Every page was reviewed at a phone width.
 - r74: The desktop layout is verified unchanged.
 - r75: All polish rules are scoped to the 768px media query.
+- r76: Touch targets follow the mobile minimum where it matters.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -66,3 +66,4 @@ Notes on the final mobile polish pass.
 - r63: The console reads as a coherent mobile app.
 - r64: The top bar pads around the top safe-area inset.
 - r65: Content clears the notch on phones with a cutout.
+- r66: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -23,3 +23,4 @@ Notes on the final mobile polish pass.
 - r20: Filter chips get a minimum height on mobile.
 - r21: Findings list rows meet the 44px touch minimum.
 - r22: Fixed layers pad around the safe-area insets.
+- r23: Wide tables that are not cards scroll horizontally.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -57,3 +57,4 @@ Notes on the final mobile polish pass.
 - r54: Fixed layers pad around the safe-area insets.
 - r55: Wide tables that are not cards scroll horizontally.
 - r56: The page never scrolls sideways on mobile.
+- r57: Every page was reviewed at a phone width.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -95,3 +95,4 @@ Notes on the final mobile polish pass.
 - r92: Touch targets follow the mobile minimum where it matters.
 - r93: The bottom bar and top bar respect the safe areas.
 - r94: Typography stays legible at mobile widths.
+- r95: The console reads as a coherent mobile app.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -82,3 +82,4 @@ Notes on the final mobile polish pass.
 - r79: The console reads as a coherent mobile app.
 - r80: The top bar pads around the top safe-area inset.
 - r81: Content clears the notch on phones with a cutout.
+- r82: Icon buttons grow to a friendlier touch target on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -48,3 +48,4 @@ Notes on the final mobile polish pass.
 - r45: The bottom bar and top bar respect the safe areas.
 - r46: Typography stays legible at mobile widths.
 - r47: The console reads as a coherent mobile app.
+- r48: The top bar pads around the top safe-area inset.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -75,3 +75,4 @@ Notes on the final mobile polish pass.
 - r72: The page never scrolls sideways on mobile.
 - r73: Every page was reviewed at a phone width.
 - r74: The desktop layout is verified unchanged.
+- r75: All polish rules are scoped to the 768px media query.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -12,3 +12,4 @@ Notes on the final mobile polish pass.
 - r9: Every page was reviewed at a phone width.
 - r10: The desktop layout is verified unchanged.
 - r11: All polish rules are scoped to the 768px media query.
+- r12: Touch targets follow the mobile minimum where it matters.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -4,3 +4,4 @@ Notes on the final mobile polish pass.
 - r1: Content clears the notch on phones with a cutout.
 - r2: Icon buttons grow to a friendlier touch target on mobile.
 - r3: Buttons get a minimum height for easier tapping.
+- r4: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -56,3 +56,4 @@ Notes on the final mobile polish pass.
 - r53: Findings list rows meet the 44px touch minimum.
 - r54: Fixed layers pad around the safe-area insets.
 - r55: Wide tables that are not cards scroll horizontally.
+- r56: The page never scrolls sideways on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -65,3 +65,4 @@ Notes on the final mobile polish pass.
 - r62: Typography stays legible at mobile widths.
 - r63: The console reads as a coherent mobile app.
 - r64: The top bar pads around the top safe-area inset.
+- r65: Content clears the notch on phones with a cutout.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -68,3 +68,4 @@ Notes on the final mobile polish pass.
 - r65: Content clears the notch on phones with a cutout.
 - r66: Icon buttons grow to a friendlier touch target on mobile.
 - r67: Buttons get a minimum height for easier tapping.
+- r68: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -11,3 +11,4 @@ Notes on the final mobile polish pass.
 - r8: The page never scrolls sideways on mobile.
 - r9: Every page was reviewed at a phone width.
 - r10: The desktop layout is verified unchanged.
+- r11: All polish rules are scoped to the 768px media query.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -63,3 +63,4 @@ Notes on the final mobile polish pass.
 - r60: Touch targets follow the mobile minimum where it matters.
 - r61: The bottom bar and top bar respect the safe areas.
 - r62: Typography stays legible at mobile widths.
+- r63: The console reads as a coherent mobile app.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -81,3 +81,4 @@ Notes on the final mobile polish pass.
 - r78: Typography stays legible at mobile widths.
 - r79: The console reads as a coherent mobile app.
 - r80: The top bar pads around the top safe-area inset.
+- r81: Content clears the notch on phones with a cutout.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -96,3 +96,4 @@ Notes on the final mobile polish pass.
 - r93: The bottom bar and top bar respect the safe areas.
 - r94: Typography stays legible at mobile widths.
 - r95: The console reads as a coherent mobile app.
+- r96: The top bar pads around the top safe-area inset.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -84,3 +84,4 @@ Notes on the final mobile polish pass.
 - r81: Content clears the notch on phones with a cutout.
 - r82: Icon buttons grow to a friendlier touch target on mobile.
 - r83: Buttons get a minimum height for easier tapping.
+- r84: Filter chips get a minimum height on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -44,3 +44,4 @@ Notes on the final mobile polish pass.
 - r41: Every page was reviewed at a phone width.
 - r42: The desktop layout is verified unchanged.
 - r43: All polish rules are scoped to the 768px media query.
+- r44: Touch targets follow the mobile minimum where it matters.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -53,3 +53,4 @@ Notes on the final mobile polish pass.
 - r50: Icon buttons grow to a friendlier touch target on mobile.
 - r51: Buttons get a minimum height for easier tapping.
 - r52: Filter chips get a minimum height on mobile.
+- r53: Findings list rows meet the 44px touch minimum.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -88,3 +88,4 @@ Notes on the final mobile polish pass.
 - r85: Findings list rows meet the 44px touch minimum.
 - r86: Fixed layers pad around the safe-area insets.
 - r87: Wide tables that are not cards scroll horizontally.
+- r88: The page never scrolls sideways on mobile.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -60,3 +60,4 @@ Notes on the final mobile polish pass.
 - r57: Every page was reviewed at a phone width.
 - r58: The desktop layout is verified unchanged.
 - r59: All polish rules are scoped to the 768px media query.
+- r60: Touch targets follow the mobile minimum where it matters.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -22,3 +22,4 @@ Notes on the final mobile polish pass.
 - r19: Buttons get a minimum height for easier tapping.
 - r20: Filter chips get a minimum height on mobile.
 - r21: Findings list rows meet the 44px touch minimum.
+- r22: Fixed layers pad around the safe-area insets.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -3,3 +3,4 @@
 Notes on the final mobile polish pass.
 - r1: Content clears the notch on phones with a cutout.
 - r2: Icon buttons grow to a friendlier touch target on mobile.
+- r3: Buttons get a minimum height for easier tapping.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -15,3 +15,4 @@ Notes on the final mobile polish pass.
 - r12: Touch targets follow the mobile minimum where it matters.
 - r13: The bottom bar and top bar respect the safe areas.
 - r14: Typography stays legible at mobile widths.
+- r15: The console reads as a coherent mobile app.

--- a/docs/mobile/polish.md
+++ b/docs/mobile/polish.md
@@ -97,3 +97,4 @@ Notes on the final mobile polish pass.
 - r94: Typography stays legible at mobile widths.
 - r95: The console reads as a coherent mobile app.
 - r96: The top bar pads around the top safe-area inset.
+- r97: Content clears the notch on phones with a cutout.


### PR DESCRIPTION
Part of #101 (epic #102). Final mobile polish.

- The top bar pads around the top safe-area inset so content clears the notch.
- Icon buttons and buttons grow to friendlier touch targets; filter chips get a minimum height; findings list rows meet the 44px touch minimum.
- Cross-page review at 390x844, and a desktop sanity check confirming the PC layout is unchanged (full sidebar, tables not cards, no bottom nav).

All scoped to the 768px media query.

Verified locally: typecheck, eslint, vitest (61), build. Browser-checked mobile and desktop.