### PR TITLE
feat: default the Kali execution image to GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Or start all three at once with a process manager (they are declared in the
 
 Open http://localhost:5183 and sign in with `admin` / `admin`.
 
-Runs execute real tools by default. Add a provider API key in Settings and make sure Docker can pull the Kali image (`martian56/kali:latest`). To dry-run against canned output instead, set `REDCELL_RUN_MODE=sim` in `.env`.
+Runs execute real tools by default. Add a provider API key in Settings and make sure Docker can pull the Kali image (`ghcr.io/martian56/redcell-kali:latest`). To dry-run against canned output instead, set `REDCELL_RUN_MODE=sim` in `.env`.
 
 ### Practice targets
 

--- a/packages/api-client/src/mock/mockClient.ts
+++ b/packages/api-client/src/mock/mockClient.ts
@@ -41,7 +41,7 @@ const PROVIDERS: ProviderCatalogEntry[] = [
 
 const DEFAULT_SETTINGS: Settings = {
   llm: { provider: 'moonshot', model: 'kimi-k3', apiKey: '', apiBase: '', reasoningEffort: 'high' },
-  execution: { backend: 'local-docker', dockerImage: 'redcell/kali:latest', sshHost: '', sshUser: 'root' },
+  execution: { backend: 'local-docker', dockerImage: 'ghcr.io/martian56/redcell-kali:latest', sshHost: '', sshUser: 'root' },
   scope: { allowPrivateTargets: false, requestsPerSecond: 10 },
   proxy: { enabled: false, url: '', rotation: 'off' },
   report: { companyName: 'REDCELL', classification: 'CONFIDENTIAL', contact: '', logoDataUrl: undefined },

--- a/packages/core/redcell_core/schemas.py
+++ b/packages/core/redcell_core/schemas.py
@@ -248,9 +248,7 @@ class LlmSettings(Camel):
 
 class ExecutionSettings(Camel):
     backend: str = "local-docker"
-    # prebuilt Kali image on Docker Hub. any host can pull it, so remote servers
-    # pull instead of shipping the local build.
-    docker_image: str = "martian56/kali:latest"
+    docker_image: str = "ghcr.io/martian56/redcell-kali:latest"
     ssh_host: str | None = ""
     ssh_user: str | None = "root"
 


### PR DESCRIPTION
## Summary
Switches the default execution (Kali) image from Docker Hub (`martian56/kali:latest`) to the release-built `ghcr.io/martian56/redcell-kali:latest`.

- The GHCR image is built from this repo's `docker/kali/Dockerfile` by the release workflow and is **public** (verified anonymous pull returns 200), so remote execution servers and the local worker can pull it without a login.
- Updated the default in `ExecutionSettings`, the README setup note, and the mock settings for consistency.
- Overridable in Settings → Execution.

No migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default Kali container image reference to `ghcr.io/martian56/redcell-kali:latest`.
  - Updated documentation and default execution settings to use the new image location consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->