### PR TITLE
feat(mobile): pull-to-refresh

### DIFF
--- a/apps/web/src/app/DashboardShell.tsx
+++ b/apps/web/src/app/DashboardShell.tsx
@@ -12,6 +12,7 @@ import { UpdateDialog } from './UpdateDialog';
 import { MobileNav } from './MobileNav';
 import { MobileDrawer } from './MobileDrawer';
 import { NotificationsBell } from './NotificationsBell';
+import { PullToRefresh } from './PullToRefresh';
 import { SIDEBAR_GROUPS } from './nav';
 
 function ActiveRunRow({ session, onClick }: { session: Session; onClick: () => void }) {
@@ -300,9 +301,15 @@ export function DashboardShell() {
             </svg>
           </button>
         </header>
-        <div className={consoleId ? 'console-body' : 'body-normal'}>
-          <Outlet />
-        </div>
+        {consoleId ? (
+          <div className="console-body">
+            <Outlet />
+          </div>
+        ) : (
+          <PullToRefresh className="body-normal">
+            <Outlet />
+          </PullToRefresh>
+        )}
         </section>
       </div>
 

--- a/apps/web/src/app/PullToRefresh.test.tsx
+++ b/apps/web/src/app/PullToRefresh.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/useIsMobile', () => ({ useIsMobile: () => true }));
+
+import { PullToRefresh } from './PullToRefresh';
+
+describe('PullToRefresh', () => {
+  it('renders children inside the scroll container with a pull indicator', () => {
+    const qc = new QueryClient();
+    const { container } = render(
+      <QueryClientProvider client={qc}>
+        <PullToRefresh className="body-normal">
+          <p>content</p>
+        </PullToRefresh>
+      </QueryClientProvider>,
+    );
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(container.querySelector('.body-normal .ptr')).not.toBeNull();
+  });
+});

--- a/apps/web/src/app/PullToRefresh.tsx
+++ b/apps/web/src/app/PullToRefresh.tsx
@@ -62,16 +62,20 @@ export function PullToRefresh({ className, children }: { className?: string; chi
         setDist(0);
       });
     };
+    const onCancel = () => {
+      startY.current = null;
+      setDist(0);
+    };
 
     el.addEventListener('touchstart', onStart, { passive: true });
     el.addEventListener('touchmove', onMove, { passive: false });
     el.addEventListener('touchend', onEnd);
-    el.addEventListener('touchcancel', onEnd);
+    el.addEventListener('touchcancel', onCancel);
     return () => {
       el.removeEventListener('touchstart', onStart);
       el.removeEventListener('touchmove', onMove);
       el.removeEventListener('touchend', onEnd);
-      el.removeEventListener('touchcancel', onEnd);
+      el.removeEventListener('touchcancel', onCancel);
     };
   }, [isMobile, qc]);
 

--- a/apps/web/src/app/PullToRefresh.tsx
+++ b/apps/web/src/app/PullToRefresh.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useIsMobile } from '@/lib/useIsMobile';
+
+const THRESHOLD = 70;
+const MAX = 110;
+const DAMP = 0.5;
+
+export function PullToRefresh({ className, children }: { className?: string; children: ReactNode }) {
+  const isMobile = useIsMobile();
+  const qc = useQueryClient();
+  const ref = useRef<HTMLDivElement>(null);
+  const startY = useRef<number | null>(null);
+  const pullRef = useRef(0);
+  const refreshingRef = useRef(false);
+  const [pull, setPull] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !isMobile) return;
+
+    const setDist = (v: number) => {
+      pullRef.current = v;
+      setPull(v);
+    };
+
+    const onStart = (e: TouchEvent) => {
+      const t = e.touches[0];
+      startY.current = t && el.scrollTop <= 0 && !refreshingRef.current ? t.clientY : null;
+    };
+    const onMove = (e: TouchEvent) => {
+      const t = e.touches[0];
+      if (startY.current === null || !t) return;
+      if (el.scrollTop > 0) {
+        startY.current = null;
+        setDist(0);
+        return;
+      }
+      const dy = t.clientY - startY.current;
+      if (dy <= 0) {
+        setDist(0);
+        return;
+      }
+      const dist = Math.min(MAX, dy * DAMP);
+      setDist(dist);
+      if (dist > 4) e.preventDefault();
+    };
+    const onEnd = () => {
+      if (startY.current === null) return;
+      startY.current = null;
+      if (pullRef.current < THRESHOLD) {
+        setDist(0);
+        return;
+      }
+      refreshingRef.current = true;
+      setRefreshing(true);
+      setDist(THRESHOLD);
+      void qc.invalidateQueries().finally(() => {
+        refreshingRef.current = false;
+        setRefreshing(false);
+        setDist(0);
+      });
+    };
+
+    el.addEventListener('touchstart', onStart, { passive: true });
+    el.addEventListener('touchmove', onMove, { passive: false });
+    el.addEventListener('touchend', onEnd);
+    el.addEventListener('touchcancel', onEnd);
+    return () => {
+      el.removeEventListener('touchstart', onStart);
+      el.removeEventListener('touchmove', onMove);
+      el.removeEventListener('touchend', onEnd);
+      el.removeEventListener('touchcancel', onEnd);
+    };
+  }, [isMobile, qc]);
+
+  return (
+    <div ref={ref} className={className}>
+      <div className="ptr" style={{ height: pull, opacity: pull > 8 ? 1 : 0 }}>
+        <span
+          className={`ptr-spin${refreshing ? ' on' : ''}`}
+          style={refreshing ? undefined : { transform: `rotate(${Math.round(pull * 2.6)}deg)` }}
+        />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/styles/design.css
+++ b/apps/web/src/styles/design.css
@@ -653,6 +653,34 @@
   color: var(--tx);
 }
 
+.ptr {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  transition: opacity 0.15s ease;
+}
+.ptr-spin {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--line);
+  border-top-color: var(--acc);
+  border-radius: 50%;
+}
+.ptr-spin.on {
+  animation: ptr-rotate 0.7s linear infinite;
+}
+@keyframes ptr-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ptr-spin.on {
+    animation: none;
+  }
+}
+
 .menu-sep {
   height: 1px;
   background: var(--line-soft);


### PR DESCRIPTION
Closes #132.

Adds a custom pull-to-refresh to the page scroll area on mobile. The app is a fixed-viewport SPA where the document never scrolls, so the browser's native pull-to-refresh never triggers.

- `PullToRefresh` wraps the `.body-normal` scroll container. Pulling down at the top (scrollTop 0) past a threshold shows a damped spinner and, on release, refetches all data by invalidating the react-query cache; the spinner spins until refetch settles, then snaps back.
- Gated on `useIsMobile` and touch events; desktop attaches no listeners and the indicator stays at zero height, so desktop is unaffected. The console view keeps its own scroll and is not wrapped.
- Spinner honors prefers-reduced-motion.

Verified: typecheck, eslint, vitest (smoke test), build. The touch gesture itself is best confirmed on a real phone after release (browser MCP was unavailable and headless touch simulation is unreliable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pull-to-refresh support for dashboard content on mobile devices.
  - Pull down on the dashboard to refresh data, with visual progress and refreshing indicators.
  - Console pages continue using the standard dashboard layout.

- **Style**
  - Added responsive spinner styling and support for reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->