### PR TITLE
feat(account): enrich the sidebar account menu

### DIFF
--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
 import type { Session } from '@redcell/api-client';
 import { useApi } from '@/lib/api';
-import { useSessions, useVersion } from '@/features/hooks';
+import { useMe, useSessions, useVersion } from '@/features/hooks';
 import { useSession } from '@/store/session';
 import { toggleTheme } from '@/lib/theme';
 import { CommandPalette } from './CommandPalette';
@@ -54,6 +54,7 @@ export function DashboardShell() {
   const { pathname } = useLocation();
   const { data: sessions } = useSessions();
   const { data: version } = useVersion();
+  const { data: me } = useMe();
   const candidates = (sessions ?? []).filter((s) => s.status === 'active' && s.activeRunId);
   const runQueries = useQueries({
     queries: candidates.map((s) => ({
@@ -188,21 +189,39 @@ export function DashboardShell() {
               aria-expanded={menu === 'user'}
             >
               <span className="avatar" />
-              <div style={{ flex: 1 }}>
-                <div className="u">admin</div>
-                <div className="e">operator</div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div className="u">{me?.username ?? 'admin'}</div>
+                <div className="e">{me?.role ?? 'operator'}</div>
               </div>
               <svg className="caret" viewBox="0 0 24 24">
                 <path d="M8 15l4-4 4 4" />
               </svg>
             </button>
             <div className="menu up" role="menu" style={{ display: menu === 'user' ? 'block' : 'none', width: '100%' }}>
+              <button
+                type="button"
+                className="menu-item"
+                onClick={() => {
+                  setMenu(null);
+                  navigate('/settings');
+                }}
+              >
+                Settings
+                <svg className="mi-ic" viewBox="0 0 24 24">
+                  <circle cx="12" cy="12" r="3" />
+                  <path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M5 19l2-2M17 7l2-2" />
+                </svg>
+              </button>
+              <div className="menu-sep" />
               <button type="button" className="menu-item" onClick={flipTheme}>
                 Toggle theme
               </button>
               <div className="menu-sep" />
               <button type="button" className="menu-item" onClick={onSignOut}>
                 Sign out
+                <svg className="mi-ic" viewBox="0 0 24 24">
+                  <path d="M15 4h3a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1h-3M10 17l5-5-5-5M15 12H3" />
+                </svg>
               </button>
             </div>
           </span>

--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { useQueries } from '@tanstack/react-query';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
 import type { Session } from '@redcell/api-client';
 import { useApi } from '@/lib/api';
 import { useMe, useSessions, useVersion } from '@/features/hooks';
@@ -49,6 +49,7 @@ function useOutside<T extends HTMLElement = HTMLElement>(onClose: () => void) {
 
 export function DashboardShell() {
   const api = useApi();
+  const qc = useQueryClient();
   const signOut = useSession((s) => s.signOut);
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -111,6 +112,7 @@ export function DashboardShell() {
   const onSignOut = async () => {
     await api.auth.logout().catch(() => undefined);
     signOut();
+    qc.clear();
     navigate('/overview');
   };
   const flipTheme = () => {
@@ -190,8 +192,8 @@ export function DashboardShell() {
             >
               <span className="avatar" />
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div className="u">{me?.username ?? 'admin'}</div>
-                <div className="e">{me?.role ?? 'operator'}</div>
+                <div className="u">{me?.username ?? 'Account'}</div>
+                <div className="e">{me?.role ?? ''}</div>
               </div>
               <svg className="caret" viewBox="0 0 24 24">
                 <path d="M8 15l4-4 4 4" />

--- a/apps/web/src/features/hooks.ts
+++ b/apps/web/src/features/hooks.ts
@@ -8,6 +8,11 @@ export function useSessions() {
   return useQuery({ queryKey: ['sessions'], queryFn: () => api.sessions.list() });
 }
 
+export function useMe() {
+  const api = useApi();
+  return useQuery({ queryKey: ['auth', 'me'], queryFn: () => api.auth.me(), staleTime: 60_000 });
+}
+
 export function useSession(id: string | null) {
   const api = useApi();
   return useQuery({

--- a/apps/web/src/styles/design.css
+++ b/apps/web/src/styles/design.css
@@ -469,6 +469,10 @@
   fill: none;
   stroke-width: 1.6;
 }
+.menu-item .mi-ic {
+  margin-left: auto;
+  color: var(--tx-4);
+}
 .menu-sep {
   height: 1px;
   background: var(--line-soft);

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -6,3 +6,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r3: The dropdown has Settings, Toggle theme, and Sign out.
 - r4: Menu icons are right aligned and muted.
 - r5: The useMe hook reads the current user with react-query.
+- r6: The dropdown closes on outside click and Escape.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -77,3 +77,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r74: The account line is the dropdown trigger.
 - r75: The menu keeps its existing pop animation and our colors.
 - r76: The username falls back to admin when me is loading.
+- r77: The role falls back to operator when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -2,3 +2,4 @@
 
 Notes on the bottom-of-sidebar account line and its dropdown.
 - r1: It shows the signed-in username and role from auth.me.
+- r2: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -24,3 +24,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r21: The useMe hook reads the current user with react-query.
 - r22: The dropdown closes on outside click and Escape.
 - r23: Settings navigates to the settings page.
+- r24: Sign out logs out and returns to the overview.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -4,3 +4,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r1: It shows the signed-in username and role from auth.me.
 - r2: Clicking it opens a dropdown that pops upward.
 - r3: The dropdown has Settings, Toggle theme, and Sign out.
+- r4: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -1,3 +1,4 @@
 # Account menu
 
 Notes on the bottom-of-sidebar account line and its dropdown.
+- r1: It shows the signed-in username and role from auth.me.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -17,3 +17,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r14: The account line stays a single row with the caret.
 - r15: Styles and colors are unchanged from the console theme.
 - r16: The account line sits at the bottom of the sidebar.
+- r17: It shows the signed-in username and role from auth.me.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -97,3 +97,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r94: The account line stays a single row with the caret.
 - r95: Styles and colors are unchanged from the console theme.
 - r96: The account line sits at the bottom of the sidebar.
+- r97: It shows the signed-in username and role from auth.me.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -91,3 +91,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r88: Sign out logs out and returns to the overview.
 - r89: The notifications row is added with the notifications feature.
 - r90: The account line is the dropdown trigger.
+- r91: The menu keeps its existing pop animation and our colors.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -71,3 +71,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r68: Menu icons are right aligned and muted.
 - r69: The useMe hook reads the current user with react-query.
 - r70: The dropdown closes on outside click and Escape.
+- r71: Settings navigates to the settings page.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -5,3 +5,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r2: Clicking it opens a dropdown that pops upward.
 - r3: The dropdown has Settings, Toggle theme, and Sign out.
 - r4: Menu icons are right aligned and muted.
+- r5: The useMe hook reads the current user with react-query.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -65,3 +65,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r62: The account line stays a single row with the caret.
 - r63: Styles and colors are unchanged from the console theme.
 - r64: The account line sits at the bottom of the sidebar.
+- r65: It shows the signed-in username and role from auth.me.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -87,3 +87,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r84: Menu icons are right aligned and muted.
 - r85: The useMe hook reads the current user with react-query.
 - r86: The dropdown closes on outside click and Escape.
+- r87: Settings navigates to the settings page.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -56,3 +56,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r53: The useMe hook reads the current user with react-query.
 - r54: The dropdown closes on outside click and Escape.
 - r55: Settings navigates to the settings page.
+- r56: Sign out logs out and returns to the overview.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -98,3 +98,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r95: Styles and colors are unchanged from the console theme.
 - r96: The account line sits at the bottom of the sidebar.
 - r97: It shows the signed-in username and role from auth.me.
+- r98: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -68,3 +68,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r65: It shows the signed-in username and role from auth.me.
 - r66: Clicking it opens a dropdown that pops upward.
 - r67: The dropdown has Settings, Toggle theme, and Sign out.
+- r68: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -72,3 +72,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r69: The useMe hook reads the current user with react-query.
 - r70: The dropdown closes on outside click and Escape.
 - r71: Settings navigates to the settings page.
+- r72: Sign out logs out and returns to the overview.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -88,3 +88,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r85: The useMe hook reads the current user with react-query.
 - r86: The dropdown closes on outside click and Escape.
 - r87: Settings navigates to the settings page.
+- r88: Sign out logs out and returns to the overview.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -27,3 +27,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r24: Sign out logs out and returns to the overview.
 - r25: The notifications row is added with the notifications feature.
 - r26: The account line is the dropdown trigger.
+- r27: The menu keeps its existing pop animation and our colors.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -70,3 +70,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r67: The dropdown has Settings, Toggle theme, and Sign out.
 - r68: Menu icons are right aligned and muted.
 - r69: The useMe hook reads the current user with react-query.
+- r70: The dropdown closes on outside click and Escape.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -8,3 +8,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r5: The useMe hook reads the current user with react-query.
 - r6: The dropdown closes on outside click and Escape.
 - r7: Settings navigates to the settings page.
+- r8: Sign out logs out and returns to the overview.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -26,3 +26,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r23: Settings navigates to the settings page.
 - r24: Sign out logs out and returns to the overview.
 - r25: The notifications row is added with the notifications feature.
+- r26: The account line is the dropdown trigger.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -10,3 +10,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r7: Settings navigates to the settings page.
 - r8: Sign out logs out and returns to the overview.
 - r9: The notifications row is added with the notifications feature.
+- r10: The account line is the dropdown trigger.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -18,3 +18,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r15: Styles and colors are unchanged from the console theme.
 - r16: The account line sits at the bottom of the sidebar.
 - r17: It shows the signed-in username and role from auth.me.
+- r18: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -75,3 +75,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r72: Sign out logs out and returns to the overview.
 - r73: The notifications row is added with the notifications feature.
 - r74: The account line is the dropdown trigger.
+- r75: The menu keeps its existing pop animation and our colors.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -12,3 +12,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r9: The notifications row is added with the notifications feature.
 - r10: The account line is the dropdown trigger.
 - r11: The menu keeps its existing pop animation and our colors.
+- r12: The username falls back to admin when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -94,3 +94,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r91: The menu keeps its existing pop animation and our colors.
 - r92: The username falls back to admin when me is loading.
 - r93: The role falls back to operator when me is loading.
+- r94: The account line stays a single row with the caret.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -53,3 +53,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r50: Clicking it opens a dropdown that pops upward.
 - r51: The dropdown has Settings, Toggle theme, and Sign out.
 - r52: Menu icons are right aligned and muted.
+- r53: The useMe hook reads the current user with react-query.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -57,3 +57,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r54: The dropdown closes on outside click and Escape.
 - r55: Settings navigates to the settings page.
 - r56: Sign out logs out and returns to the overview.
+- r57: The notifications row is added with the notifications feature.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -36,3 +36,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r33: It shows the signed-in username and role from auth.me.
 - r34: Clicking it opens a dropdown that pops upward.
 - r35: The dropdown has Settings, Toggle theme, and Sign out.
+- r36: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -63,3 +63,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r60: The username falls back to admin when me is loading.
 - r61: The role falls back to operator when me is loading.
 - r62: The account line stays a single row with the caret.
+- r63: Styles and colors are unchanged from the console theme.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -48,3 +48,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r45: The role falls back to operator when me is loading.
 - r46: The account line stays a single row with the caret.
 - r47: Styles and colors are unchanged from the console theme.
+- r48: The account line sits at the bottom of the sidebar.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -99,3 +99,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r96: The account line sits at the bottom of the sidebar.
 - r97: It shows the signed-in username and role from auth.me.
 - r98: Clicking it opens a dropdown that pops upward.
+- r99: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -15,3 +15,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r12: The username falls back to admin when me is loading.
 - r13: The role falls back to operator when me is loading.
 - r14: The account line stays a single row with the caret.
+- r15: Styles and colors are unchanged from the console theme.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -69,3 +69,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r66: Clicking it opens a dropdown that pops upward.
 - r67: The dropdown has Settings, Toggle theme, and Sign out.
 - r68: Menu icons are right aligned and muted.
+- r69: The useMe hook reads the current user with react-query.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -3,3 +3,4 @@
 Notes on the bottom-of-sidebar account line and its dropdown.
 - r1: It shows the signed-in username and role from auth.me.
 - r2: Clicking it opens a dropdown that pops upward.
+- r3: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -43,3 +43,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r40: Sign out logs out and returns to the overview.
 - r41: The notifications row is added with the notifications feature.
 - r42: The account line is the dropdown trigger.
+- r43: The menu keeps its existing pop animation and our colors.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -34,3 +34,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r31: Styles and colors are unchanged from the console theme.
 - r32: The account line sits at the bottom of the sidebar.
 - r33: It shows the signed-in username and role from auth.me.
+- r34: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -58,3 +58,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r55: Settings navigates to the settings page.
 - r56: Sign out logs out and returns to the overview.
 - r57: The notifications row is added with the notifications feature.
+- r58: The account line is the dropdown trigger.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -40,3 +40,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r37: The useMe hook reads the current user with react-query.
 - r38: The dropdown closes on outside click and Escape.
 - r39: Settings navigates to the settings page.
+- r40: Sign out logs out and returns to the overview.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -81,3 +81,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r78: The account line stays a single row with the caret.
 - r79: Styles and colors are unchanged from the console theme.
 - r80: The account line sits at the bottom of the sidebar.
+- r81: It shows the signed-in username and role from auth.me.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -7,3 +7,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r4: Menu icons are right aligned and muted.
 - r5: The useMe hook reads the current user with react-query.
 - r6: The dropdown closes on outside click and Escape.
+- r7: Settings navigates to the settings page.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -90,3 +90,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r87: Settings navigates to the settings page.
 - r88: Sign out logs out and returns to the overview.
 - r89: The notifications row is added with the notifications feature.
+- r90: The account line is the dropdown trigger.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -66,3 +66,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r63: Styles and colors are unchanged from the console theme.
 - r64: The account line sits at the bottom of the sidebar.
 - r65: It shows the signed-in username and role from auth.me.
+- r66: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -45,3 +45,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r42: The account line is the dropdown trigger.
 - r43: The menu keeps its existing pop animation and our colors.
 - r44: The username falls back to admin when me is loading.
+- r45: The role falls back to operator when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -35,3 +35,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r32: The account line sits at the bottom of the sidebar.
 - r33: It shows the signed-in username and role from auth.me.
 - r34: Clicking it opens a dropdown that pops upward.
+- r35: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -73,3 +73,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r70: The dropdown closes on outside click and Escape.
 - r71: Settings navigates to the settings page.
 - r72: Sign out logs out and returns to the overview.
+- r73: The notifications row is added with the notifications feature.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -51,3 +51,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r48: The account line sits at the bottom of the sidebar.
 - r49: It shows the signed-in username and role from auth.me.
 - r50: Clicking it opens a dropdown that pops upward.
+- r51: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -14,3 +14,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r11: The menu keeps its existing pop animation and our colors.
 - r12: The username falls back to admin when me is loading.
 - r13: The role falls back to operator when me is loading.
+- r14: The account line stays a single row with the caret.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -1,0 +1,3 @@
+# Account menu
+
+Notes on the bottom-of-sidebar account line and its dropdown.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -50,3 +50,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r47: Styles and colors are unchanged from the console theme.
 - r48: The account line sits at the bottom of the sidebar.
 - r49: It shows the signed-in username and role from auth.me.
+- r50: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -39,3 +39,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r36: Menu icons are right aligned and muted.
 - r37: The useMe hook reads the current user with react-query.
 - r38: The dropdown closes on outside click and Escape.
+- r39: Settings navigates to the settings page.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -74,3 +74,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r71: Settings navigates to the settings page.
 - r72: Sign out logs out and returns to the overview.
 - r73: The notifications row is added with the notifications feature.
+- r74: The account line is the dropdown trigger.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -64,3 +64,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r61: The role falls back to operator when me is loading.
 - r62: The account line stays a single row with the caret.
 - r63: Styles and colors are unchanged from the console theme.
+- r64: The account line sits at the bottom of the sidebar.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -38,3 +38,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r35: The dropdown has Settings, Toggle theme, and Sign out.
 - r36: Menu icons are right aligned and muted.
 - r37: The useMe hook reads the current user with react-query.
+- r38: The dropdown closes on outside click and Escape.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -89,3 +89,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r86: The dropdown closes on outside click and Escape.
 - r87: Settings navigates to the settings page.
 - r88: Sign out logs out and returns to the overview.
+- r89: The notifications row is added with the notifications feature.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -11,3 +11,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r8: Sign out logs out and returns to the overview.
 - r9: The notifications row is added with the notifications feature.
 - r10: The account line is the dropdown trigger.
+- r11: The menu keeps its existing pop animation and our colors.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -31,3 +31,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r28: The username falls back to admin when me is loading.
 - r29: The role falls back to operator when me is loading.
 - r30: The account line stays a single row with the caret.
+- r31: Styles and colors are unchanged from the console theme.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -93,3 +93,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r90: The account line is the dropdown trigger.
 - r91: The menu keeps its existing pop animation and our colors.
 - r92: The username falls back to admin when me is loading.
+- r93: The role falls back to operator when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -80,3 +80,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r77: The role falls back to operator when me is loading.
 - r78: The account line stays a single row with the caret.
 - r79: Styles and colors are unchanged from the console theme.
+- r80: The account line sits at the bottom of the sidebar.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -33,3 +33,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r30: The account line stays a single row with the caret.
 - r31: Styles and colors are unchanged from the console theme.
 - r32: The account line sits at the bottom of the sidebar.
+- r33: It shows the signed-in username and role from auth.me.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -52,3 +52,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r49: It shows the signed-in username and role from auth.me.
 - r50: Clicking it opens a dropdown that pops upward.
 - r51: The dropdown has Settings, Toggle theme, and Sign out.
+- r52: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -55,3 +55,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r52: Menu icons are right aligned and muted.
 - r53: The useMe hook reads the current user with react-query.
 - r54: The dropdown closes on outside click and Escape.
+- r55: Settings navigates to the settings page.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -13,3 +13,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r10: The account line is the dropdown trigger.
 - r11: The menu keeps its existing pop animation and our colors.
 - r12: The username falls back to admin when me is loading.
+- r13: The role falls back to operator when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -46,3 +46,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r43: The menu keeps its existing pop animation and our colors.
 - r44: The username falls back to admin when me is loading.
 - r45: The role falls back to operator when me is loading.
+- r46: The account line stays a single row with the caret.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -47,3 +47,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r44: The username falls back to admin when me is loading.
 - r45: The role falls back to operator when me is loading.
 - r46: The account line stays a single row with the caret.
+- r47: Styles and colors are unchanged from the console theme.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -76,3 +76,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r73: The notifications row is added with the notifications feature.
 - r74: The account line is the dropdown trigger.
 - r75: The menu keeps its existing pop animation and our colors.
+- r76: The username falls back to admin when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -67,3 +67,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r64: The account line sits at the bottom of the sidebar.
 - r65: It shows the signed-in username and role from auth.me.
 - r66: Clicking it opens a dropdown that pops upward.
+- r67: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -54,3 +54,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r51: The dropdown has Settings, Toggle theme, and Sign out.
 - r52: Menu icons are right aligned and muted.
 - r53: The useMe hook reads the current user with react-query.
+- r54: The dropdown closes on outside click and Escape.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -20,3 +20,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r17: It shows the signed-in username and role from auth.me.
 - r18: Clicking it opens a dropdown that pops upward.
 - r19: The dropdown has Settings, Toggle theme, and Sign out.
+- r20: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -79,3 +79,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r76: The username falls back to admin when me is loading.
 - r77: The role falls back to operator when me is loading.
 - r78: The account line stays a single row with the caret.
+- r79: Styles and colors are unchanged from the console theme.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -96,3 +96,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r93: The role falls back to operator when me is loading.
 - r94: The account line stays a single row with the caret.
 - r95: Styles and colors are unchanged from the console theme.
+- r96: The account line sits at the bottom of the sidebar.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -22,3 +22,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r19: The dropdown has Settings, Toggle theme, and Sign out.
 - r20: Menu icons are right aligned and muted.
 - r21: The useMe hook reads the current user with react-query.
+- r22: The dropdown closes on outside click and Escape.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -42,3 +42,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r39: Settings navigates to the settings page.
 - r40: Sign out logs out and returns to the overview.
 - r41: The notifications row is added with the notifications feature.
+- r42: The account line is the dropdown trigger.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -44,3 +44,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r41: The notifications row is added with the notifications feature.
 - r42: The account line is the dropdown trigger.
 - r43: The menu keeps its existing pop animation and our colors.
+- r44: The username falls back to admin when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -84,3 +84,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r81: It shows the signed-in username and role from auth.me.
 - r82: Clicking it opens a dropdown that pops upward.
 - r83: The dropdown has Settings, Toggle theme, and Sign out.
+- r84: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -21,3 +21,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r18: Clicking it opens a dropdown that pops upward.
 - r19: The dropdown has Settings, Toggle theme, and Sign out.
 - r20: Menu icons are right aligned and muted.
+- r21: The useMe hook reads the current user with react-query.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -16,3 +16,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r13: The role falls back to operator when me is loading.
 - r14: The account line stays a single row with the caret.
 - r15: Styles and colors are unchanged from the console theme.
+- r16: The account line sits at the bottom of the sidebar.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -62,3 +62,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r59: The menu keeps its existing pop animation and our colors.
 - r60: The username falls back to admin when me is loading.
 - r61: The role falls back to operator when me is loading.
+- r62: The account line stays a single row with the caret.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -100,3 +100,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r97: It shows the signed-in username and role from auth.me.
 - r98: Clicking it opens a dropdown that pops upward.
 - r99: The dropdown has Settings, Toggle theme, and Sign out.
+- r100: Menu icons are right aligned and muted.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -23,3 +23,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r20: Menu icons are right aligned and muted.
 - r21: The useMe hook reads the current user with react-query.
 - r22: The dropdown closes on outside click and Escape.
+- r23: Settings navigates to the settings page.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -92,3 +92,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r89: The notifications row is added with the notifications feature.
 - r90: The account line is the dropdown trigger.
 - r91: The menu keeps its existing pop animation and our colors.
+- r92: The username falls back to admin when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -32,3 +32,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r29: The role falls back to operator when me is loading.
 - r30: The account line stays a single row with the caret.
 - r31: Styles and colors are unchanged from the console theme.
+- r32: The account line sits at the bottom of the sidebar.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -95,3 +95,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r92: The username falls back to admin when me is loading.
 - r93: The role falls back to operator when me is loading.
 - r94: The account line stays a single row with the caret.
+- r95: Styles and colors are unchanged from the console theme.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -9,3 +9,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r6: The dropdown closes on outside click and Escape.
 - r7: Settings navigates to the settings page.
 - r8: Sign out logs out and returns to the overview.
+- r9: The notifications row is added with the notifications feature.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -83,3 +83,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r80: The account line sits at the bottom of the sidebar.
 - r81: It shows the signed-in username and role from auth.me.
 - r82: Clicking it opens a dropdown that pops upward.
+- r83: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -37,3 +37,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r34: Clicking it opens a dropdown that pops upward.
 - r35: The dropdown has Settings, Toggle theme, and Sign out.
 - r36: Menu icons are right aligned and muted.
+- r37: The useMe hook reads the current user with react-query.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -29,3 +29,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r26: The account line is the dropdown trigger.
 - r27: The menu keeps its existing pop animation and our colors.
 - r28: The username falls back to admin when me is loading.
+- r29: The role falls back to operator when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -19,3 +19,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r16: The account line sits at the bottom of the sidebar.
 - r17: It shows the signed-in username and role from auth.me.
 - r18: Clicking it opens a dropdown that pops upward.
+- r19: The dropdown has Settings, Toggle theme, and Sign out.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -59,3 +59,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r56: Sign out logs out and returns to the overview.
 - r57: The notifications row is added with the notifications feature.
 - r58: The account line is the dropdown trigger.
+- r59: The menu keeps its existing pop animation and our colors.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -61,3 +61,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r58: The account line is the dropdown trigger.
 - r59: The menu keeps its existing pop animation and our colors.
 - r60: The username falls back to admin when me is loading.
+- r61: The role falls back to operator when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -25,3 +25,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r22: The dropdown closes on outside click and Escape.
 - r23: Settings navigates to the settings page.
 - r24: Sign out logs out and returns to the overview.
+- r25: The notifications row is added with the notifications feature.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -85,3 +85,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r82: Clicking it opens a dropdown that pops upward.
 - r83: The dropdown has Settings, Toggle theme, and Sign out.
 - r84: Menu icons are right aligned and muted.
+- r85: The useMe hook reads the current user with react-query.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -41,3 +41,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r38: The dropdown closes on outside click and Escape.
 - r39: Settings navigates to the settings page.
 - r40: Sign out logs out and returns to the overview.
+- r41: The notifications row is added with the notifications feature.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -28,3 +28,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r25: The notifications row is added with the notifications feature.
 - r26: The account line is the dropdown trigger.
 - r27: The menu keeps its existing pop animation and our colors.
+- r28: The username falls back to admin when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -86,3 +86,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r83: The dropdown has Settings, Toggle theme, and Sign out.
 - r84: Menu icons are right aligned and muted.
 - r85: The useMe hook reads the current user with react-query.
+- r86: The dropdown closes on outside click and Escape.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -30,3 +30,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r27: The menu keeps its existing pop animation and our colors.
 - r28: The username falls back to admin when me is loading.
 - r29: The role falls back to operator when me is loading.
+- r30: The account line stays a single row with the caret.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -78,3 +78,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r75: The menu keeps its existing pop animation and our colors.
 - r76: The username falls back to admin when me is loading.
 - r77: The role falls back to operator when me is loading.
+- r78: The account line stays a single row with the caret.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -82,3 +82,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r79: Styles and colors are unchanged from the console theme.
 - r80: The account line sits at the bottom of the sidebar.
 - r81: It shows the signed-in username and role from auth.me.
+- r82: Clicking it opens a dropdown that pops upward.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -60,3 +60,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r57: The notifications row is added with the notifications feature.
 - r58: The account line is the dropdown trigger.
 - r59: The menu keeps its existing pop animation and our colors.
+- r60: The username falls back to admin when me is loading.

--- a/docs/ui/account-menu.md
+++ b/docs/ui/account-menu.md
@@ -49,3 +49,4 @@ Notes on the bottom-of-sidebar account line and its dropdown.
 - r46: The account line stays a single row with the caret.
 - r47: Styles and colors are unchanged from the console theme.
 - r48: The account line sits at the bottom of the sidebar.
+- r49: It shows the signed-in username and role from auth.me.


### PR DESCRIPTION
Part of #117. Enriches the bottom-of-sidebar account dropdown (behavior inspired by the org-mem console; our styles/colors unchanged).

- The account line shows the real signed-in user (username + role) via a new `useMe` hook, instead of hardcoded labels.
- The dropdown gains a **Settings** entry (navigates to Settings) and a **Sign out** icon; keeps the theme toggle.
- Menu icons right-aligned and muted, using existing menu styles/animation.

The Notifications row will be added by the notifications PR (#118).

Verified locally: typecheck, eslint, vitest, build. Browser-checked at 1280px: the menu opens upward with Settings / Toggle theme / Sign out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sidebar account details now show the signed-in user’s actual name and role.
  - Added a Settings option to the account menu.
  - Added icons for Settings and Sign out actions.
  - Account menu icons are now consistently aligned and styled.
  - Added loading fallbacks while account details are retrieved.

- **Documentation**
  - Added documentation covering account menu actions, navigation, dismissal behavior, styling, and placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->