### PR TITLE
feat: dashboard recommended actions (AI key + ngrok)

### DIFF
--- a/apps/api/app/routers/settings.py
+++ b/apps/api/app/routers/settings.py
@@ -9,12 +9,14 @@ from redcell_core.repositories import secrets as secrets_repo
 from redcell_core.repositories import settings as settings_repo
 from redcell_core.schemas import (
     AvailableModel,
+    DismissActionInput,
     NgrokStatus,
     NgrokTokenInput,
     ProviderCatalogEntry,
     ProviderKeyInput,
     ProviderKeyStatus,
     Settings,
+    SetupStatus,
 )
 from redcell_core.security import current_user
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -80,6 +82,23 @@ async def set_ngrok_token(body: NgrokTokenInput, s: AsyncSession = Depends(db)) 
 @router.delete("/integrations/ngrok", status_code=204)
 async def clear_ngrok_token(s: AsyncSession = Depends(db)) -> None:
     await secrets_repo.delete_secret(s, secrets_repo.NGROK_AUTHTOKEN)
+
+
+# ---- onboarding / recommended actions ----
+@router.get("/setup-status", response_model=SetupStatus)
+async def setup_status(s: AsyncSession = Depends(db)) -> SetupStatus:
+    keyed = await creds_repo.keyed_ids(s)
+    cfg = await settings_repo.get(s)
+    has_ai = bool(keyed) or bool((cfg.llm or {}).get("api_key"))
+    has_ngrok = await secrets_repo.has_secret(s, secrets_repo.NGROK_AUTHTOKEN)
+    dismissed = await settings_repo.dismissed_actions(s)
+    return SetupStatus(has_ai_key=has_ai, has_ngrok=has_ngrok, dismissed=dismissed)
+
+
+@router.post("/setup-status/dismiss", response_model=SetupStatus)
+async def dismiss_setup_action(body: DismissActionInput, s: AsyncSession = Depends(db)) -> SetupStatus:
+    await settings_repo.dismiss_action(s, body.action)
+    return await setup_status(s)
 
 
 # ---- models available to the operator (keyed + keyless providers) ----

--- a/apps/web/src/app/pages/OverviewPage.tsx
+++ b/apps/web/src/app/pages/OverviewPage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import type { Severity } from '@redcell/api-client';
-import { useSessions } from '@/features/hooks';
+import { useDismissSetupAction, useSessions, useSetupStatus } from '@/features/hooks';
 import { SEVERITIES, sevVar, timeAgo } from '@/lib/format';
 import { AreaChart } from '@/components/ui/AreaChart';
 import { SessionRow } from './shared';
@@ -13,10 +13,33 @@ const SEV_LABEL: Record<Severity, string> = {
   info: 'Info',
 };
 
+const RECOMMENDED: { key: string; satisfied: (s: { hasAiKey: boolean; hasNgrok: boolean }) => boolean; title: string; desc: string; cta: string }[] = [
+  {
+    key: 'ai-key',
+    satisfied: (s) => s.hasAiKey,
+    title: 'Add an AI provider key',
+    desc: 'REDCELL needs a model provider key to run engagements. Add one to start a session.',
+    cta: 'Add a key',
+  },
+  {
+    key: 'ngrok',
+    satisfied: (s) => s.hasNgrok,
+    title: 'Connect ngrok for reverse shells',
+    desc: 'Add an ngrok auth token to catch reverse shells with no open ports. Works on a free ngrok account.',
+    cta: 'Add ngrok token',
+  },
+];
+
 export function OverviewPage() {
   const nav = useNavigate();
   const { data: sessions } = useSessions();
+  const { data: setup } = useSetupStatus();
+  const dismissAction = useDismissSetupAction();
   const list = sessions ?? [];
+
+  const recs = setup
+    ? RECOMMENDED.filter((r) => !r.satisfied(setup) && !setup.dismissed.includes(r.key))
+    : [];
 
   const activeCount = list.filter((s) => s.status === 'active').length;
   const totalFindings = list.reduce((a, s) => a + s.findingsCount, 0);
@@ -45,6 +68,39 @@ export function OverviewPage() {
 
   return (
     <div className="wrap">
+      {recs.length > 0 && (
+        <div className="card" style={{ marginBottom: 16 }}>
+          <div className="card-h">
+            <h3>Recommended actions</h3>
+            <span className="cs">· finish setting up REDCELL</span>
+          </div>
+          <div className="card-b">
+            {recs.map((r) => (
+              <div className="formrow" key={r.key}>
+                <div>
+                  <div className="ft">{r.title}</div>
+                  <div className="fd">{r.desc}</div>
+                </div>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexShrink: 0 }}>
+                  <button type="button" className="btn sm pri" onClick={() => nav('/settings')}>
+                    {r.cta}
+                  </button>
+                  <button
+                    type="button"
+                    className="btn sm"
+                    aria-label={`Dismiss: ${r.title}`}
+                    disabled={dismissAction.isPending}
+                    onClick={() => dismissAction.mutate(r.key)}
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="kpis">
         <div className="kpi">
           <span className="k">Active sessions</span>

--- a/apps/web/src/features/hooks.ts
+++ b/apps/web/src/features/hooks.ts
@@ -286,6 +286,20 @@ export function useClearNgrokToken() {
   });
 }
 
+export function useSetupStatus() {
+  const api = useApi();
+  return useQuery({ queryKey: ['setup-status'], queryFn: () => api.settings.setupStatus() });
+}
+
+export function useDismissSetupAction() {
+  const api = useApi();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (action: string) => api.settings.dismissSetupAction(action),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['setup-status'] }),
+  });
+}
+
 export function useSaveSettings() {
   const api = useApi();
   const qc = useQueryClient();

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -30,6 +30,7 @@ import type {
   Session,
   SessionKind,
   SetProviderKeyInput,
+  SetupStatus,
   UpdateProxyInput,
   UpdateServerInput,
   Settings,
@@ -160,6 +161,8 @@ export interface ApiClient {
     ngrokStatus(): Promise<NgrokStatus>;
     setNgrokToken(token: string): Promise<NgrokStatus>;
     clearNgrokToken(): Promise<void>;
+    setupStatus(): Promise<SetupStatus>;
+    dismissSetupAction(action: string): Promise<SetupStatus>;
   };
   ai: {
     draftChat(input: DraftChatInput): Promise<DraftChatOutput>;

--- a/packages/api-client/src/http/httpClient.ts
+++ b/packages/api-client/src/http/httpClient.ts
@@ -115,6 +115,8 @@ export function createHttpClient(baseUrl: string, rawWsUrl: string): ApiClient {
       ngrokStatus: () => req('/integrations/ngrok'),
       setNgrokToken: (token) => req('/integrations/ngrok', json({ token })),
       clearNgrokToken: () => req('/integrations/ngrok', { method: 'DELETE' }),
+      setupStatus: () => req('/setup-status'),
+      dismissSetupAction: (action) => req('/setup-status/dismiss', json({ action })),
     },
     ai: {
       draftChat: (input) => req('/sessions/draft/chat', json(input)),

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -59,6 +59,7 @@ export function createMockClient(): ApiClient {
   let settings = structuredClone(DEFAULT_SETTINGS);
   let mockKeys: string[] = [settings.llm.provider];
   let mockNgrok = false;
+  const mockDismissed: string[] = [];
   const chatSubs = new Map<string, Set<(m: ChatMessage) => void>>();
   const now = () => new Date().toISOString();
   let counter = 1000;
@@ -397,6 +398,15 @@ export function createMockClient(): ApiClient {
       async clearNgrokToken() {
         await delay(150);
         mockNgrok = false;
+      },
+      async setupStatus() {
+        await delay();
+        return { hasAiKey: mockKeys.length > 0, hasNgrok: mockNgrok, dismissed: [...mockDismissed] };
+      },
+      async dismissSetupAction(action) {
+        await delay(150);
+        if (!mockDismissed.includes(action)) mockDismissed.push(action);
+        return { hasAiKey: mockKeys.length > 0, hasNgrok: mockNgrok, dismissed: [...mockDismissed] };
       },
     },
 

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -243,6 +243,12 @@ export interface NgrokStatus {
   configured: boolean;
 }
 
+export interface SetupStatus {
+  hasAiKey: boolean;
+  hasNgrok: boolean;
+  dismissed: string[];
+}
+
 /** New-session chat with the model to scope an engagement. */
 export interface DraftMessage {
   role: string;

--- a/packages/core/redcell_core/alembic/versions/e6f7a8b9c0d1_onboarding.py
+++ b/packages/core/redcell_core/alembic/versions/e6f7a8b9c0d1_onboarding.py
@@ -1,0 +1,28 @@
+"""app_settings.onboarding for dismissed recommended actions
+
+Revision ID: e6f7a8b9c0d1
+Revises: d5e6f7a8b9c0
+Create Date: 2026-09-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "e6f7a8b9c0d1"
+down_revision: Union[str, None] = "d5e6f7a8b9c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "app_settings",
+        sa.Column("onboarding", JSONB(), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("app_settings", "onboarding")

--- a/packages/core/redcell_core/models/settings.py
+++ b/packages/core/redcell_core/models/settings.py
@@ -14,3 +14,4 @@ class AppSettings(Base):
     proxy: Mapped[dict] = mapped_column(JSONB, default=dict)
     report: Mapped[dict] = mapped_column(JSONB, default=dict)
     notifications: Mapped[dict] = mapped_column(JSONB, default=dict)
+    onboarding: Mapped[dict] = mapped_column(JSONB, default=dict)

--- a/packages/core/redcell_core/repositories/settings.py
+++ b/packages/core/redcell_core/repositories/settings.py
@@ -34,3 +34,18 @@ async def save(s: AsyncSession, data: dict) -> AppSettings:
     row.notifications = data.get("notifications", row.notifications)
     await s.flush()
     return row
+
+
+async def dismissed_actions(s: AsyncSession) -> list[str]:
+    row = await get(s)
+    return list((row.onboarding or {}).get("dismissed", []))
+
+
+async def dismiss_action(s: AsyncSession, key: str) -> list[str]:
+    row = await get(s)
+    dismissed = list((row.onboarding or {}).get("dismissed", []))
+    if key not in dismissed:
+        dismissed.append(key)
+    row.onboarding = {**(row.onboarding or {}), "dismissed": dismissed}
+    await s.flush()
+    return dismissed

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -465,6 +465,16 @@ class NgrokTokenInput(Camel):
     token: str
 
 
+class SetupStatus(Camel):
+    has_ai_key: bool = False
+    has_ngrok: bool = False
+    dismissed: list[str] = []
+
+
+class DismissActionInput(Camel):
+    action: str
+
+
 # ---- draft (new-session) chat ----
 class DraftMessage(Camel):
     role: str

--- a/packages/core/tests/test_onboarding.py
+++ b/packages/core/tests/test_onboarding.py
@@ -1,0 +1,17 @@
+import pytest
+from redcell_core.db import session_scope
+from redcell_core.repositories import settings as settings_repo
+
+
+@pytest.mark.asyncio
+async def test_dismiss_action_is_idempotent_and_persisted():
+    async with session_scope() as s:
+        assert await settings_repo.dismissed_actions(s) == []
+        await settings_repo.dismiss_action(s, "ngrok")
+        await settings_repo.dismiss_action(s, "ngrok")
+        await settings_repo.dismiss_action(s, "ai-key")
+
+    async with session_scope() as s:
+        dismissed = await settings_repo.dismissed_actions(s)
+        assert dismissed.count("ngrok") == 1
+        assert set(dismissed) == {"ngrok", "ai-key"}


### PR DESCRIPTION
## Summary
Adds a dismissible **Recommended actions** section to the Overview dashboard that nudges the operator to finish setup.

- Shows an **Add an AI provider key** card when no provider key is set, and a **Connect ngrok** card when no ngrok token is set.
- A satisfied prerequisite hides its card; each card links into Settings.
- **Dismiss** persists server-side in `app_settings.onboarding` (single-user), so it stays gone across reloads and devices.
- New `GET /setup-status` and `POST /setup-status/dismiss` API; mock + http clients and hooks.

## Tests
Backend test for the onboarding dismiss (idempotent + persisted). Browser-verified: both cards render, satisfied prerequisites hide their card, dismiss removes and persists. typecheck, eslint, ruff, build pass.

Closes #144