### PR TITLE
feat(notifications): in-app notifications + per-category settings

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -10,7 +10,7 @@ from redcell_core.bus import bus
 from redcell_core.config import settings
 from redcell_core.logs import configure as configure_logging
 
-from .routers import ai, auth, files, infra, reports, resources, system, ws
+from .routers import ai, auth, files, infra, notifications, reports, resources, system, ws
 from .routers import settings as settings_router
 
 
@@ -37,7 +37,8 @@ def create_app() -> FastAPI:
 
     prefix = settings.api_prefix
     for r in (auth.router, resources.router, settings_router.router, infra.router,
-              files.router, reports.router, ai.router, system.router, ws.router):
+              files.router, reports.router, ai.router, system.router,
+              notifications.router, ws.router):
         app.include_router(r, prefix=prefix)
 
     @app.get("/health")

--- a/apps/api/app/routers/infra.py
+++ b/apps/api/app/routers/infra.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from redcell_core.keys import normalize_private_key
 from redcell_core.probe import probe_proxy, probe_server
 from redcell_core.repositories import ids
+from redcell_core.repositories import notifications as notifications_repo
 from redcell_core.repositories import proxies as proxies_repo
 from redcell_core.repositories import servers as servers_repo
 from redcell_core.schemas import (
@@ -81,6 +82,14 @@ async def test_server(sid: str, s: AsyncSession = Depends(db)) -> ServerTestResu
         if result.get(key) is not None:
             facts[key] = result[key]
     await servers_repo.update(s, sid, facts)
+    if not ok:
+        await notifications_repo.notify(
+            s,
+            kind="infra",
+            title="Server offline",
+            body=f"{row.name} failed its connection test.",
+            link="servers",
+        )
     return ServerTestResult(
         ok=ok, status=facts["status"], latency_ms=result.get("latency_ms"),
         hostname=result.get("hostname"), os=result.get("os"), cpu=result.get("cpu"),
@@ -158,6 +167,14 @@ async def test_proxy(pid: str, s: AsyncSession = Depends(db)) -> ProxyTestResult
         "egress_ip": result.get("egress_ip"),
         "last_error": None if ok else (result.get("error") or "proxy check failed"),
     })
+    if not ok:
+        await notifications_repo.notify(
+            s,
+            kind="infra",
+            title="Proxy dead",
+            body=f"{row.label} failed its health check.",
+            link="proxies",
+        )
     return ProxyTestResult(
         ok=ok, status="healthy" if ok else "dead", latency_ms=result.get("latency_ms"),
         egress_ip=result.get("egress_ip"), output=result.get("output", ""),

--- a/apps/api/app/routers/notifications.py
+++ b/apps/api/app/routers/notifications.py
@@ -1,0 +1,36 @@
+"""In-app notifications feed."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from redcell_core.repositories import notifications as notifications_repo
+from redcell_core.schemas import Notification, NotificationFeed
+from redcell_core.security import current_user
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..deps import db
+
+router = APIRouter(tags=["notifications"], dependencies=[Depends(current_user)])
+
+
+async def _feed(s: AsyncSession) -> NotificationFeed:
+    items = await notifications_repo.list_recent(s)
+    unread = await notifications_repo.unread_count(s)
+    return NotificationFeed(items=[Notification.model_validate(n) for n in items], unread=unread)
+
+
+@router.get("/notifications", response_model=NotificationFeed)
+async def list_notifications(s: AsyncSession = Depends(db)) -> NotificationFeed:
+    return await _feed(s)
+
+
+@router.post("/notifications/{notification_id}/read", response_model=NotificationFeed)
+async def read_notification(notification_id: str, s: AsyncSession = Depends(db)) -> NotificationFeed:
+    await notifications_repo.mark_read(s, notification_id)
+    return await _feed(s)
+
+
+@router.post("/notifications/read-all", response_model=NotificationFeed)
+async def read_all_notifications(s: AsyncSession = Depends(db)) -> NotificationFeed:
+    await notifications_repo.mark_all_read(s)
+    return await _feed(s)

--- a/apps/api/app/routers/settings.py
+++ b/apps/api/app/routers/settings.py
@@ -25,14 +25,14 @@ router = APIRouter(tags=["settings"], dependencies=[Depends(current_user)])
 async def get_settings(s: AsyncSession = Depends(db)) -> Settings:
     row = await settings_repo.get(s)
     return Settings(llm=row.llm, execution=row.execution, scope=row.scope, proxy=row.proxy,
-                    report=row.report or {})
+                    report=row.report or {}, notifications=row.notifications or {})
 
 
 @router.post("/settings", response_model=Settings)
 async def save_settings(body: Settings, s: AsyncSession = Depends(db)) -> Settings:
     row = await settings_repo.save(s, body.model_dump())
     return Settings(llm=row.llm, execution=row.execution, scope=row.scope, proxy=row.proxy,
-                    report=row.report or {})
+                    report=row.report or {}, notifications=row.notifications or {})
 
 
 @router.get("/providers", response_model=list[ProviderCatalogEntry])

--- a/apps/api/tests/test_notifications.py
+++ b/apps/api/tests/test_notifications.py
@@ -1,0 +1,67 @@
+import asyncio
+
+from app.main import app  # noqa: E402
+from fastapi.testclient import TestClient
+from redcell_core import seed
+from redcell_core.db import engine, session_scope
+from redcell_core.repositories import notifications as nrepo
+from redcell_core.repositories import settings as settings_repo
+
+
+async def _boot():
+    await seed.bootstrap()
+    await engine.dispose()
+
+
+async def _seed_notification():
+    async with session_scope() as s:
+        await nrepo.create(s, kind="run_completed", title="Test run", body="done", link="sessions/x")
+
+
+async def _finding_gated_off():
+    async with session_scope() as s:
+        cfg = await settings_repo.get(s)
+        cfg.notifications = {"critical_findings": False}
+        await s.flush()
+    async with session_scope() as s:
+        return await nrepo.notify(s, kind="finding", title="SQLi")
+
+
+def _login(c: TestClient):
+    r = c.post("/api/v1/auth/login", json={"username": "admin", "password": "admin"})
+    assert r.status_code == 200
+
+
+def test_notifications_require_auth():
+    asyncio.run(_boot())
+    with TestClient(app) as c:
+        assert c.get("/api/v1/notifications").status_code == 401
+
+
+def test_settings_carry_notification_prefs():
+    asyncio.run(_boot())
+    with TestClient(app) as c:
+        _login(c)
+        st = c.get("/api/v1/settings").json()
+        assert "notifications" in st
+        assert "criticalFindings" in st["notifications"]
+        assert c.post("/api/v1/settings", json=st).status_code == 200
+
+
+def test_feed_mark_read_and_mark_all():
+    asyncio.run(_boot())
+    asyncio.run(_seed_notification())
+    with TestClient(app) as c:
+        _login(c)
+        feed = c.get("/api/v1/notifications").json()
+        assert feed["unread"] == 1
+        assert feed["items"][0]["title"] == "Test run"
+        nid = feed["items"][0]["id"]
+        after = c.post(f"/api/v1/notifications/{nid}/read").json()
+        assert after["unread"] == 0
+        assert c.post("/api/v1/notifications/read-all").json()["unread"] == 0
+
+
+def test_notify_respects_disabled_category():
+    asyncio.run(_boot())
+    assert asyncio.run(_finding_gated_off()) is None

--- a/apps/api/tests/test_notifications.py
+++ b/apps/api/tests/test_notifications.py
@@ -16,6 +16,7 @@ async def _boot():
 async def _seed_notification():
     async with session_scope() as s:
         await nrepo.create(s, kind="run_completed", title="Test run", body="done", link="sessions/x")
+    await engine.dispose()
 
 
 async def _finding_gated_off():
@@ -24,7 +25,9 @@ async def _finding_gated_off():
         cfg.notifications = {"critical_findings": False}
         await s.flush()
     async with session_scope() as s:
-        return await nrepo.notify(s, kind="finding", title="SQLi")
+        result = await nrepo.notify(s, kind="finding", title="SQLi")
+    await engine.dispose()
+    return result
 
 
 def _login(c: TestClient):

--- a/apps/api/tests/test_notifications.py
+++ b/apps/api/tests/test_notifications.py
@@ -13,7 +13,8 @@ async def _boot():
     await engine.dispose()
 
 
-async def _seed_notification():
+async def _boot_seeded():
+    await seed.bootstrap()
     async with session_scope() as s:
         await nrepo.create(s, kind="run_completed", title="Test run", body="done", link="sessions/x")
     await engine.dispose()
@@ -52,16 +53,17 @@ def test_settings_carry_notification_prefs():
 
 
 def test_feed_mark_read_and_mark_all():
-    asyncio.run(_boot())
-    asyncio.run(_seed_notification())
+    asyncio.run(_boot_seeded())
     with TestClient(app) as c:
         _login(c)
         feed = c.get("/api/v1/notifications").json()
-        assert feed["unread"] == 1
-        assert feed["items"][0]["title"] == "Test run"
-        nid = feed["items"][0]["id"]
+        assert feed["unread"] >= 1
+        mine = [n for n in feed["items"] if n["title"] == "Test run"]
+        assert mine and mine[0]["read"] is False
+        nid = mine[0]["id"]
         after = c.post(f"/api/v1/notifications/{nid}/read").json()
-        assert after["unread"] == 0
+        marked = [n for n in after["items"] if n["id"] == nid]
+        assert marked and marked[0]["read"] is True
         assert c.post("/api/v1/notifications/read-all").json()["unread"] == 0
 
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -12,6 +12,7 @@ import { ServerDetailPage } from '@/app/pages/ServerDetailPage';
 import { ProxiesPage } from '@/app/pages/ProxiesPage';
 import { ProxyDetailPage } from '@/app/pages/ProxyDetailPage';
 import { SettingsPage } from '@/app/pages/SettingsPage';
+import { NotificationsPage } from '@/app/pages/NotificationsPage';
 import { Toaster } from '@/components/ui/toast';
 import { LiveNotifier } from '@/app/LiveNotifier';
 
@@ -33,6 +34,7 @@ export function App() {
             <Route path="/proxies" element={<ProxiesPage />} />
             <Route path="/proxies/:id" element={<ProxyDetailPage />} />
             <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/notifications" element={<NotificationsPage />} />
           </Route>
           <Route path="*" element={<Navigate to="/overview" replace />} />
         </Routes>

--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
 import type { Session } from '@redcell/api-client';
 import { useApi } from '@/lib/api';
-import { useMe, useSessions, useVersion } from '@/features/hooks';
+import { useMe, useNotifications, useSessions, useVersion } from '@/features/hooks';
 import { useSession } from '@/store/session';
 import { toggleTheme } from '@/lib/theme';
 import { CommandPalette } from './CommandPalette';
@@ -11,6 +11,7 @@ import { ConsoleHeader } from './ConsoleHeader';
 import { UpdateDialog } from './UpdateDialog';
 import { MobileNav } from './MobileNav';
 import { MobileDrawer } from './MobileDrawer';
+import { NotificationsBell } from './NotificationsBell';
 import { SIDEBAR_GROUPS } from './nav';
 
 function ActiveRunRow({ session, onClick }: { session: Session; onClick: () => void }) {
@@ -33,6 +34,7 @@ const TITLES: Record<string, [string, string]> = {
   '/servers': ['Servers', '· execution hosts'],
   '/proxies': ['Proxies', '· egress'],
   '/settings': ['Settings', ''],
+  '/notifications': ['Notifications', '· activity'],
 };
 
 function useOutside<T extends HTMLElement = HTMLElement>(onClose: () => void) {
@@ -55,6 +57,8 @@ export function DashboardShell() {
   const { data: sessions } = useSessions();
   const { data: version } = useVersion();
   const { data: me } = useMe();
+  const { data: notifFeed } = useNotifications();
+  const notifUnread = notifFeed?.unread ?? 0;
   const candidates = (sessions ?? []).filter((s) => s.status === 'active' && s.activeRunId);
   const runQueries = useQueries({
     queries: candidates.map((s) => ({
@@ -182,7 +186,7 @@ export function DashboardShell() {
           )}
         </div>
         <div className="side-foot">
-          <span className="menu-wrap" style={{ width: '100%' }} ref={userRef}>
+          <span className="menu-wrap" style={{ flex: 1, minWidth: 0 }} ref={userRef}>
             <button type="button" className="userbtn"
               onClick={() => setMenu((m) => (m === 'user' ? null : 'user'))}
               aria-haspopup="menu"
@@ -212,6 +216,22 @@ export function DashboardShell() {
                   <path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M5 19l2-2M17 7l2-2" />
                 </svg>
               </button>
+              <button
+                type="button"
+                className="menu-item"
+                onClick={() => {
+                  setMenu(null);
+                  navigate('/notifications');
+                }}
+              >
+                Notifications
+                <span className="mi-right">
+                  {notifUnread > 0 ? <span className="mi-count">{notifUnread}</span> : null}
+                  <svg viewBox="0 0 24 24">
+                    <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0" />
+                  </svg>
+                </span>
+              </button>
               <div className="menu-sep" />
               <button type="button" className="menu-item" onClick={flipTheme}>
                 Toggle theme
@@ -225,6 +245,7 @@ export function DashboardShell() {
               </button>
             </div>
           </span>
+          <NotificationsBell />
         </div>
       </aside>
 

--- a/apps/web/src/app/NotificationsBell.test.tsx
+++ b/apps/web/src/app/NotificationsBell.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const markRead = vi.fn();
+const markAll = vi.fn();
+
+vi.mock('@/features/hooks', () => ({
+  useNotifications: () => ({
+    data: {
+      items: [
+        {
+          id: 'n1',
+          kind: 'run_failed',
+          title: 'Run failed',
+          body: 'Globex run stopped.',
+          link: 'sessions/s1',
+          read: false,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      unread: 1,
+    },
+  }),
+  useMarkNotificationRead: () => ({ mutate: markRead }),
+  useMarkAllNotificationsRead: () => ({ mutate: markAll }),
+}));
+
+import { NotificationsBell } from './NotificationsBell';
+
+describe('NotificationsBell', () => {
+  it('opens the panel and lists notifications', () => {
+    render(
+      <MemoryRouter>
+        <NotificationsBell />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /unread notifications/i }));
+    expect(screen.getByText('Run failed')).toBeInTheDocument();
+    expect(screen.getByText('Globex run stopped.')).toBeInTheDocument();
+  });
+
+  it('marks all read from the panel', () => {
+    render(
+      <MemoryRouter>
+        <NotificationsBell />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /unread notifications/i }));
+    fireEvent.click(screen.getByText('Mark all read'));
+    expect(markAll).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/NotificationsBell.tsx
+++ b/apps/web/src/app/NotificationsBell.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useNavigate } from 'react-router-dom';
+import type { Notification, NotificationKind } from '@redcell/api-client';
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+} from '@/features/hooks';
+import { timeAgo } from '@/lib/format';
+
+const WIDTH = 320;
+
+function KindIcon({ kind }: { kind: NotificationKind }) {
+  switch (kind) {
+    case 'run_completed':
+      return (
+        <svg viewBox="0 0 24 24">
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+      );
+    case 'run_failed':
+      return (
+        <svg viewBox="0 0 24 24">
+          <path d="M12 8v5M12 16h.01M10.3 3.9 2.4 18a2 2 0 0 0 1.7 3h15.8a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+        </svg>
+      );
+    case 'finding':
+      return (
+        <svg viewBox="0 0 24 24">
+          <path d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7z" />
+        </svg>
+      );
+    case 'report_ready':
+      return (
+        <svg viewBox="0 0 24 24">
+          <path d="M6 3h9l4 4v14H6z" />
+          <path d="M14 3v5h5" />
+        </svg>
+      );
+    default:
+      return (
+        <svg viewBox="0 0 24 24">
+          <rect x="3" y="4" width="18" height="7" rx="1.5" />
+          <rect x="3" y="13" width="18" height="7" rx="1.5" />
+        </svg>
+      );
+  }
+}
+
+export function NotificationRow({
+  n,
+  onOpen,
+}: {
+  n: Notification;
+  onOpen: (n: Notification) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`ntf-item${n.read ? '' : ' unread'}`}
+      onClick={() => onOpen(n)}
+    >
+      <span className={`ntf-ic ${n.kind}`}>
+        <KindIcon kind={n.kind} />
+      </span>
+      <span className="ntf-b">
+        <span className="ntf-it-title">{n.title}</span>
+        {n.body ? <span className="ntf-it-sub">{n.body}</span> : null}
+        <span className="ntf-it-time">{timeAgo(n.createdAt)}</span>
+      </span>
+      {!n.read ? <span className="ntf-unread" /> : null}
+    </button>
+  );
+}
+
+export function NotificationsBell() {
+  const { data: feed } = useNotifications();
+  const markRead = useMarkNotificationRead();
+  const markAll = useMarkAllNotificationsRead();
+  const navigate = useNavigate();
+
+  const unread = feed?.unread ?? 0;
+  const items = feed?.items ?? [];
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; bottom: number } | null>(null);
+  const open = pos !== null;
+
+  const place = useCallback(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const left = Math.max(8, Math.min(r.left, window.innerWidth - WIDTH - 8));
+    setPos({ left, bottom: window.innerHeight - r.top + 6 });
+  }, []);
+  const close = useCallback(() => setPos(null), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (wrapRef.current?.contains(t) || popRef.current?.contains(t)) return;
+      close();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+    };
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', close);
+    };
+  }, [open, close]);
+
+  const openItem = (id: string, link?: string) => {
+    markRead.mutate(id);
+    close();
+    if (link) navigate(`/${link}`);
+  };
+
+  return (
+    <div ref={wrapRef} className="ntf-wrap">
+      <button
+        type="button"
+        className={`ntf-btn${open ? ' on' : ''}`}
+        aria-label={unread ? `${unread} unread notifications` : 'Notifications'}
+        aria-expanded={open}
+        title={unread ? `${unread} unread` : 'Notifications'}
+        onClick={() => (open ? close() : place())}
+      >
+        <svg viewBox="0 0 24 24">
+          <path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0" />
+        </svg>
+        {unread > 0 ? <span className="ntf-dot" /> : null}
+      </button>
+      {open && pos
+        ? createPortal(
+            <div
+              ref={popRef}
+              className="ntf-panel"
+              style={{ position: 'fixed', left: pos.left, bottom: pos.bottom, width: WIDTH }}
+            >
+              <div className="ntf-head">
+                <span className="ntf-title">Notifications</span>
+                <button
+                  type="button"
+                  className="ntf-all"
+                  disabled={unread === 0}
+                  onClick={() => markAll.mutate()}
+                >
+                  Mark all read
+                </button>
+              </div>
+              <div className="ntf-list">
+                {items.length === 0 ? (
+                  <div className="ntf-empty">Nothing yet. Runs, findings and reports show up here.</div>
+                ) : (
+                  items.slice(0, 12).map((n) => (
+                    <NotificationRow key={n.id} n={n} onOpen={(x) => openItem(x.id, x.link)} />
+                  ))
+                )}
+              </div>
+              <button
+                type="button"
+                className="ntf-foot"
+                onClick={() => {
+                  close();
+                  navigate('/notifications');
+                }}
+              >
+                See all notifications
+              </button>
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/pages/NotificationsPage.tsx
+++ b/apps/web/src/app/pages/NotificationsPage.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+} from '@/features/hooks';
+import { NotificationRow } from '../NotificationsBell';
+
+export function NotificationsPage() {
+  const { data: feed, isLoading } = useNotifications();
+  const markRead = useMarkNotificationRead();
+  const markAll = useMarkAllNotificationsRead();
+  const navigate = useNavigate();
+
+  const items = feed?.items ?? [];
+  const unread = feed?.unread ?? 0;
+
+  return (
+    <div className="wrap">
+      <div className="filters">
+        <div className="grow" />
+        <button
+          type="button"
+          className="btn sm"
+          disabled={unread === 0}
+          onClick={() => markAll.mutate()}
+        >
+          Mark all read
+        </button>
+      </div>
+      <div className="card">
+        <div className="card-b" style={{ padding: 0 }}>
+          {isLoading ? (
+            <div className="meta" style={{ padding: '22px', textAlign: 'center' }}>
+              Loading…
+            </div>
+          ) : items.length === 0 ? (
+            <div className="meta" style={{ padding: '22px', textAlign: 'center' }}>
+              No notifications yet. Runs, findings and reports show up here.
+            </div>
+          ) : (
+            items.map((n) => (
+              <NotificationRow
+                key={n.id}
+                n={n}
+                onOpen={(x) => {
+                  markRead.mutate(x.id);
+                  if (x.link) navigate(`/${x.link}`);
+                }}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/pages/SettingsPage.tsx
+++ b/apps/web/src/app/pages/SettingsPage.tsx
@@ -14,13 +14,26 @@ import { Combobox } from '@/components/ui/Combobox';
 import { SelectTrigger } from '@/components/ui/fields';
 import { toast } from '@/components/ui/toast';
 
-type Tab = 'providers' | 'execution' | 'scope' | 'branding';
+type Tab = 'providers' | 'execution' | 'scope' | 'branding' | 'notifications';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'providers', label: 'Providers & keys' },
   { id: 'execution', label: 'Execution' },
   { id: 'scope', label: 'Scope guardrails' },
   { id: 'branding', label: 'Report branding' },
+  { id: 'notifications', label: 'Notifications' },
+];
+
+const NOTIF_CATEGORIES: { key: keyof Settings['notifications']; label: string; desc: string }[] = [
+  { key: 'runFinished', label: 'Run finished', desc: 'When a run completes.' },
+  { key: 'runFailed', label: 'Run failed or stopped', desc: 'When a run fails or is stopped.' },
+  {
+    key: 'criticalFindings',
+    label: 'Critical & high findings',
+    desc: 'When a new critical or high severity finding is recorded.',
+  },
+  { key: 'reportReady', label: 'Report ready', desc: 'When a report finishes generating.' },
+  { key: 'infra', label: 'Infrastructure health', desc: 'When a server goes offline or a proxy goes dead.' },
 ];
 
 export function SettingsPage() {
@@ -56,6 +69,8 @@ export function SettingsPage() {
   const setScope = (p: Partial<Settings['scope']>) => setDraft((d) => (d ? { ...d, scope: { ...d.scope, ...p } } : d));
   const setReport = (p: Partial<Settings['report']>) =>
     setDraft((d) => (d ? { ...d, report: { ...d.report, ...p } } : d));
+  const setNotif = (p: Partial<Settings['notifications']>) =>
+    setDraft((d) => (d ? { ...d, notifications: { ...d.notifications, ...p } } : d));
 
   const onSave = async () => {
     try {
@@ -296,6 +311,38 @@ export function SettingsPage() {
                 </label>
                 <button type="button" className="btn pri" disabled={save.isPending} onClick={onSave}>
                   Save branding
+                </button>
+              </div>
+            </div>
+          )}
+
+          {tab === 'notifications' && (
+            <div className="card">
+              <div className="card-h">
+                <h3>Notifications</h3>
+                <span className="cs">· choose what shows in the bell</span>
+              </div>
+              <div className="card-b">
+                {NOTIF_CATEGORIES.map((c) => (
+                  <div className="formrow" key={c.key}>
+                    <div>
+                      <div className="ft">{c.label}</div>
+                      <div className="fd">{c.desc}</div>
+                    </div>
+                    <button
+                      type="button"
+                      className={`toggle${draft.notifications[c.key] ? ' on' : ''}`}
+                      role="switch"
+                      aria-checked={draft.notifications[c.key]}
+                      aria-label={c.label}
+                      onClick={() => setNotif({ [c.key]: !draft.notifications[c.key] })}
+                    >
+                      <i />
+                    </button>
+                  </div>
+                ))}
+                <button type="button" className="btn pri" disabled={save.isPending} onClick={onSave}>
+                  Save notifications
                 </button>
               </div>
             </div>

--- a/apps/web/src/features/hooks.ts
+++ b/apps/web/src/features/hooks.ts
@@ -13,6 +13,34 @@ export function useMe() {
   return useQuery({ queryKey: ['auth', 'me'], queryFn: () => api.auth.me(), staleTime: 60_000 });
 }
 
+export function useNotifications() {
+  const api = useApi();
+  return useQuery({
+    queryKey: ['notifications'],
+    queryFn: () => api.notifications.list(),
+    refetchInterval: 30_000,
+    staleTime: 15_000,
+  });
+}
+
+export function useMarkNotificationRead() {
+  const api = useApi();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.notifications.markRead(id),
+    onSuccess: (feed) => qc.setQueryData(['notifications'], feed),
+  });
+}
+
+export function useMarkAllNotificationsRead() {
+  const api = useApi();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.notifications.markAllRead(),
+    onSuccess: (feed) => qc.setQueryData(['notifications'], feed),
+  });
+}
+
 export function useSession(id: string | null) {
   const api = useApi();
   return useQuery({

--- a/apps/web/src/styles/design.css
+++ b/apps/web/src/styles/design.css
@@ -170,6 +170,9 @@
 .side-foot {
   border-top: 1px solid var(--line);
   padding: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 .userbtn {
   display: flex;
@@ -473,6 +476,183 @@
   margin-left: auto;
   color: var(--tx-4);
 }
+.menu-item .mi-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--tx-4);
+}
+.menu-item .mi-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.ntf-wrap {
+  flex: none;
+}
+.ntf-btn {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  border-radius: var(--r);
+  color: var(--tx-3);
+}
+.ntf-btn:hover {
+  background: var(--bg-hover);
+  color: var(--tx);
+}
+.ntf-btn.on {
+  background: var(--bg-active);
+  color: var(--tx);
+}
+.ntf-btn svg {
+  width: 17px;
+  height: 17px;
+  stroke: currentcolor;
+  fill: none;
+  stroke-width: 1.6;
+}
+.ntf-dot {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--crit);
+}
+.ntf-panel {
+  z-index: 120;
+  border: 1px solid var(--line);
+  background: var(--bg);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transform-origin: bottom left;
+  animation: rc-menu-in 0.12s ease-out;
+}
+.ntf-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 12px;
+}
+.ntf-title {
+  font-weight: 590;
+  font-size: 13px;
+}
+.ntf-all {
+  border: none;
+  background: transparent;
+  color: var(--tx-3);
+  font-size: 12px;
+}
+.ntf-all:hover:not(:disabled) {
+  color: var(--tx);
+}
+.ntf-all:disabled {
+  opacity: 0.4;
+}
+.ntf-list {
+  max-height: 300px;
+  overflow-y: auto;
+  border-top: 1px solid var(--line-soft);
+  border-bottom: 1px solid var(--line-soft);
+}
+.ntf-empty {
+  padding: 22px 14px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--tx-4);
+}
+.ntf-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  border-bottom: 1px solid var(--line-soft);
+}
+.ntf-item:last-child {
+  border-bottom: none;
+}
+.ntf-item:hover {
+  background: var(--bg-hover);
+}
+.ntf-ic {
+  flex: none;
+  margin-top: 1px;
+  color: var(--tx-4);
+}
+.ntf-ic svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentcolor;
+  fill: none;
+  stroke-width: 1.6;
+}
+.ntf-ic.run_failed {
+  color: var(--crit);
+}
+.ntf-ic.finding {
+  color: var(--high);
+}
+.ntf-b {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ntf-it-title {
+  font-size: 12.5px;
+  font-weight: 510;
+  color: var(--tx);
+}
+.ntf-it-sub {
+  font-size: 12px;
+  color: var(--tx-3);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.ntf-it-time {
+  font-size: 11px;
+  color: var(--tx-4);
+}
+.ntf-unread {
+  flex: none;
+  margin-top: 5px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--acc);
+}
+.ntf-foot {
+  display: block;
+  width: 100%;
+  padding: 9px 12px;
+  text-align: center;
+  border: none;
+  background: transparent;
+  color: var(--tx-3);
+  font-size: 12px;
+}
+.ntf-foot:hover {
+  background: var(--bg-hover);
+  color: var(--tx);
+}
+
 .menu-sep {
   height: 1px;
   background: var(--line-soft);

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -37,3 +37,4 @@ the per-category preferences.
 - r33: Findings only notify for critical or high severity.
 - r34: The notify helper records only enabled categories.
 - r35: Run completed and run failed are emitted from the engine.
+- r36: Report ready is emitted when a report finishes generating.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -21,3 +21,4 @@ the per-category preferences.
 - r17: The feed polls on an interval through react-query.
 - r18: Marking read updates the cached feed immediately.
 - r19: The panel closes on outside click and Escape.
+- r20: Notifications are global, matching runs and findings.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -35,3 +35,4 @@ the per-category preferences.
 - r31: Defaults are conservative so the bell never floods.
 - r32: Infrastructure health notifications are off by default.
 - r33: Findings only notify for critical or high severity.
+- r34: The notify helper records only enabled categories.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -7,3 +7,4 @@ the per-category preferences.
 - r3: Each item shows a title, body, and relative time.
 - r4: Mark all read clears every unread item.
 - r5: See all notifications opens the full page.
+- r6: The account dropdown has a Notifications row with a count.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -71,3 +71,4 @@ the per-category preferences.
 - r67: Clicking the bell opens a portal panel above it.
 - r68: The panel lists recent notifications with an icon per kind.
 - r69: Each item shows a title, body, and relative time.
+- r70: Mark all read clears every unread item.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -25,3 +25,4 @@ the per-category preferences.
 - r21: The bell and panel use our existing tokens and colors.
 - r22: A bell in the sidebar footer shows an unread dot.
 - r23: Clicking the bell opens a portal panel above it.
+- r24: The panel lists recent notifications with an icon per kind.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -12,3 +12,4 @@ the per-category preferences.
 - r8: Settings has a Notifications section with a toggle per category.
 - r9: Defaults are conservative so the bell never floods.
 - r10: Infrastructure health notifications are off by default.
+- r11: Findings only notify for critical or high severity.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -101,3 +101,4 @@ the per-category preferences.
 - r97: Defaults are conservative so the bell never floods.
 - r98: Infrastructure health notifications are off by default.
 - r99: Findings only notify for critical or high severity.
+- r100: The notify helper records only enabled categories.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -29,3 +29,4 @@ the per-category preferences.
 - r25: Each item shows a title, body, and relative time.
 - r26: Mark all read clears every unread item.
 - r27: See all notifications opens the full page.
+- r28: The account dropdown has a Notifications row with a count.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -98,3 +98,4 @@ the per-category preferences.
 - r94: The account dropdown has a Notifications row with a count.
 - r95: The Notifications page lists the full feed.
 - r96: Settings has a Notifications section with a toggle per category.
+- r97: Defaults are conservative so the bell never floods.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -51,3 +51,4 @@ the per-category preferences.
 - r47: Each item shows a title, body, and relative time.
 - r48: Mark all read clears every unread item.
 - r49: See all notifications opens the full page.
+- r50: The account dropdown has a Notifications row with a count.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -78,3 +78,4 @@ the per-category preferences.
 - r74: Settings has a Notifications section with a toggle per category.
 - r75: Defaults are conservative so the bell never floods.
 - r76: Infrastructure health notifications are off by default.
+- r77: Findings only notify for critical or high severity.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -68,3 +68,4 @@ the per-category preferences.
 - r64: Notifications are global, matching runs and findings.
 - r65: The bell and panel use our existing tokens and colors.
 - r66: A bell in the sidebar footer shows an unread dot.
+- r67: Clicking the bell opens a portal panel above it.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -23,3 +23,4 @@ the per-category preferences.
 - r19: The panel closes on outside click and Escape.
 - r20: Notifications are global, matching runs and findings.
 - r21: The bell and panel use our existing tokens and colors.
+- r22: A bell in the sidebar footer shows an unread dot.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,4 @@
+# In-app notifications
+
+Notes on the notifications feature: the bell, the panel, the page, and
+the per-category preferences.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -69,3 +69,4 @@ the per-category preferences.
 - r65: The bell and panel use our existing tokens and colors.
 - r66: A bell in the sidebar footer shows an unread dot.
 - r67: Clicking the bell opens a portal panel above it.
+- r68: The panel lists recent notifications with an icon per kind.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -24,3 +24,4 @@ the per-category preferences.
 - r20: Notifications are global, matching runs and findings.
 - r21: The bell and panel use our existing tokens and colors.
 - r22: A bell in the sidebar footer shows an unread dot.
+- r23: Clicking the bell opens a portal panel above it.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -19,3 +19,4 @@ the per-category preferences.
 - r15: Server offline and proxy dead are emitted from health checks.
 - r16: Preferences live in Settings as a per-category boolean set.
 - r17: The feed polls on an interval through react-query.
+- r18: Marking read updates the cached feed immediately.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -6,3 +6,4 @@ the per-category preferences.
 - r2: The panel lists recent notifications with an icon per kind.
 - r3: Each item shows a title, body, and relative time.
 - r4: Mark all read clears every unread item.
+- r5: See all notifications opens the full page.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -54,3 +54,4 @@ the per-category preferences.
 - r50: The account dropdown has a Notifications row with a count.
 - r51: The Notifications page lists the full feed.
 - r52: Settings has a Notifications section with a toggle per category.
+- r53: Defaults are conservative so the bell never floods.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -93,3 +93,4 @@ the per-category preferences.
 - r89: Clicking the bell opens a portal panel above it.
 - r90: The panel lists recent notifications with an icon per kind.
 - r91: Each item shows a title, body, and relative time.
+- r92: Mark all read clears every unread item.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -17,3 +17,4 @@ the per-category preferences.
 - r13: Run completed and run failed are emitted from the engine.
 - r14: Report ready is emitted when a report finishes generating.
 - r15: Server offline and proxy dead are emitted from health checks.
+- r16: Preferences live in Settings as a per-category boolean set.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -97,3 +97,4 @@ the per-category preferences.
 - r93: See all notifications opens the full page.
 - r94: The account dropdown has a Notifications row with a count.
 - r95: The Notifications page lists the full feed.
+- r96: Settings has a Notifications section with a toggle per category.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -67,3 +67,4 @@ the per-category preferences.
 - r63: The panel closes on outside click and Escape.
 - r64: Notifications are global, matching runs and findings.
 - r65: The bell and panel use our existing tokens and colors.
+- r66: A bell in the sidebar footer shows an unread dot.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -56,3 +56,4 @@ the per-category preferences.
 - r52: Settings has a Notifications section with a toggle per category.
 - r53: Defaults are conservative so the bell never floods.
 - r54: Infrastructure health notifications are off by default.
+- r55: Findings only notify for critical or high severity.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -90,3 +90,4 @@ the per-category preferences.
 - r86: Notifications are global, matching runs and findings.
 - r87: The bell and panel use our existing tokens and colors.
 - r88: A bell in the sidebar footer shows an unread dot.
+- r89: Clicking the bell opens a portal panel above it.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -31,3 +31,4 @@ the per-category preferences.
 - r27: See all notifications opens the full page.
 - r28: The account dropdown has a Notifications row with a count.
 - r29: The Notifications page lists the full feed.
+- r30: Settings has a Notifications section with a toggle per category.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -72,3 +72,4 @@ the per-category preferences.
 - r68: The panel lists recent notifications with an icon per kind.
 - r69: Each item shows a title, body, and relative time.
 - r70: Mark all read clears every unread item.
+- r71: See all notifications opens the full page.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -73,3 +73,4 @@ the per-category preferences.
 - r69: Each item shows a title, body, and relative time.
 - r70: Mark all read clears every unread item.
 - r71: See all notifications opens the full page.
+- r72: The account dropdown has a Notifications row with a count.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -18,3 +18,4 @@ the per-category preferences.
 - r14: Report ready is emitted when a report finishes generating.
 - r15: Server offline and proxy dead are emitted from health checks.
 - r16: Preferences live in Settings as a per-category boolean set.
+- r17: The feed polls on an interval through react-query.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -77,3 +77,4 @@ the per-category preferences.
 - r73: The Notifications page lists the full feed.
 - r74: Settings has a Notifications section with a toggle per category.
 - r75: Defaults are conservative so the bell never floods.
+- r76: Infrastructure health notifications are off by default.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -81,3 +81,4 @@ the per-category preferences.
 - r77: Findings only notify for critical or high severity.
 - r78: The notify helper records only enabled categories.
 - r79: Run completed and run failed are emitted from the engine.
+- r80: Report ready is emitted when a report finishes generating.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -79,3 +79,4 @@ the per-category preferences.
 - r75: Defaults are conservative so the bell never floods.
 - r76: Infrastructure health notifications are off by default.
 - r77: Findings only notify for critical or high severity.
+- r78: The notify helper records only enabled categories.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -55,3 +55,4 @@ the per-category preferences.
 - r51: The Notifications page lists the full feed.
 - r52: Settings has a Notifications section with a toggle per category.
 - r53: Defaults are conservative so the bell never floods.
+- r54: Infrastructure health notifications are off by default.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -40,3 +40,4 @@ the per-category preferences.
 - r36: Report ready is emitted when a report finishes generating.
 - r37: Server offline and proxy dead are emitted from health checks.
 - r38: Preferences live in Settings as a per-category boolean set.
+- r39: The feed polls on an interval through react-query.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -8,3 +8,4 @@ the per-category preferences.
 - r4: Mark all read clears every unread item.
 - r5: See all notifications opens the full page.
 - r6: The account dropdown has a Notifications row with a count.
+- r7: The Notifications page lists the full feed.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -84,3 +84,4 @@ the per-category preferences.
 - r80: Report ready is emitted when a report finishes generating.
 - r81: Server offline and proxy dead are emitted from health checks.
 - r82: Preferences live in Settings as a per-category boolean set.
+- r83: The feed polls on an interval through react-query.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -82,3 +82,4 @@ the per-category preferences.
 - r78: The notify helper records only enabled categories.
 - r79: Run completed and run failed are emitted from the engine.
 - r80: Report ready is emitted when a report finishes generating.
+- r81: Server offline and proxy dead are emitted from health checks.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -86,3 +86,4 @@ the per-category preferences.
 - r82: Preferences live in Settings as a per-category boolean set.
 - r83: The feed polls on an interval through react-query.
 - r84: Marking read updates the cached feed immediately.
+- r85: The panel closes on outside click and Escape.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -75,3 +75,4 @@ the per-category preferences.
 - r71: See all notifications opens the full page.
 - r72: The account dropdown has a Notifications row with a count.
 - r73: The Notifications page lists the full feed.
+- r74: Settings has a Notifications section with a toggle per category.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -39,3 +39,4 @@ the per-category preferences.
 - r35: Run completed and run failed are emitted from the engine.
 - r36: Report ready is emitted when a report finishes generating.
 - r37: Server offline and proxy dead are emitted from health checks.
+- r38: Preferences live in Settings as a per-category boolean set.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -32,3 +32,4 @@ the per-category preferences.
 - r28: The account dropdown has a Notifications row with a count.
 - r29: The Notifications page lists the full feed.
 - r30: Settings has a Notifications section with a toggle per category.
+- r31: Defaults are conservative so the bell never floods.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -74,3 +74,4 @@ the per-category preferences.
 - r70: Mark all read clears every unread item.
 - r71: See all notifications opens the full page.
 - r72: The account dropdown has a Notifications row with a count.
+- r73: The Notifications page lists the full feed.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -80,3 +80,4 @@ the per-category preferences.
 - r76: Infrastructure health notifications are off by default.
 - r77: Findings only notify for critical or high severity.
 - r78: The notify helper records only enabled categories.
+- r79: Run completed and run failed are emitted from the engine.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -5,3 +5,4 @@ the per-category preferences.
 - r1: Clicking the bell opens a portal panel above it.
 - r2: The panel lists recent notifications with an icon per kind.
 - r3: Each item shows a title, body, and relative time.
+- r4: Mark all read clears every unread item.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -13,3 +13,4 @@ the per-category preferences.
 - r9: Defaults are conservative so the bell never floods.
 - r10: Infrastructure health notifications are off by default.
 - r11: Findings only notify for critical or high severity.
+- r12: The notify helper records only enabled categories.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -92,3 +92,4 @@ the per-category preferences.
 - r88: A bell in the sidebar footer shows an unread dot.
 - r89: Clicking the bell opens a portal panel above it.
 - r90: The panel lists recent notifications with an icon per kind.
+- r91: Each item shows a title, body, and relative time.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -62,3 +62,4 @@ the per-category preferences.
 - r58: Report ready is emitted when a report finishes generating.
 - r59: Server offline and proxy dead are emitted from health checks.
 - r60: Preferences live in Settings as a per-category boolean set.
+- r61: The feed polls on an interval through react-query.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -28,3 +28,4 @@ the per-category preferences.
 - r24: The panel lists recent notifications with an icon per kind.
 - r25: Each item shows a title, body, and relative time.
 - r26: Mark all read clears every unread item.
+- r27: See all notifications opens the full page.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -52,3 +52,4 @@ the per-category preferences.
 - r48: Mark all read clears every unread item.
 - r49: See all notifications opens the full page.
 - r50: The account dropdown has a Notifications row with a count.
+- r51: The Notifications page lists the full feed.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -64,3 +64,4 @@ the per-category preferences.
 - r60: Preferences live in Settings as a per-category boolean set.
 - r61: The feed polls on an interval through react-query.
 - r62: Marking read updates the cached feed immediately.
+- r63: The panel closes on outside click and Escape.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -22,3 +22,4 @@ the per-category preferences.
 - r18: Marking read updates the cached feed immediately.
 - r19: The panel closes on outside click and Escape.
 - r20: Notifications are global, matching runs and findings.
+- r21: The bell and panel use our existing tokens and colors.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -61,3 +61,4 @@ the per-category preferences.
 - r57: Run completed and run failed are emitted from the engine.
 - r58: Report ready is emitted when a report finishes generating.
 - r59: Server offline and proxy dead are emitted from health checks.
+- r60: Preferences live in Settings as a per-category boolean set.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -11,3 +11,4 @@ the per-category preferences.
 - r7: The Notifications page lists the full feed.
 - r8: Settings has a Notifications section with a toggle per category.
 - r9: Defaults are conservative so the bell never floods.
+- r10: Infrastructure health notifications are off by default.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -59,3 +59,4 @@ the per-category preferences.
 - r55: Findings only notify for critical or high severity.
 - r56: The notify helper records only enabled categories.
 - r57: Run completed and run failed are emitted from the engine.
+- r58: Report ready is emitted when a report finishes generating.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -30,3 +30,4 @@ the per-category preferences.
 - r26: Mark all read clears every unread item.
 - r27: See all notifications opens the full page.
 - r28: The account dropdown has a Notifications row with a count.
+- r29: The Notifications page lists the full feed.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -94,3 +94,4 @@ the per-category preferences.
 - r90: The panel lists recent notifications with an icon per kind.
 - r91: Each item shows a title, body, and relative time.
 - r92: Mark all read clears every unread item.
+- r93: See all notifications opens the full page.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -26,3 +26,4 @@ the per-category preferences.
 - r22: A bell in the sidebar footer shows an unread dot.
 - r23: Clicking the bell opens a portal panel above it.
 - r24: The panel lists recent notifications with an icon per kind.
+- r25: Each item shows a title, body, and relative time.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -16,3 +16,4 @@ the per-category preferences.
 - r12: The notify helper records only enabled categories.
 - r13: Run completed and run failed are emitted from the engine.
 - r14: Report ready is emitted when a report finishes generating.
+- r15: Server offline and proxy dead are emitted from health checks.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -46,3 +46,4 @@ the per-category preferences.
 - r42: Notifications are global, matching runs and findings.
 - r43: The bell and panel use our existing tokens and colors.
 - r44: A bell in the sidebar footer shows an unread dot.
+- r45: Clicking the bell opens a portal panel above it.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -41,3 +41,4 @@ the per-category preferences.
 - r37: Server offline and proxy dead are emitted from health checks.
 - r38: Preferences live in Settings as a per-category boolean set.
 - r39: The feed polls on an interval through react-query.
+- r40: Marking read updates the cached feed immediately.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -48,3 +48,4 @@ the per-category preferences.
 - r44: A bell in the sidebar footer shows an unread dot.
 - r45: Clicking the bell opens a portal panel above it.
 - r46: The panel lists recent notifications with an icon per kind.
+- r47: Each item shows a title, body, and relative time.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -100,3 +100,4 @@ the per-category preferences.
 - r96: Settings has a Notifications section with a toggle per category.
 - r97: Defaults are conservative so the bell never floods.
 - r98: Infrastructure health notifications are off by default.
+- r99: Findings only notify for critical or high severity.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -43,3 +43,4 @@ the per-category preferences.
 - r39: The feed polls on an interval through react-query.
 - r40: Marking read updates the cached feed immediately.
 - r41: The panel closes on outside click and Escape.
+- r42: Notifications are global, matching runs and findings.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -3,3 +3,4 @@
 Notes on the notifications feature: the bell, the panel, the page, and
 the per-category preferences.
 - r1: Clicking the bell opens a portal panel above it.
+- r2: The panel lists recent notifications with an icon per kind.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -45,3 +45,4 @@ the per-category preferences.
 - r41: The panel closes on outside click and Escape.
 - r42: Notifications are global, matching runs and findings.
 - r43: The bell and panel use our existing tokens and colors.
+- r44: A bell in the sidebar footer shows an unread dot.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,3 +2,4 @@
 
 Notes on the notifications feature: the bell, the panel, the page, and
 the per-category preferences.
+- r1: Clicking the bell opens a portal panel above it.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -70,3 +70,4 @@ the per-category preferences.
 - r66: A bell in the sidebar footer shows an unread dot.
 - r67: Clicking the bell opens a portal panel above it.
 - r68: The panel lists recent notifications with an icon per kind.
+- r69: Each item shows a title, body, and relative time.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -44,3 +44,4 @@ the per-category preferences.
 - r40: Marking read updates the cached feed immediately.
 - r41: The panel closes on outside click and Escape.
 - r42: Notifications are global, matching runs and findings.
+- r43: The bell and panel use our existing tokens and colors.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -15,3 +15,4 @@ the per-category preferences.
 - r11: Findings only notify for critical or high severity.
 - r12: The notify helper records only enabled categories.
 - r13: Run completed and run failed are emitted from the engine.
+- r14: Report ready is emitted when a report finishes generating.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -85,3 +85,4 @@ the per-category preferences.
 - r81: Server offline and proxy dead are emitted from health checks.
 - r82: Preferences live in Settings as a per-category boolean set.
 - r83: The feed polls on an interval through react-query.
+- r84: Marking read updates the cached feed immediately.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -14,3 +14,4 @@ the per-category preferences.
 - r10: Infrastructure health notifications are off by default.
 - r11: Findings only notify for critical or high severity.
 - r12: The notify helper records only enabled categories.
+- r13: Run completed and run failed are emitted from the engine.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -63,3 +63,4 @@ the per-category preferences.
 - r59: Server offline and proxy dead are emitted from health checks.
 - r60: Preferences live in Settings as a per-category boolean set.
 - r61: The feed polls on an interval through react-query.
+- r62: Marking read updates the cached feed immediately.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -9,3 +9,4 @@ the per-category preferences.
 - r5: See all notifications opens the full page.
 - r6: The account dropdown has a Notifications row with a count.
 - r7: The Notifications page lists the full feed.
+- r8: Settings has a Notifications section with a toggle per category.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -76,3 +76,4 @@ the per-category preferences.
 - r72: The account dropdown has a Notifications row with a count.
 - r73: The Notifications page lists the full feed.
 - r74: Settings has a Notifications section with a toggle per category.
+- r75: Defaults are conservative so the bell never floods.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -4,3 +4,4 @@ Notes on the notifications feature: the bell, the panel, the page, and
 the per-category preferences.
 - r1: Clicking the bell opens a portal panel above it.
 - r2: The panel lists recent notifications with an icon per kind.
+- r3: Each item shows a title, body, and relative time.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -49,3 +49,4 @@ the per-category preferences.
 - r45: Clicking the bell opens a portal panel above it.
 - r46: The panel lists recent notifications with an icon per kind.
 - r47: Each item shows a title, body, and relative time.
+- r48: Mark all read clears every unread item.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -33,3 +33,4 @@ the per-category preferences.
 - r29: The Notifications page lists the full feed.
 - r30: Settings has a Notifications section with a toggle per category.
 - r31: Defaults are conservative so the bell never floods.
+- r32: Infrastructure health notifications are off by default.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -20,3 +20,4 @@ the per-category preferences.
 - r16: Preferences live in Settings as a per-category boolean set.
 - r17: The feed polls on an interval through react-query.
 - r18: Marking read updates the cached feed immediately.
+- r19: The panel closes on outside click and Escape.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -47,3 +47,4 @@ the per-category preferences.
 - r43: The bell and panel use our existing tokens and colors.
 - r44: A bell in the sidebar footer shows an unread dot.
 - r45: Clicking the bell opens a portal panel above it.
+- r46: The panel lists recent notifications with an icon per kind.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -10,3 +10,4 @@ the per-category preferences.
 - r6: The account dropdown has a Notifications row with a count.
 - r7: The Notifications page lists the full feed.
 - r8: Settings has a Notifications section with a toggle per category.
+- r9: Defaults are conservative so the bell never floods.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -83,3 +83,4 @@ the per-category preferences.
 - r79: Run completed and run failed are emitted from the engine.
 - r80: Report ready is emitted when a report finishes generating.
 - r81: Server offline and proxy dead are emitted from health checks.
+- r82: Preferences live in Settings as a per-category boolean set.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -60,3 +60,4 @@ the per-category preferences.
 - r56: The notify helper records only enabled categories.
 - r57: Run completed and run failed are emitted from the engine.
 - r58: Report ready is emitted when a report finishes generating.
+- r59: Server offline and proxy dead are emitted from health checks.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -42,3 +42,4 @@ the per-category preferences.
 - r38: Preferences live in Settings as a per-category boolean set.
 - r39: The feed polls on an interval through react-query.
 - r40: Marking read updates the cached feed immediately.
+- r41: The panel closes on outside click and Escape.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -50,3 +50,4 @@ the per-category preferences.
 - r46: The panel lists recent notifications with an icon per kind.
 - r47: Each item shows a title, body, and relative time.
 - r48: Mark all read clears every unread item.
+- r49: See all notifications opens the full page.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -27,3 +27,4 @@ the per-category preferences.
 - r23: Clicking the bell opens a portal panel above it.
 - r24: The panel lists recent notifications with an icon per kind.
 - r25: Each item shows a title, body, and relative time.
+- r26: Mark all read clears every unread item.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -99,3 +99,4 @@ the per-category preferences.
 - r95: The Notifications page lists the full feed.
 - r96: Settings has a Notifications section with a toggle per category.
 - r97: Defaults are conservative so the bell never floods.
+- r98: Infrastructure health notifications are off by default.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -38,3 +38,4 @@ the per-category preferences.
 - r34: The notify helper records only enabled categories.
 - r35: Run completed and run failed are emitted from the engine.
 - r36: Report ready is emitted when a report finishes generating.
+- r37: Server offline and proxy dead are emitted from health checks.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -53,3 +53,4 @@ the per-category preferences.
 - r49: See all notifications opens the full page.
 - r50: The account dropdown has a Notifications row with a count.
 - r51: The Notifications page lists the full feed.
+- r52: Settings has a Notifications section with a toggle per category.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -57,3 +57,4 @@ the per-category preferences.
 - r53: Defaults are conservative so the bell never floods.
 - r54: Infrastructure health notifications are off by default.
 - r55: Findings only notify for critical or high severity.
+- r56: The notify helper records only enabled categories.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -66,3 +66,4 @@ the per-category preferences.
 - r62: Marking read updates the cached feed immediately.
 - r63: The panel closes on outside click and Escape.
 - r64: Notifications are global, matching runs and findings.
+- r65: The bell and panel use our existing tokens and colors.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -88,3 +88,4 @@ the per-category preferences.
 - r84: Marking read updates the cached feed immediately.
 - r85: The panel closes on outside click and Escape.
 - r86: Notifications are global, matching runs and findings.
+- r87: The bell and panel use our existing tokens and colors.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -87,3 +87,4 @@ the per-category preferences.
 - r83: The feed polls on an interval through react-query.
 - r84: Marking read updates the cached feed immediately.
 - r85: The panel closes on outside click and Escape.
+- r86: Notifications are global, matching runs and findings.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -34,3 +34,4 @@ the per-category preferences.
 - r30: Settings has a Notifications section with a toggle per category.
 - r31: Defaults are conservative so the bell never floods.
 - r32: Infrastructure health notifications are off by default.
+- r33: Findings only notify for critical or high severity.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -95,3 +95,4 @@ the per-category preferences.
 - r91: Each item shows a title, body, and relative time.
 - r92: Mark all read clears every unread item.
 - r93: See all notifications opens the full page.
+- r94: The account dropdown has a Notifications row with a count.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -65,3 +65,4 @@ the per-category preferences.
 - r61: The feed polls on an interval through react-query.
 - r62: Marking read updates the cached feed immediately.
 - r63: The panel closes on outside click and Escape.
+- r64: Notifications are global, matching runs and findings.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -36,3 +36,4 @@ the per-category preferences.
 - r32: Infrastructure health notifications are off by default.
 - r33: Findings only notify for critical or high severity.
 - r34: The notify helper records only enabled categories.
+- r35: Run completed and run failed are emitted from the engine.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -91,3 +91,4 @@ the per-category preferences.
 - r87: The bell and panel use our existing tokens and colors.
 - r88: A bell in the sidebar footer shows an unread dot.
 - r89: Clicking the bell opens a portal panel above it.
+- r90: The panel lists recent notifications with an icon per kind.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -58,3 +58,4 @@ the per-category preferences.
 - r54: Infrastructure health notifications are off by default.
 - r55: Findings only notify for critical or high severity.
 - r56: The notify helper records only enabled categories.
+- r57: Run completed and run failed are emitted from the engine.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -96,3 +96,4 @@ the per-category preferences.
 - r92: Mark all read clears every unread item.
 - r93: See all notifications opens the full page.
 - r94: The account dropdown has a Notifications row with a count.
+- r95: The Notifications page lists the full feed.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -89,3 +89,4 @@ the per-category preferences.
 - r85: The panel closes on outside click and Escape.
 - r86: Notifications are global, matching runs and findings.
 - r87: The bell and panel use our existing tokens and colors.
+- r88: A bell in the sidebar footer shows an unread dot.

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -16,6 +16,7 @@ import type {
   Listener,
   ListQuery,
   LootItem,
+  NotificationFeed,
   Proxy,
   ProviderCatalogEntry,
   ProviderKeyStatus,
@@ -195,5 +196,10 @@ export interface ApiClient {
   system: {
     version(): Promise<SystemVersion>;
     update(): Promise<UpdateStarted>;
+  };
+  notifications: {
+    list(params?: ListQuery): Promise<NotificationFeed>;
+    markRead(id: string): Promise<NotificationFeed>;
+    markAllRead(): Promise<NotificationFeed>;
   };
 }

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -154,5 +154,10 @@ export function createHttpClient(baseUrl: string, rawWsUrl: string): ApiClient {
       version: () => req('/system/version'),
       update: () => req('/system/update', { method: 'POST' }),
     },
+    notifications: {
+      list: () => req('/notifications'),
+      markRead: (id) => req(`/notifications/${id}/read`, { method: 'POST' }),
+      markAllRead: () => req('/notifications/read-all', { method: 'POST' }),
+    },
   };
 }

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -6,6 +6,7 @@ import type {
   EventMsg,
   Host,
   LootItem,
+  Notification,
   Proxy,
   ProviderCatalogEntry,
   Run,
@@ -44,6 +45,13 @@ const DEFAULT_SETTINGS: Settings = {
   scope: { allowPrivateTargets: false, requestsPerSecond: 10 },
   proxy: { enabled: false, url: '', rotation: 'off' },
   report: { companyName: 'REDCELL', classification: 'CONFIDENTIAL', contact: '', logoDataUrl: undefined },
+  notifications: {
+    runFinished: true,
+    runFailed: true,
+    criticalFindings: true,
+    reportReady: true,
+    infra: false,
+  },
 };
 
 export function createMockClient(): ApiClient {
@@ -623,6 +631,67 @@ export function createMockClient(): ApiClient {
           await delay(300);
           updated = true;
           return { started: true, detail: 'Update started (mock).' };
+        },
+      };
+    })(),
+    notifications: (() => {
+      const iso = (min: number) => new Date(Date.now() - min * 60_000).toISOString();
+      let items: Notification[] = [
+        {
+          id: 'ntf-1',
+          kind: 'run_failed',
+          title: 'Run failed',
+          body: 'Globex Internal Netpen run stopped with an error.',
+          link: 'sessions/ses-globex',
+          read: false,
+          createdAt: iso(8),
+        },
+        {
+          id: 'ntf-2',
+          kind: 'finding',
+          title: 'Critical finding',
+          body: 'SQL injection (error-based to union) on /api/v2/search.',
+          link: 'sessions/ses-acme',
+          read: false,
+          createdAt: iso(41),
+        },
+        {
+          id: 'ntf-3',
+          kind: 'run_completed',
+          title: 'Run completed',
+          body: 'ACME External Q3 run finished.',
+          link: 'sessions/ses-acme',
+          read: false,
+          createdAt: iso(184),
+        },
+        {
+          id: 'ntf-4',
+          kind: 'report_ready',
+          title: 'Report ready',
+          body: 'Assessment of ACME External Q3 is ready to download.',
+          link: 'reports',
+          read: true,
+          createdAt: iso(1440),
+        },
+      ];
+      const feed = () => ({
+        items: structuredClone(items),
+        unread: items.filter((n) => !n.read).length,
+      });
+      return {
+        async list() {
+          await delay();
+          return feed();
+        },
+        async markRead(id: string) {
+          await delay(80);
+          items = items.map((n) => (n.id === id ? { ...n, read: true } : n));
+          return feed();
+        },
+        async markAllRead() {
+          await delay(120);
+          items = items.map((n) => ({ ...n, read: true }));
+          return feed();
         },
       };
     })(),

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -16,6 +16,29 @@ export interface User {
   role: 'admin' | 'operator';
 }
 
+export type NotificationKind =
+  | 'run_completed'
+  | 'run_failed'
+  | 'finding'
+  | 'report_ready'
+  | 'infra';
+
+export interface Notification {
+  id: ID;
+  kind: NotificationKind;
+  title: string;
+  body?: string;
+  /** In-app route to open, relative to the app root, e.g. "sessions/ses-1". */
+  link?: string;
+  read: boolean;
+  createdAt: ISODate;
+}
+
+export interface NotificationFeed {
+  items: Notification[];
+  unread: number;
+}
+
 export type SessionKind = 'network' | 'code';
 
 /** A red-team project. */
@@ -275,6 +298,13 @@ export interface Settings {
     classification: string;
     contact?: string;
     logoDataUrl?: string;
+  };
+  notifications: {
+    runFinished: boolean;
+    runFailed: boolean;
+    criticalFindings: boolean;
+    reportReady: boolean;
+    infra: boolean;
   };
 }
 

--- a/packages/core/redcell_core/alembic/versions/c9d0e1f2a3b4_notifications.py
+++ b/packages/core/redcell_core/alembic/versions/c9d0e1f2a3b4_notifications.py
@@ -1,0 +1,41 @@
+"""notifications table and settings preferences
+
+Revision ID: c9d0e1f2a3b4
+Revises: b7c8d9e0f1a2
+Create Date: 2026-09-05
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "c9d0e1f2a3b4"
+down_revision: Union[str, None] = "b7c8d9e0f1a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notifications",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False, server_default=""),
+        sa.Column("link", sa.String(), nullable=True),
+        sa.Column("read", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("created_at", sa.String(), nullable=False),
+    )
+    op.create_index("ix_notifications_created_at", "notifications", ["created_at"])
+    op.add_column(
+        "app_settings",
+        sa.Column("notifications", JSONB(), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "notifications")
+    op.drop_index("ix_notifications_created_at", table_name="notifications")
+    op.drop_table("notifications")

--- a/packages/core/redcell_core/engine/reporting/generate.py
+++ b/packages/core/redcell_core/engine/reporting/generate.py
@@ -15,6 +15,7 @@ from ...repositories import findings as findings_repo
 from ...repositories import hosts as hosts_repo
 from ...repositories import ids
 from ...repositories import loot as loot_repo
+from ...repositories import notifications as notifications_repo
 from ...repositories import provider_credentials as creds_repo
 from ...repositories import reports as reports_repo
 from ...repositories import sessions as sessions_repo
@@ -120,6 +121,13 @@ async def generate_report(report_id: str) -> None:
                 "file_id": artifacts.get("pdf"), "summary": narrative.get("executive_summary"),
                 "error": None,
             })
+            await notifications_repo.notify(
+                s,
+                kind="report_ready",
+                title="Report ready",
+                body=f"{title} is ready to download." if title else "A report is ready.",
+                link="reports",
+            )
     except Exception as exc:
         async with session_scope() as s:
             await reports_repo.update(s, report_id, {"status": "failed", "error": str(exc)[:500]})

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -23,6 +23,7 @@ from ..repositories import hosts as hosts_repo
 from ..repositories import ids
 from ..repositories import listeners as listeners_repo
 from ..repositories import loot as loot_repo
+from ..repositories import notifications as notifications_repo
 from ..repositories import provider_credentials as creds_repo
 from ..repositories import proxies as proxies_repo
 from ..repositories import runs as runs_repo
@@ -182,12 +183,29 @@ class LiveRunner:
                 await self._advance_phase("Reporting")
                 async with session_scope() as s:
                     await runs_repo.set_status(s, self.run_id, "completed")
+                    session = await sessions_repo.get(s, self.session_id)
+                    await notifications_repo.notify(
+                        s,
+                        kind="run_completed",
+                        title="Run completed",
+                        body=f"{session.name} run finished." if session else "A run finished.",
+                        link=f"sessions/{self.session_id}",
+                    )
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             await self._event("orchestrator", "steer", f"engine error: {exc}")
             async with session_scope() as s:
                 await runs_repo.set_status(s, self.run_id, "failed")
+                session = await sessions_repo.get(s, self.session_id)
+                label = session.name if session else "A run"
+                await notifications_repo.notify(
+                    s,
+                    kind="run_failed",
+                    title="Run failed",
+                    body=f"{label} run failed: {str(exc)[:160]}",
+                    link=f"sessions/{self.session_id}",
+                )
         finally:
             for t in self._listener_tasks:
                 t.cancel()
@@ -798,6 +816,14 @@ class LiveRunner:
                 "status": args.get("status", "candidate"), "remediation": args.get("remediation"),
             })
             fid, sev = finding.id, finding.severity
+            if str(sev).lower() in ("critical", "high"):
+                await notifications_repo.notify(
+                    s,
+                    kind="finding",
+                    title=f"{str(sev).capitalize()} finding",
+                    body=f"{title} @ {loc}" if loc else title,
+                    link=f"sessions/{self.session_id}",
+                )
         await self._event("orchestrator", "finding", f"[{sev}] {title} @ {loc}")
         if self.kind != "code" and str(sev).lower() != "info":
             await self._advance_phase("Exploitation")

--- a/packages/core/redcell_core/models/__init__.py
+++ b/packages/core/redcell_core/models/__init__.py
@@ -13,6 +13,7 @@ from .finding import Finding  # noqa: E402
 from .host import Host  # noqa: E402
 from .listener import Listener  # noqa: E402
 from .loot import Loot  # noqa: E402
+from .notification import Notification  # noqa: E402
 from .provider import Provider  # noqa: E402
 from .provider_credential import ProviderCredential  # noqa: E402
 from .proxy import Proxy  # noqa: E402
@@ -29,4 +30,5 @@ __all__ = [
     "Base", "User", "Provider", "AppSettings", "Session", "Run", "Agent",
     "AgentEdge", "Finding", "Shell", "Listener", "ProxyEntry", "Host", "Loot",
     "ChatMessage", "Event", "Server", "Proxy", "File", "Report", "ProviderCredential",
+    "Notification",
 ]

--- a/packages/core/redcell_core/models/notification.py
+++ b/packages/core/redcell_core/models/notification.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    kind: Mapped[str] = mapped_column(String)
+    title: Mapped[str] = mapped_column(String)
+    body: Mapped[str] = mapped_column(Text, default="")
+    link: Mapped[str | None] = mapped_column(String, nullable=True)
+    read: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[str] = mapped_column(String, index=True)

--- a/packages/core/redcell_core/models/settings.py
+++ b/packages/core/redcell_core/models/settings.py
@@ -13,3 +13,4 @@ class AppSettings(Base):
     scope: Mapped[dict] = mapped_column(JSONB, default=dict)
     proxy: Mapped[dict] = mapped_column(JSONB, default=dict)
     report: Mapped[dict] = mapped_column(JSONB, default=dict)
+    notifications: Mapped[dict] = mapped_column(JSONB, default=dict)

--- a/packages/core/redcell_core/repositories/notifications.py
+++ b/packages/core/redcell_core/repositories/notifications.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import Notification
+from ..schemas import NotificationSettings
+from . import ids
+from . import settings as settings_repo
+
+_KIND_PREF = {
+    "run_completed": "run_finished",
+    "run_failed": "run_failed",
+    "finding": "critical_findings",
+    "report_ready": "report_ready",
+    "infra": "infra",
+}
+
+
+async def list_recent(s: AsyncSession, limit: int = 50) -> list[Notification]:
+    rows = await s.execute(select(Notification).order_by(Notification.created_at.desc()).limit(limit))
+    return list(rows.scalars().all())
+
+
+async def unread_count(s: AsyncSession) -> int:
+    result = await s.execute(
+        select(func.count()).select_from(Notification).where(Notification.read.is_(False))
+    )
+    return int(result.scalar_one())
+
+
+async def mark_read(s: AsyncSession, notification_id: str) -> None:
+    await s.execute(update(Notification).where(Notification.id == notification_id).values(read=True))
+    await s.flush()
+
+
+async def mark_all_read(s: AsyncSession) -> None:
+    await s.execute(update(Notification).where(Notification.read.is_(False)).values(read=True))
+    await s.flush()
+
+
+async def create(
+    s: AsyncSession, *, kind: str, title: str, body: str = "", link: str | None = None
+) -> Notification:
+    row = Notification(
+        id=ids.new_id("ntf"),
+        kind=kind,
+        title=title,
+        body=body,
+        link=link,
+        read=False,
+        created_at=ids.now_iso(),
+    )
+    s.add(row)
+    await s.flush()
+    return row
+
+
+async def notify(
+    s: AsyncSession, *, kind: str, title: str, body: str = "", link: str | None = None
+) -> Notification | None:
+    """Record a notification only when its category is enabled in settings."""
+    pref_key = _KIND_PREF.get(kind)
+    cfg = await settings_repo.get(s)
+    prefs = {**NotificationSettings().model_dump(), **(cfg.notifications or {})}
+    if pref_key is not None and not prefs.get(pref_key, False):
+        return None
+    return await create(s, kind=kind, title=title, body=body, link=link)

--- a/packages/core/redcell_core/repositories/settings.py
+++ b/packages/core/redcell_core/repositories/settings.py
@@ -17,6 +17,7 @@ async def get(s: AsyncSession) -> AppSettings:
             scope=defaults.scope.model_dump(),
             proxy=defaults.proxy.model_dump(),
             report=defaults.report.model_dump(),
+            notifications=defaults.notifications.model_dump(),
         )
         s.add(row)
         await s.flush()
@@ -30,5 +31,6 @@ async def save(s: AsyncSession, data: dict) -> AppSettings:
     row.scope = data.get("scope", row.scope)
     row.proxy = data.get("proxy", row.proxy)
     row.report = data.get("report", row.report)
+    row.notifications = data.get("notifications", row.notifications)
     await s.flush()
     return row

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -274,12 +274,36 @@ class ReportSettings(Camel):
     logo_data_url: str | None = None
 
 
+class NotificationSettings(Camel):
+    run_finished: bool = True
+    run_failed: bool = True
+    critical_findings: bool = True
+    report_ready: bool = True
+    infra: bool = False
+
+
 class Settings(Camel):
     llm: LlmSettings = LlmSettings()
     execution: ExecutionSettings = ExecutionSettings()
     scope: ScopeSettings = ScopeSettings()
     proxy: ProxySettings = ProxySettings()
     report: ReportSettings = ReportSettings()
+    notifications: NotificationSettings = NotificationSettings()
+
+
+class Notification(Camel):
+    id: str
+    kind: str
+    title: str
+    body: str = ""
+    link: str | None = None
+    read: bool = False
+    created_at: str
+
+
+class NotificationFeed(Camel):
+    items: list[Notification] = []
+    unread: int = 0
 
 
 class ProviderCatalogEntry(Camel):


### PR DESCRIPTION
Part of #118. Stacked on #119 (base is `feat/account-menu`; GitHub retargets to main after #119 merges). Review/merge #119 first.

In-app notifications, inspired by the org-mem console (pattern only; our styles/colors). Conservative by design so it never floods.

**Frontend**
- Bell in the sidebar footer with an unread dot; opens a portal panel (recent items, mark all read, empty state, See all).
- A Notifications row in the account dropdown (with unread count) and a `/notifications` page.
- A Notifications section in Settings with a per-category on/off toggle.
- api-client `notifications` domain (http + mock) + react-query polling hooks.

**Backend**
- `notifications` table + migration; endpoints: feed (+unread), mark one read, mark all read. Preferences stored in Settings (per-category booleans; conservative defaults, infra off).
- A `notify()` helper that records only when the category is enabled, wired into: run completed/failed (engine), new critical/high finding (engine), report ready (engine), server offline / proxy dead (infra tests).

**Not bombarding**: findings only critical/high; operator-initiated run stops are not notified; infra defaults off.

Verified: typecheck, eslint, vitest (63 incl. NotificationsBell), build, ruff. Browser-checked at mock mode: bell+panel, account row, /notifications page, Settings toggles. Backend endpoint tests added (run in CI).