### PR TITLE
chore(release): v0.4.3

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.4.2"
+version = "0.4.3"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.4.2"
+version = "0.4.3"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]


### PR DESCRIPTION
Release v0.4.3: continuing a finished run no longer starts from zero (#126).

The orchestrator reconstructs context from the session's findings, hosts, and loot in Postgres on a fresh start, so continuing in chat builds on prior work even when the LangGraph checkpoint was lost.

Bumps api/worker/web to 0.4.3. No migration. Squash-merge, then tag v0.4.3 to build and publish images.