### PR TITLE
feat: store an ngrok auth token as a global encrypted secret

### DIFF
--- a/apps/api/app/routers/settings.py
+++ b/apps/api/app/routers/settings.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from redcell_core.repositories import provider_credentials as creds_repo
 from redcell_core.repositories import providers as providers_repo
+from redcell_core.repositories import secrets as secrets_repo
 from redcell_core.repositories import settings as settings_repo
 from redcell_core.schemas import (
     AvailableModel,
+    NgrokStatus,
+    NgrokTokenInput,
     ProviderCatalogEntry,
     ProviderKeyInput,
     ProviderKeyStatus,
@@ -57,6 +60,26 @@ async def set_provider_key(body: ProviderKeyInput, s: AsyncSession = Depends(db)
 @router.delete("/provider-keys/{provider_id}", status_code=204)
 async def remove_provider_key(provider_id: str, s: AsyncSession = Depends(db)) -> None:
     await creds_repo.delete(s, provider_id)
+
+
+# ---- ngrok auth token (Fernet-encrypted at rest) ----
+@router.get("/integrations/ngrok", response_model=NgrokStatus)
+async def ngrok_status(s: AsyncSession = Depends(db)) -> NgrokStatus:
+    return NgrokStatus(configured=await secrets_repo.has_secret(s, secrets_repo.NGROK_AUTHTOKEN))
+
+
+@router.post("/integrations/ngrok", response_model=NgrokStatus)
+async def set_ngrok_token(body: NgrokTokenInput, s: AsyncSession = Depends(db)) -> NgrokStatus:
+    token = body.token.strip()
+    if len(token) < 20 or " " in token:
+        raise HTTPException(status_code=422, detail="that does not look like an ngrok auth token")
+    await secrets_repo.set_secret(s, secrets_repo.NGROK_AUTHTOKEN, token)
+    return NgrokStatus(configured=True)
+
+
+@router.delete("/integrations/ngrok", status_code=204)
+async def clear_ngrok_token(s: AsyncSession = Depends(db)) -> None:
+    await secrets_repo.delete_secret(s, secrets_repo.NGROK_AUTHTOKEN)
 
 
 # ---- models available to the operator (keyed + keyless providers) ----

--- a/apps/web/src/app/pages/SettingsPage.tsx
+++ b/apps/web/src/app/pages/SettingsPage.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
 import type { ProviderCatalogEntry, Settings } from '@redcell/api-client';
 import {
+  useClearNgrokToken,
+  useNgrokStatus,
   useProviderKeys,
   useProviders,
   useRemoveProviderKey,
   useSaveSettings,
+  useSetNgrokToken,
   useSetProviderKey,
   useSettings,
 } from '@/features/hooks';
@@ -14,7 +17,7 @@ import { Combobox } from '@/components/ui/Combobox';
 import { SelectTrigger } from '@/components/ui/fields';
 import { toast } from '@/components/ui/toast';
 
-type Tab = 'providers' | 'execution' | 'scope' | 'branding' | 'notifications';
+type Tab = 'providers' | 'execution' | 'scope' | 'branding' | 'notifications' | 'integrations';
 
 const TABS: { id: Tab; label: string }[] = [
   { id: 'providers', label: 'Providers & keys' },
@@ -22,6 +25,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: 'scope', label: 'Scope guardrails' },
   { id: 'branding', label: 'Report branding' },
   { id: 'notifications', label: 'Notifications' },
+  { id: 'integrations', label: 'Integrations' },
 ];
 
 const NOTIF_CATEGORIES: { key: keyof Settings['notifications']; label: string; desc: string }[] = [
@@ -43,11 +47,15 @@ export function SettingsPage() {
   const setKey = useSetProviderKey();
   const removeKey = useRemoveProviderKey();
   const save = useSaveSettings();
+  const { data: ngrok } = useNgrokStatus();
+  const setNgrok = useSetNgrokToken();
+  const clearNgrok = useClearNgrokToken();
 
   const [tab, setTab] = useState<Tab>('providers');
   const [draft, setDraft] = useState<Settings | null>(null);
   const [keyFor, setKeyFor] = useState<ProviderCatalogEntry | null>(null);
   const [keyInput, setKeyInput] = useState('');
+  const [ngrokInput, setNgrokInput] = useState('');
 
   useEffect(() => {
     if (initial && !draft) setDraft(structuredClone(initial));
@@ -84,6 +92,27 @@ export function SettingsPage() {
   const keyedIds = new Set((keys ?? []).filter((k) => k.hasKey).map((k) => k.providerId));
   const provider = providers.find((p) => p.id === draft.llm.provider);
   const models = provider?.models ?? [];
+
+  const saveNgrok = async () => {
+    const token = ngrokInput.trim();
+    if (!token) return;
+    try {
+      await setNgrok.mutateAsync(token);
+      setNgrokInput('');
+      toast('ngrok token saved', 'success');
+    } catch {
+      toast('That does not look like an ngrok auth token', 'error');
+    }
+  };
+
+  const removeNgrok = async () => {
+    try {
+      await clearNgrok.mutateAsync();
+      toast('ngrok token removed', 'success');
+    } catch {
+      toast('Could not remove the ngrok token', 'error');
+    }
+  };
 
   const saveKey = async () => {
     if (!keyFor || !keyInput.trim() || !keys) return;
@@ -343,6 +372,59 @@ export function SettingsPage() {
                 ))}
                 <button type="button" className="btn pri" disabled={save.isPending} onClick={onSave}>
                   Save notifications
+                </button>
+              </div>
+            </div>
+          )}
+
+          {tab === 'integrations' && (
+            <div className="card">
+              <div className="card-h">
+                <h3>ngrok</h3>
+                <span className="cs">· catch reverse shells without opening a port</span>
+              </div>
+              <div className="card-b">
+                <p className="fd" style={{ marginBottom: 14 }}>
+                  With an ngrok auth token, REDCELL opens a TCP tunnel on demand so a target can call
+                  back through ngrok. Works on a free ngrok account and needs no inbound ports on the
+                  server.
+                </p>
+                <div className="prow">
+                  <span className="plogo">n</span>
+                  <div style={{ flex: 1 }}>
+                    <div className="pn">Auth token</div>
+                    <div className="pm">Encrypted at rest. Find it in your ngrok dashboard.</div>
+                  </div>
+                  {ngrok?.configured ? (
+                    <span className="badge ok">
+                      <span className="hd ok" />
+                      Configured
+                    </span>
+                  ) : (
+                    <span className="badge off">
+                      <span className="hd un" />
+                      Not set
+                    </span>
+                  )}
+                  {ngrok?.configured && (
+                    <button type="button" className="btn sm danger" disabled={clearNgrok.isPending} onClick={() => void removeNgrok()}>
+                      Remove
+                    </button>
+                  )}
+                </div>
+                <div className="field" style={{ marginTop: 14 }}>
+                  <span className="label">{ngrok?.configured ? 'Replace token' : 'Auth token'}</span>
+                  <input
+                    className="input mono"
+                    type="password"
+                    value={ngrokInput}
+                    placeholder="2a…"
+                    onChange={(e) => setNgrokInput(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && ngrokInput.trim() && void saveNgrok()}
+                  />
+                </div>
+                <button type="button" className="btn pri" disabled={!ngrokInput.trim() || setNgrok.isPending} onClick={() => void saveNgrok()}>
+                  Save token
                 </button>
               </div>
             </div>

--- a/apps/web/src/features/hooks.ts
+++ b/apps/web/src/features/hooks.ts
@@ -263,6 +263,29 @@ export function useRemoveProviderKey() {
   });
 }
 
+export function useNgrokStatus() {
+  const api = useApi();
+  return useQuery({ queryKey: ['ngrok'], queryFn: () => api.settings.ngrokStatus() });
+}
+
+export function useSetNgrokToken() {
+  const api = useApi();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (token: string) => api.settings.setNgrokToken(token),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['ngrok'] }),
+  });
+}
+
+export function useClearNgrokToken() {
+  const api = useApi();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.settings.clearNgrokToken(),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['ngrok'] }),
+  });
+}
+
 export function useSaveSettings() {
   const api = useApi();
   const qc = useQueryClient();

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -16,6 +16,7 @@ import type {
   Listener,
   ListQuery,
   LootItem,
+  NgrokStatus,
   NotificationFeed,
   Proxy,
   ProviderCatalogEntry,
@@ -156,6 +157,9 @@ export interface ApiClient {
     setProviderKey(input: SetProviderKeyInput): Promise<ProviderKeyStatus>;
     removeProviderKey(providerId: string): Promise<void>;
     availableModels(): Promise<AvailableModel[]>;
+    ngrokStatus(): Promise<NgrokStatus>;
+    setNgrokToken(token: string): Promise<NgrokStatus>;
+    clearNgrokToken(): Promise<void>;
   };
   ai: {
     draftChat(input: DraftChatInput): Promise<DraftChatOutput>;

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -112,6 +112,9 @@ export function createHttpClient(baseUrl: string, rawWsUrl: string): ApiClient {
       removeProviderKey: (providerId) =>
         req(`/provider-keys/${encodeURIComponent(providerId)}`, { method: 'DELETE' }),
       availableModels: () => req('/models/available'),
+      ngrokStatus: () => req('/integrations/ngrok'),
+      setNgrokToken: (token) => req('/integrations/ngrok', json({ token })),
+      clearNgrokToken: () => req('/integrations/ngrok', { method: 'DELETE' }),
     },
     ai: {
       draftChat: (input) => req('/sessions/draft/chat', json(input)),

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -58,6 +58,7 @@ export function createMockClient(): ApiClient {
   const db = makeFixtures();
   let settings = structuredClone(DEFAULT_SETTINGS);
   let mockKeys: string[] = [settings.llm.provider];
+  let mockNgrok = false;
   const chatSubs = new Map<string, Set<(m: ChatMessage) => void>>();
   const now = () => new Date().toISOString();
   let counter = 1000;
@@ -383,6 +384,19 @@ export function createMockClient(): ApiClient {
         return PROVIDERS.filter((p) => !p.needsKey || mockKeys.includes(p.id)).flatMap((p) =>
           p.models.map((model) => ({ provider: p.id, providerLabel: p.label, model })),
         );
+      },
+      async ngrokStatus() {
+        await delay();
+        return { configured: mockNgrok };
+      },
+      async setNgrokToken() {
+        await delay(150);
+        mockNgrok = true;
+        return { configured: true };
+      },
+      async clearNgrokToken() {
+        await delay(150);
+        mockNgrok = false;
       },
     },
 

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -239,6 +239,10 @@ export interface AvailableModel {
   model: string;
 }
 
+export interface NgrokStatus {
+  configured: boolean;
+}
+
 /** New-session chat with the model to scope an engagement. */
 export interface DraftMessage {
   role: string;

--- a/packages/core/redcell_core/alembic/versions/d5e6f7a8b9c0_secrets.py
+++ b/packages/core/redcell_core/alembic/versions/d5e6f7a8b9c0_secrets.py
@@ -1,0 +1,29 @@
+"""secrets table for encrypted integration tokens
+
+Revision ID: d5e6f7a8b9c0
+Revises: c9d0e1f2a3b4
+Create Date: 2026-09-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: Union[str, None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "secrets",
+        sa.Column("name", sa.String(), primary_key=True),
+        sa.Column("value_enc", sa.Text(), nullable=False, server_default=""),
+        sa.Column("created_at", sa.String(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("secrets")

--- a/packages/core/redcell_core/models/__init__.py
+++ b/packages/core/redcell_core/models/__init__.py
@@ -20,6 +20,7 @@ from .proxy import Proxy  # noqa: E402
 from .proxy_entry import ProxyEntry  # noqa: E402
 from .report import Report  # noqa: E402
 from .run import Run  # noqa: E402
+from .secret import Secret  # noqa: E402
 from .server import Server  # noqa: E402
 from .session import Session  # noqa: E402
 from .settings import AppSettings  # noqa: E402
@@ -30,5 +31,5 @@ __all__ = [
     "Base", "User", "Provider", "AppSettings", "Session", "Run", "Agent",
     "AgentEdge", "Finding", "Shell", "Listener", "ProxyEntry", "Host", "Loot",
     "ChatMessage", "Event", "Server", "Proxy", "File", "Report", "ProviderCredential",
-    "Notification",
+    "Notification", "Secret",
 ]

--- a/packages/core/redcell_core/models/secret.py
+++ b/packages/core/redcell_core/models/secret.py
@@ -1,0 +1,11 @@
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from . import Base
+
+
+class Secret(Base):
+    __tablename__ = "secrets"
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    value_enc: Mapped[str] = mapped_column(Text, default="")
+    created_at: Mapped[str] = mapped_column(String)

--- a/packages/core/redcell_core/repositories/secrets.py
+++ b/packages/core/redcell_core/repositories/secrets.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..crypto import decrypt, encrypt
+from ..models import Secret
+from . import ids
+
+NGROK_AUTHTOKEN = "ngrok_authtoken"
+
+
+async def set_secret(s: AsyncSession, name: str, value: str) -> None:
+    row = await s.get(Secret, name)
+    if row is None:
+        row = Secret(name=name, created_at=ids.now_iso())
+        s.add(row)
+    row.value_enc = encrypt(value)
+    await s.flush()
+
+
+async def get_secret(s: AsyncSession, name: str) -> str:
+    row = await s.get(Secret, name)
+    if row is None:
+        return ""
+    return decrypt(row.value_enc)
+
+
+async def has_secret(s: AsyncSession, name: str) -> bool:
+    row = await s.get(Secret, name)
+    return bool(row and row.value_enc)
+
+
+async def delete_secret(s: AsyncSession, name: str) -> bool:
+    row = await s.get(Secret, name)
+    if not row:
+        return False
+    await s.delete(row)
+    await s.flush()
+    return True

--- a/packages/core/redcell_core/repositories/secrets.py
+++ b/packages/core/redcell_core/repositories/secrets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..crypto import decrypt, encrypt
@@ -10,11 +11,10 @@ NGROK_AUTHTOKEN = "ngrok_authtoken"
 
 
 async def set_secret(s: AsyncSession, name: str, value: str) -> None:
-    row = await s.get(Secret, name)
-    if row is None:
-        row = Secret(name=name, created_at=ids.now_iso())
-        s.add(row)
-    row.value_enc = encrypt(value)
+    stmt = pg_insert(Secret).values(name=name, value_enc=encrypt(value), created_at=ids.now_iso())
+    stmt = stmt.on_conflict_do_update(index_elements=[Secret.name],
+                                      set_={"value_enc": stmt.excluded.value_enc})
+    await s.execute(stmt)
     await s.flush()
 
 

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -457,6 +457,14 @@ class AvailableModel(Camel):
     model: str
 
 
+class NgrokStatus(Camel):
+    configured: bool = False
+
+
+class NgrokTokenInput(Camel):
+    token: str
+
+
 # ---- draft (new-session) chat ----
 class DraftMessage(Camel):
     role: str

--- a/packages/core/tests/test_secrets_repo.py
+++ b/packages/core/tests/test_secrets_repo.py
@@ -20,6 +20,10 @@ async def test_secret_roundtrip_and_encryption():
         assert "s3cr3t-value-1234567890" not in row.value_enc
 
     async with session_scope() as s:
+        await secrets_repo.set_secret(s, name, "second-value-0987654321")
+        assert await secrets_repo.get_secret(s, name) == "second-value-0987654321"
+
+    async with session_scope() as s:
         assert await secrets_repo.delete_secret(s, name) is True
         assert await secrets_repo.has_secret(s, name) is False
         assert await secrets_repo.get_secret(s, name) == ""

--- a/packages/core/tests/test_secrets_repo.py
+++ b/packages/core/tests/test_secrets_repo.py
@@ -1,0 +1,25 @@
+import pytest
+from redcell_core.db import session_scope
+from redcell_core.repositories import secrets as secrets_repo
+
+
+@pytest.mark.asyncio
+async def test_secret_roundtrip_and_encryption():
+    name = "test_token"
+    async with session_scope() as s:
+        assert await secrets_repo.has_secret(s, name) is False
+        await secrets_repo.set_secret(s, name, "s3cr3t-value-1234567890")
+        assert await secrets_repo.has_secret(s, name) is True
+        assert await secrets_repo.get_secret(s, name) == "s3cr3t-value-1234567890"
+
+    async with session_scope() as s:
+        from redcell_core.models import Secret
+
+        row = await s.get(Secret, name)
+        assert row is not None
+        assert "s3cr3t-value-1234567890" not in row.value_enc
+
+    async with session_scope() as s:
+        assert await secrets_repo.delete_secret(s, name) is True
+        assert await secrets_repo.has_secret(s, name) is False
+        assert await secrets_repo.get_secret(s, name) == ""


### PR DESCRIPTION
## Summary
Adds secure storage for the operator's ngrok auth token, so REDCELL can later catch reverse shells through ngrok (issue #143) without opening ports.

- New generic `secrets` table + repository, Fernet-encrypted at rest (same crypto as provider keys). REDCELL is single-user, so the token is global.
- API: `GET/POST/DELETE /integrations/ngrok`. POST does a lightweight sanity check on the token; status endpoints never return the plaintext.
- Web: a new **Integrations** tab in Settings to set, replace, or remove the token, showing configured/not-set state.
- api-client: mock + http clients and hooks for the three endpoints.

## Tests
Secrets repo round-trip test asserts the stored value is encrypted at rest and cleared on delete. typecheck, eslint, vitest, ruff, and build all pass locally.

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Integrations section to Settings for configuring Ngrok.
  - Users can add, replace, view the status of, or remove their Ngrok authentication token.
  - Token configuration is securely encrypted and displays clear success or error feedback.
  - Added validation requiring tokens to be at least 20 characters long and contain no spaces.

- **Bug Fixes**
  - Settings actions now indicate when updates are in progress and prevent duplicate submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->