### PR TITLE
fix(update): remove the keep-working hint from the update panel

### DIFF
--- a/apps/web/src/app/UpdateDialog.tsx
+++ b/apps/web/src/app/UpdateDialog.tsx
@@ -128,9 +128,7 @@ export function UpdateDialog({ open, onClose, target }: { open: boolean; onClose
             <button type="button" className="btn sm" onClick={onClose}>
               Close
             </button>
-          ) : (
-            <span className="meta">You can keep working; the console reconnects on its own.</span>
-          )}
+          ) : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Removes the "You can keep working; the console reconnects on its own." line shown while an update is in progress. No behavior change; the footer is empty during the in-progress phase.

Not tagging a release for this; it ships with the next release.