### PR TITLE
chore(release): v0.4.7

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-api"
-version = "0.4.6"
+version = "0.4.7"
 description = "REDCELL red-team platform API (FastAPI)"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redcell/web",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcell-worker"
-version = "0.4.6"
+version = "0.4.7"
 description = "REDCELL background worker (arq)"
 requires-python = ">=3.12"
 dependencies = ["redcell-core", "arq>=0.26"]

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/web": {
       "name": "@redcell/web",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "dependencies": {
         "@novnc/novnc": "1.7.0",
         "@redcell/api-client": "workspace:*",

--- a/uv.lock
+++ b/uv.lock
@@ -2179,7 +2179,7 @@ wheels = [
 
 [[package]]
 name = "redcell-api"
-version = "0.4.3"
+version = "0.4.7"
 source = { virtual = "apps/api" }
 dependencies = [
     { name = "fastapi" },
@@ -2261,7 +2261,7 @@ live = [
 
 [[package]]
 name = "redcell-worker"
-version = "0.4.3"
+version = "0.4.7"
 source = { virtual = "apps/worker" }
 dependencies = [
     { name = "arq" },


### PR DESCRIPTION
Release v0.4.7.

Reverse shells:
- Direct callback path: configurable `callback_host` + opt-in worker port range (#145)
- ngrok auth token stored encrypted, set in Settings > Integrations (#147)
- Catch reverse shells over on-demand ngrok TCP tunnels, free-tier compatible (#148)

Dashboard:
- Recommended actions onboarding cards (AI key + ngrok), dismiss persists server-side (#151)

Toasts:
- Explicit close button (#149)
- Removed the off-palette red glow (#150)

Includes a DB migration (secrets table + app_settings.onboarding); the in-app updater re-runs it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application, API, and worker package versions from 0.4.6 to 0.4.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->