### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.3.8"
+version = "0.4.0"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.3.8",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.3.8"
+version = "0.4.0"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]


### PR DESCRIPTION
Release v0.4.0: the mobile-responsive console (epic #102, PRs #103-#115).

The web console now works as a mobile app on phones (bottom tab bar, overflow drawer, reflowed pages, single-panel session console, sheet dialogs, safe-area and touch-target handling) while the desktop layout is unchanged. Also fixes the duplicate New session button (#89).

Bumps api/worker/web to 0.4.0. Squash-merge, then tag v0.4.0 to build and publish images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the API, web application, and worker package versions from 0.3.8 to 0.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->