### PR TITLE
fix(engine): reconstruct run context from Postgres on continue

### DIFF
--- a/apps/api/tests/test_run_context.py
+++ b/apps/api/tests/test_run_context.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from redcell_core.engine.runner import summarize_progress
+
+
+def _f(title, severity, location="", status="candidate"):
+    return SimpleNamespace(title=title, severity=severity, location=location, status=status)
+
+
+def _h(host, ip=None, ports=None, tech=None):
+    return SimpleNamespace(host=host, ip=ip, ports=ports or [], tech=tech or [])
+
+
+def _l(kind, label):
+    return SimpleNamespace(kind=kind, label=label)
+
+
+def test_summary_none_when_empty():
+    assert summarize_progress([], [], []) is None
+
+
+def test_summary_ignores_dismissed_findings():
+    assert summarize_progress([_f("SQLi", "critical", "/x", "dismissed")], [], []) is None
+
+
+def test_summary_includes_findings_hosts_and_loot():
+    text = summarize_progress(
+        [_f("SQL injection", "critical", "/api/v2/search", "verified")],
+        [_h("app.acme.io", "1.2.3.4", [443, {"port": 8443}], ["nginx"])],
+        [_l("credential", "admin@acme")],
+    )
+    assert text is not None
+    assert "SQL injection" in text
+    assert "/api/v2/search" in text
+    assert "critical" in text
+    assert "app.acme.io" in text and "1.2.3.4" in text
+    assert "443" in text and "8443" in text and "nginx" in text
+    assert "credential: admin@acme" in text

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -50,6 +50,33 @@ MAX_ORCH_STEPS = 40
 MAX_EXEC_STEPS = 10
 MAX_CONCURRENT_EXECUTORS = 3
 
+
+def summarize_progress(findings, hosts, loot) -> str | None:
+    """A compact recap of what the engagement already found, so a continued run
+    picks up from the durable Postgres state instead of starting cold."""
+    live = [f for f in findings if getattr(f, "status", "") != "dismissed"]
+    if not (live or hosts or loot):
+        return None
+    lines: list[str] = []
+    if live:
+        lines.append("Findings already recorded:")
+        for f in live[:40]:
+            loc = f" @ {f.location}" if getattr(f, "location", "") else ""
+            lines.append(f"- [{f.severity}] {f.title}{loc} (status: {f.status})")
+    if hosts:
+        lines.append("Attack surface already mapped:")
+        for h in hosts[:40]:
+            ip = f" ({h.ip})" if getattr(h, "ip", None) else ""
+            ports = [p.get("port", p) if isinstance(p, dict) else p for p in (h.ports or [])][:12]
+            pstr = f" ports {', '.join(str(p) for p in ports)}" if ports else ""
+            tech = f" tech {', '.join(str(t) for t in (h.tech or [])[:8])}" if h.tech else ""
+            lines.append(f"- {h.host}{ip}{pstr}{tech}")
+    if loot:
+        lines.append("Loot and credentials already collected:")
+        for x in loot[:30]:
+            lines.append(f"- {x.kind}: {x.label}")
+    return "\n".join(lines)
+
 # Fallback CVSS when a finding is recorded without a numeric score.
 _CVSS_BY_SEVERITY = {"critical": 9.5, "high": 8.0, "medium": 5.5, "low": 3.1, "info": 0.0}
 
@@ -294,6 +321,13 @@ class LiveRunner:
         return agent.id
 
     # ---- LangGraph plan/act loop ----
+    async def _prior_progress(self) -> str | None:
+        async with session_scope() as s:
+            findings = await findings_repo.list_for_session(s, self.session_id)
+            hosts = await hosts_repo.list_for_session(s, self.session_id)
+            loot = await loot_repo.list_for_session(s, self.session_id)
+        return summarize_progress(findings, hosts, loot)
+
     async def _orchestrate(self) -> None:
         from langgraph.graph import END, StateGraph
 
@@ -325,11 +359,16 @@ class LiveRunner:
                   else orchestrator_system(self.run_name, self.scope, self.targets, self.roe,
                                            brief=self.brief, instruction=self.instruction,
                                            files=self.assessment_files))
-        init: _State = {
-            "messages": [{"role": "system", "content": system},
-                         {"role": "user", "content": "Begin the engagement."}],
-            "steps": 0, "done": False,
-        }
+        prior = await self._prior_progress()
+        messages: list[dict] = [{"role": "system", "content": system}]
+        if prior:
+            messages.append({
+                "role": "system",
+                "content": ("Progress already made in this engagement. Build on it and do not "
+                            "repeat completed work:\n" + prior),
+            })
+        messages.append({"role": "user", "content": "Begin the engagement."})
+        init: _State = {"messages": messages, "steps": 0, "done": False}
         if not saver:
             await app.ainvoke(init, config={"recursion_limit": MAX_ORCH_STEPS * 2 + 4})
             return


### PR DESCRIPTION
Closes #126.

When a finished run is continued in chat, it often restarted cold and re-discovered everything, because the only memory was a LangGraph SQLite checkpoint that is lost whenever the worker restarts or is recreated.

This loads the session's existing findings, hosts, and loot from Postgres on the fresh-start path, summarizes them (severity, location, status for findings; host, ip, ports, tech for surface; kind and label for loot), and injects that recap into the orchestrator's opening context. So a continued run builds on the durable state instead of starting from zero, regardless of the checkpoint.

Dismissed findings are excluded; the recap is capped so it stays compact. Adds a unit test for the summary.

Follow-up (separate PR): move the LangGraph checkpointer from SQLite to Postgres so the full conversation is durable too.