### PR TITLE
chore(release): v0.4.4

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.4.3"
+version = "0.4.4"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.4.3"
+version = "0.4.4"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]


### PR DESCRIPTION
Release v0.4.4: the LangGraph checkpointer moved from SQLite to Postgres (#129).

The agent-loop state is stored in the shared Postgres database, durable across worker restarts, with no ephemeral SQLite file. psycopg replaces aiosqlite. No alembic migration: the saver creates its own tables on first use.

Bumps api/worker/web to 0.4.4. Squash-merge, then tag v0.4.4 to build and publish images.