### PR TITLE
chore(release): v0.4.2

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.4.1"
+version = "0.4.2"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.4.1"
+version = "0.4.2"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]


### PR DESCRIPTION
Release v0.4.2: mobile layout fixes (#123).

- Page bottoms clear the fixed bottom nav on all mobile browsers.
- The running-session console header fits on a phone.

Bumps api/worker/web to 0.4.2. No migration. Squash-merge, then tag v0.4.2 to build and publish images.