### PR TITLE
feat: catch reverse shells over ngrok TCP tunnels

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -2,6 +2,14 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc -o /etc/apt/trusted.gpg.d/ngrok.asc \
+    && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" > /etc/apt/sources.list.d/ngrok.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ngrok \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never \

--- a/packages/core/redcell_core/engine/listeners.py
+++ b/packages/core/redcell_core/engine/listeners.py
@@ -46,6 +46,8 @@ class ListenerManager:
         if server is not None:
             server.close()
             await server.wait_closed()
+        from .live import get_ngrok_manager
+        await get_ngrok_manager().close(listener_id)
 
     async def stop_all(self) -> None:
         for lid in list(self._servers):

--- a/packages/core/redcell_core/engine/live.py
+++ b/packages/core/redcell_core/engine/live.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 from ..bus import bus
 from .listeners import ListenerManager
+from .ngrok import NgrokManager
 
 _listeners: ListenerManager | None = None
+_ngrok: NgrokManager | None = None
 
 
 def get_listener_manager() -> ListenerManager:
@@ -14,3 +16,10 @@ def get_listener_manager() -> ListenerManager:
     if _listeners is None:
         _listeners = ListenerManager(bus)
     return _listeners
+
+
+def get_ngrok_manager() -> NgrokManager:
+    global _ngrok
+    if _ngrok is None:
+        _ngrok = NgrokManager()
+    return _ngrok

--- a/packages/core/redcell_core/engine/ngrok.py
+++ b/packages/core/redcell_core/engine/ngrok.py
@@ -1,0 +1,76 @@
+"""On-demand ngrok TCP tunnels for reverse-shell listeners. Each armed listener
+gets its own ngrok agent process tunnelling to the local listener port; the
+assigned public address is parsed from the agent's json logs, so ephemeral
+free-tier addresses work without assuming a reserved endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from ..logs import get_logger
+
+log = get_logger("ngrok")
+
+_URL_TIMEOUT = 30.0
+
+
+class NgrokError(RuntimeError):
+    pass
+
+
+class NgrokManager:
+    def __init__(self) -> None:
+        self._procs: dict[str, asyncio.subprocess.Process] = {}
+
+    async def open(self, listener_id: str, port: int, token: str) -> str:
+        await self.close(listener_id)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ngrok", "tcp", str(port), "--authtoken", token,
+                "--log", "stdout", "--log-format", "json", "--log-level", "info",
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT)
+        except FileNotFoundError as exc:
+            raise NgrokError("ngrok is not installed on the worker") from exc
+        self._procs[listener_id] = proc
+        try:
+            public = await asyncio.wait_for(self._read_public_url(proc), timeout=_URL_TIMEOUT)
+        except (TimeoutError, NgrokError):
+            await self.close(listener_id)
+            raise
+        if not public:
+            await self.close(listener_id)
+            raise NgrokError("ngrok exited before publishing a tunnel address")
+        return public
+
+    async def close(self, listener_id: str) -> None:
+        proc = self._procs.pop(listener_id, None)
+        if proc is None:
+            return
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except TimeoutError:
+                proc.kill()
+
+    async def close_all(self) -> None:
+        for lid in list(self._procs):
+            await self.close(lid)
+
+    async def _read_public_url(self, proc: asyncio.subprocess.Process) -> str | None:
+        assert proc.stdout is not None
+        while True:
+            line = await proc.stdout.readline()
+            if not line:
+                return None
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            err = rec.get("err")
+            if err and err != "<nil>":
+                raise NgrokError(str(err))
+            url = rec.get("url", "")
+            if isinstance(url, str) and url.startswith("tcp://"):
+                return url[len("tcp://"):]

--- a/packages/core/redcell_core/engine/runner.py
+++ b/packages/core/redcell_core/engine/runner.py
@@ -27,6 +27,7 @@ from ..repositories import notifications as notifications_repo
 from ..repositories import provider_credentials as creds_repo
 from ..repositories import proxies as proxies_repo
 from ..repositories import runs as runs_repo
+from ..repositories import secrets as secrets_repo
 from ..repositories import servers as servers_repo
 from ..repositories import sessions as sessions_repo
 from ..repositories import settings as settings_repo
@@ -444,7 +445,8 @@ class LiveRunner:
         if name == "record_host":
             return await self._record_host(args)
         if name == "start_listener":
-            return await self._start_listener(int(args.get("port", 4444)))
+            return await self._start_listener(int(args.get("port", 4444)),
+                                              str(args.get("method", "auto")))
         if name == "open_pivot":
             return await self._open_pivot(args.get("shellId") or args.get("shell_id", ""))
         if name == "close_pivot":
@@ -933,12 +935,18 @@ class LiveRunner:
         await self._event("orchestrator", "net", "pivot closed")
         return {"ok": True}
 
-    async def _start_listener(self, port: int) -> dict[str, Any]:
+    async def _start_listener(self, port: int, method: str = "auto") -> dict[str, Any]:
         remote = self.server is not None and getattr(self.backend, "kind", "") == "remote-docker"
         if not remote and not _in_callback_range(port):
             return {"error": f"port {port} is outside the reachable callback range "
                     f"{settings.callback_port_min}-{settings.callback_port_max}; "
                     f"retry start_listener with a port in that range."}
+        async with session_scope() as s:
+            token = await secrets_repo.get_secret(s, secrets_repo.NGROK_AUTHTOKEN)
+        if method == "ngrok" and not token:
+            return {"error": "ngrok requested but no ngrok auth token is configured "
+                    "(Settings > Integrations); use method 'direct' or add a token."}
+        use_ngrok = not remote and method != "direct" and (method == "ngrok" or bool(token))
         bind = f"0.0.0.0:{port}"
         async with session_scope() as s:
             listener = await listeners_repo.create(s, {"session_id": self.session_id, "kind": "tcp",
@@ -951,9 +959,15 @@ class LiveRunner:
             callback = f"{self.server.host}:{port}"
             status = "listening"
         else:
-            from .live import get_listener_manager
+            from .live import get_listener_manager, get_ngrok_manager
             status = await get_listener_manager().start(lid)
             callback = f"{settings.callback_host}:{port}"
+            if use_ngrok and status == "listening":
+                try:
+                    callback = await get_ngrok_manager().open(lid, port, token)
+                except Exception as exc:
+                    await self._event("listener", "steer",
+                                      f"ngrok tunnel failed, using direct callback: {exc}")
         await self._event("listener", "net", f"listener {bind} ({status}); reverse-shell callback -> {callback}")
         await self._advance_phase("Post-Exploitation")
         return {"listenerId": lid, "bind": bind, "status": status, "callback": callback,

--- a/packages/core/redcell_core/engine/tools.py
+++ b/packages/core/redcell_core/engine/tools.py
@@ -104,11 +104,12 @@ ORCHESTRATOR_TOOLS = [
         "type": "function",
         "function": {
             "name": "start_listener",
-            "description": "Start a TCP listener on the operator host to catch a reverse shell. Returns the address the payload must call back to. Call this BEFORE triggering a reverse-shell payload.",
+            "description": "Start a TCP listener on the operator host to catch a reverse shell. Returns the address the payload must call back to. Call this BEFORE triggering a reverse-shell payload. When an ngrok token is configured the callback is a public ngrok address, so targets can reach it with no open ports on the server.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "port": {"type": "integer", "description": "Port to listen on. Must be in the configured reachable callback range unless a remote VPS execution host is in use."},
+                    "method": {"type": "string", "enum": ["auto", "ngrok", "direct"], "description": "How the target reaches the listener. 'auto' (default) uses ngrok when a token is configured, else a direct port. 'ngrok' forces a tunnel; 'direct' forces the server port."},
                 },
                 "required": ["port"],
             },

--- a/packages/core/tests/test_ngrok.py
+++ b/packages/core/tests/test_ngrok.py
@@ -1,0 +1,41 @@
+import pytest
+from redcell_core.engine.ngrok import NgrokError, NgrokManager
+
+
+class _FakeStdout:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    async def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+
+class _FakeProc:
+    def __init__(self, lines):
+        self.stdout = _FakeStdout(lines)
+
+
+@pytest.mark.asyncio
+async def test_parse_public_url_from_json_logs():
+    mgr = NgrokManager()
+    proc = _FakeProc([
+        b'{"lvl":"info","msg":"starting agent"}\n',
+        b'not json at all\n',
+        b'{"msg":"started tunnel","url":"tcp://5.tcp.ngrok.io:12345"}\n',
+    ])
+    assert await mgr._read_public_url(proc) == "5.tcp.ngrok.io:12345"
+
+
+@pytest.mark.asyncio
+async def test_parse_raises_on_error_line():
+    mgr = NgrokManager()
+    proc = _FakeProc([b'{"err":"authentication failed","msg":"x"}\n'])
+    with pytest.raises(NgrokError):
+        await mgr._read_public_url(proc)
+
+
+@pytest.mark.asyncio
+async def test_parse_returns_none_on_eof():
+    mgr = NgrokManager()
+    proc = _FakeProc([b'{"msg":"no url here"}\n'])
+    assert await mgr._read_public_url(proc) is None


### PR DESCRIPTION
## Summary
Lets REDCELL catch reverse shells with no inbound ports on the server, using the operator's ngrok token (stored in #147).

- New `NgrokManager` (engine/ngrok.py): starts an on-demand `ngrok tcp` agent per armed listener, parses the assigned public address from the agent's json logs. No reserved endpoint assumed, so free-tier ephemeral addresses work.
- `start_listener` gains a `method` (auto/ngrok/direct): auto uses ngrok when a token is configured, else a direct port; ngrok tunnel failures fall back to the direct callback.
- Tunnel is torn down when the listener stops (wired into `ListenerManager.stop`).
- The ngrok agent is installed in the worker image (validated: builds ngrok 3.39.11).

## Free-tier
Verified the free plan gives ephemeral `N.tcp.ngrok.io:PORT` addresses (3 concurrent endpoints, no session timeout); the manager reads the address dynamically each start and closes the agent on teardown to stay within the cap.

## Tests
Unit tests for the json-log URL parsing (success, error line, EOF). ruff clean; worker ngrok layer build-verified locally.

Closes #143