### PR TITLE
fix: remove the red glow from critical toasts

### DIFF
--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -86,10 +86,7 @@ export function Toaster() {
             key={t.id}
             role="status"
             style={{ borderLeftColor: TONE_ACCENT[t.tone] }}
-            className={cn(
-              'toast-in pointer-events-auto relative flex w-full items-start gap-2 rounded-[var(--radius)] border border-border2 border-l-2 bg-panel2 py-2.5 pl-3.5 pr-8 text-left shadow-[var(--shadow)]',
-              t.tone === 'critical' && 'toast-pulse',
-            )}
+            className="toast-in pointer-events-auto relative flex w-full items-start gap-2 rounded-[var(--radius)] border border-border2 border-l-2 bg-panel2 py-2.5 pl-3.5 pr-8 text-left shadow-[var(--shadow)]"
           >
             <div
               className={cn('min-w-0 flex-1', clickable && 'cursor-pointer')}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -289,11 +289,6 @@
   to   { opacity: 1; transform: translateX(0) scale(1); }
 }
 .toast-in { animation: toast-in 0.18s ease-out; }
-@keyframes toast-pulse {
-  0%, 100% { box-shadow: 0 12px 32px rgba(0,0,0,0.55), 0 0 0 0 rgba(255,51,68,0.0); }
-  50%      { box-shadow: 0 12px 32px rgba(0,0,0,0.55), 0 0 0 3px rgba(255,51,68,0.28); }
-}
-.toast-pulse { animation: toast-pulse 1.6s ease-in-out infinite; }
 
 /* ---- Chat "thinking" indicator (red, Claude-Code style) ---- */
 .thinking {
@@ -322,7 +317,7 @@
 .thinking-bubble { animation: thinking-glow 1.8s ease-in-out infinite; }
 
 @media (prefers-reduced-motion: reduce) {
-  .toast-in, .toast-pulse, .thinking .dot, .thinking-bubble { animation: none; }
+  .toast-in, .thinking .dot, .thinking-bubble { animation: none; }
 }
 
 /* ---- Chat message entrance ---- */


### PR DESCRIPTION
## Summary
Critical toasts pulsed with a hardcoded off-token red halo (`rgba(255,51,68)` in global.css), which isn't in the design system (the accent is indigo; even the severity red `--crit` is a different value).

- Removed the `toast-pulse` animation and its red glow.
- Critical toasts now use the accent border like every other tone, so toasts stay on-palette.

## Verification
Triggered a critical toast in the browser: no red glow, indigo accent border, close button intact. typecheck, eslint, and the toast test pass.

Closes #146 follow-up (raised during review of #149).