### PR TITLE
chore(release): v0.4.6

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.4.5"
+version = "0.4.6"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.4.5"
+version = "0.4.6"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]


### PR DESCRIPTION
Release v0.4.6: the console is now an installable PWA (#136).

Adds a web app manifest, a service worker that precaches the static app shell (API and websocket traffic excluded), and a REDCELL shield icon set. Also includes the update-panel hint removal (#135).

Bumps api/worker/web to 0.4.6. Squash-merge, then tag v0.4.6 to build and publish images.