### PR TITLE
fix: give toasts an explicit close button

### DIFF
--- a/apps/web/src/components/ui/toast.test.tsx
+++ b/apps/web/src/components/ui/toast.test.tsx
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Toaster, notifyToast, useToasts } from './toast';
+
+afterEach(() => {
+  act(() => useToasts.setState({ toasts: [] }));
+});
+
+describe('Toaster', () => {
+  it('shows a toast and dismisses it via the close button', () => {
+    render(<Toaster />);
+    act(() => notifyToast({ title: 'Saved', durationMs: 0 }));
+    expect(screen.getByText('Saved')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument();
+  });
+
+  it('runs the click action without the close button firing it', () => {
+    let clicked = 0;
+    render(<Toaster />);
+    act(() => notifyToast({ title: 'Open run', durationMs: 0, onClick: () => (clicked += 1) }));
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss notification/i }));
+    expect(clicked).toBe(0);
+    expect(screen.queryByText('Open run')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from 'react';
 import { create } from 'zustand';
 import { cn } from '@/lib/cn';
 
@@ -74,23 +75,54 @@ export function Toaster() {
   const dismiss = useToasts((s) => s.dismiss);
   return (
     <div className="pointer-events-none fixed bottom-4 right-4 z-[100] flex w-[320px] max-w-[92vw] flex-col gap-2">
-      {toasts.map((t) => (
-        <button type="button"
-          key={t.id}
-          onClick={() => {
-            t.onClick?.();
-            dismiss(t.id);
-          }}
-          style={{ borderLeftColor: TONE_ACCENT[t.tone] }}
-          className={cn(
-            'toast-in pointer-events-auto w-full rounded-[var(--radius)] border border-border2 border-l-2 bg-panel2 px-3.5 py-2.5 text-left shadow-[var(--shadow)]',
-            t.tone === 'critical' && 'toast-pulse',
-          )}
-        >
-          <div className={cn('text-xs font-semibold', TONE_TEXT[t.tone])}>{t.title}</div>
-          {t.body ? <div className="mt-0.5 text-[11px] leading-snug text-muted">{t.body}</div> : null}
-        </button>
-      ))}
+      {toasts.map((t) => {
+        const clickable = !!t.onClick;
+        const act = () => {
+          t.onClick?.();
+          dismiss(t.id);
+        };
+        return (
+          <div
+            key={t.id}
+            role="status"
+            style={{ borderLeftColor: TONE_ACCENT[t.tone] }}
+            className={cn(
+              'toast-in pointer-events-auto relative flex w-full items-start gap-2 rounded-[var(--radius)] border border-border2 border-l-2 bg-panel2 py-2.5 pl-3.5 pr-8 text-left shadow-[var(--shadow)]',
+              t.tone === 'critical' && 'toast-pulse',
+            )}
+          >
+            <div
+              className={cn('min-w-0 flex-1', clickable && 'cursor-pointer')}
+              {...(clickable
+                ? {
+                    role: 'button',
+                    tabIndex: 0,
+                    onClick: act,
+                    onKeyDown: (e: KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        act();
+                      }
+                    },
+                  }
+                : {})}
+            >
+              <div className={cn('text-xs font-semibold', TONE_TEXT[t.tone])}>{t.title}</div>
+              {t.body ? <div className="mt-0.5 text-[11px] leading-snug text-muted">{t.body}</div> : null}
+            </div>
+            <button
+              type="button"
+              aria-label="Dismiss notification"
+              onClick={() => dismiss(t.id)}
+              className="absolute right-1.5 top-1.5 grid h-5 w-5 place-items-center rounded text-muted transition-colors hover:bg-[var(--color-border2)] hover:text-text"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+                <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Toasts already auto-dismiss on a per-tone timer, but the whole toast was one button with no visible close control.

- Each toast is now a container with an accessible **close (x)** button (aria-label), so dismissing is discoverable and the markup is valid (no nested buttons).
- The optional click action is preserved on the body; the x dismisses without firing it.
- Auto-dismiss timers unchanged (critical still stays until dismissed).
- Styling uses the existing design tokens (tone accent, radius, panel, muted).

## Tests
Added a Toaster test: close button removes the toast, and clicking x does not trigger the toast's onClick. typecheck, eslint, and vitest pass locally.

Closes #146